### PR TITLE
v0.1.5: Confirmation prompts for destructive commands

### DIFF
--- a/cmd/dns/dns.go
+++ b/cmd/dns/dns.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
 	"github.com/crowdy/conoha-cli/internal/output"
+	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
 var Cmd = &cobra.Command{
@@ -97,6 +98,14 @@ func init() {
 	domainDeleteCmd := &cobra.Command{
 		Use: "delete <id>", Short: "Delete a domain", Args: cmdutil.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ok, err := prompt.Confirm("Delete domain and all its records?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintln(os.Stderr, "Cancelled.")
+				return nil
+			}
 			client, err := cmdutil.NewClient(cmd)
 			if err != nil {
 				return err

--- a/cmd/lb/lb.go
+++ b/cmd/lb/lb.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
 	"github.com/crowdy/conoha-cli/internal/output"
+	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
 var Cmd = &cobra.Command{
@@ -99,6 +100,14 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete a load balancer",
 	Args:  cmdutil.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ok, err := prompt.Confirm(fmt.Sprintf("Delete load balancer %s?", args[0]))
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
+		}
 		client, err := cmdutil.NewClient(cmd)
 		if err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ var (
 	flagQuiet   bool
 	flagVerbose bool
 	flagNoColor bool
+	flagYes     bool
 )
 
 // rootCmd is the base command.
@@ -49,6 +50,9 @@ var rootCmd = &cobra.Command{
 		if flagNoInput {
 			_ = os.Setenv(config.EnvNoInput, "1")
 		}
+		if flagYes {
+			_ = os.Setenv(config.EnvYes, "1")
+		}
 	},
 }
 
@@ -59,6 +63,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&flagQuiet, "quiet", false, "suppress non-essential output")
 	rootCmd.PersistentFlags().BoolVar(&flagVerbose, "verbose", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&flagNoColor, "no-color", false, "disable color output")
+	rootCmd.PersistentFlags().BoolVarP(&flagYes, "yes", "y", false, "skip confirmation prompts")
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(completionCmd)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -278,6 +278,53 @@ var createCmd = &cobra.Command{
 			req.Server.ImageRef = imageID
 		}
 
+		// Resolve names for summary
+		imageAPI := api.NewImageAPI(client)
+		imageName := imageID
+		if img, err := imageAPI.GetImage(imageID); err == nil {
+			imageName = img.Name
+		}
+
+		// Print summary
+		fmt.Fprintln(os.Stderr, "=== Server Create Summary ===")
+		fmt.Fprintf(os.Stderr, "  Name:     %s\n", name)
+		fmt.Fprintf(os.Stderr, "  Flavor:   %s (%d vCPU, %s RAM)\n", flavor.Name, flavor.VCPUs, formatMB(flavor.RAM))
+		fmt.Fprintf(os.Stderr, "  Image:    %s\n", imageName)
+		if volumeID != "" {
+			volAnnotation := "[existing]"
+			if created {
+				volAnnotation = "[new]"
+			}
+			volInfo := volumeID[:8]
+			if vol, err := volumeAPI.GetVolume(volumeID); err == nil {
+				volInfo = fmt.Sprintf("%d GB (%s)", vol.Size, vol.VolumeType)
+			}
+			fmt.Fprintf(os.Stderr, "  Volume:   %s %s\n", volInfo, volAnnotation)
+		}
+		if keyName != "" {
+			fmt.Fprintf(os.Stderr, "  Key:      %s\n", keyName)
+		}
+		if adminPass != "" {
+			fmt.Fprintln(os.Stderr, "  Password: (set)")
+		}
+
+		ok, err := prompt.Confirm("Create this server?")
+		if err != nil {
+			if created {
+				fmt.Fprintf(os.Stderr, "Warning: boot volume %s was created but server creation was cancelled.\n", volumeID)
+				fmt.Fprintf(os.Stderr, "You can delete it with: conoha volume delete %s\n", volumeID)
+			}
+			return err
+		}
+		if !ok {
+			if created {
+				fmt.Fprintf(os.Stderr, "Warning: boot volume %s was already created.\n", volumeID)
+				fmt.Fprintf(os.Stderr, "You can delete it with: conoha volume delete %s\n", volumeID)
+			}
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
+		}
+
 		server, err := compute.CreateServer(req)
 		if err != nil {
 			if created {
@@ -530,14 +577,22 @@ var deleteCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		id, err := resolveServerID(compute, args[0])
+		s, err := compute.FindServer(args[0])
 		if err != nil {
 			return err
 		}
-		if err := compute.DeleteServer(id); err != nil {
+		ok, err := prompt.Confirm(fmt.Sprintf("Delete server %q (%s)? This cannot be undone", s.Name, s.ID))
+		if err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stderr, "Server %s deleted\n", args[0])
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
+		}
+		if err := compute.DeleteServer(s.ID); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "Server %s deleted\n", s.Name)
 		return nil
 	},
 }
@@ -619,6 +674,14 @@ var resizeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		ok, err := prompt.Confirm("Resize server? This may cause downtime")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
+		}
 		if err := compute.ResizeServer(id, args[1]); err != nil {
 			return err
 		}
@@ -639,6 +702,14 @@ var rebuildCmd = &cobra.Command{
 		id, err := resolveServerID(compute, args[0])
 		if err != nil {
 			return err
+		}
+		ok, err := prompt.Confirm("Rebuild server? All data will be lost")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
 		}
 		if err := compute.RebuildServer(id, args[1]); err != nil {
 			return err

--- a/cmd/volume/volume.go
+++ b/cmd/volume/volume.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crowdy/conoha-cli/internal/api"
 	"github.com/crowdy/conoha-cli/internal/model"
 	"github.com/crowdy/conoha-cli/internal/output"
+	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
 var Cmd = &cobra.Command{
@@ -112,7 +113,24 @@ var deleteCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := api.NewVolumeAPI(client).DeleteVolume(args[0]); err != nil {
+		volumeAPI := api.NewVolumeAPI(client)
+		vol, err := volumeAPI.GetVolume(args[0])
+		if err != nil {
+			return err
+		}
+		label := fmt.Sprintf("Delete volume %q (%s)?", vol.Name, vol.ID)
+		if vol.Name == "" {
+			label = fmt.Sprintf("Delete volume %s?", vol.ID)
+		}
+		ok, err := prompt.Confirm(label)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
+		}
+		if err := volumeAPI.DeleteVolume(vol.ID); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "Volume %s deleted\n", args[0])

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -15,6 +15,7 @@ const (
 	EnvEndpoint     = "CONOHA_ENDPOINT"
 	EnvEndpointMode = "CONOHA_ENDPOINT_MODE"
 	EnvDebug        = "CONOHA_DEBUG"
+	EnvYes          = "CONOHA_YES"
 )
 
 // EnvOr returns the environment variable value if set, otherwise the fallback.
@@ -28,4 +29,9 @@ func EnvOr(key, fallback string) string {
 // IsNoInput returns true if non-interactive mode is requested.
 func IsNoInput() bool {
 	return os.Getenv(EnvNoInput) == "1" || os.Getenv(EnvNoInput) == "true"
+}
+
+// IsYes returns true if confirmation prompts should be auto-confirmed.
+func IsYes() bool {
+	return os.Getenv(EnvYes) == "1" || os.Getenv(EnvYes) == "true"
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -76,8 +76,11 @@ func Password(label string) (string, error) {
 
 // Confirm asks for yes/no confirmation.
 func Confirm(label string) (bool, error) {
+	if config.IsYes() {
+		return true, nil
+	}
 	if config.IsNoInput() {
-		return false, fmt.Errorf("confirmation required but --no-input is set")
+		return false, fmt.Errorf("confirmation required but --no-input is set; use --yes to auto-confirm")
 	}
 	fmt.Fprintf(os.Stderr, "%s [y/N]: ", label)
 	reader := bufio.NewReader(os.Stdin)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,0 +1,94 @@
+package prompt
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfirm_Yes_Env(t *testing.T) {
+	t.Setenv("CONOHA_YES", "1")
+	ok, err := Confirm("Delete?")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected true when CONOHA_YES=1")
+	}
+}
+
+func TestConfirm_NoInput_Without_Yes(t *testing.T) {
+	t.Setenv("CONOHA_NO_INPUT", "1")
+	ok, err := Confirm("Delete?")
+	if ok {
+		t.Fatal("expected false when --no-input without --yes")
+	}
+	if err == nil {
+		t.Fatal("expected error when --no-input without --yes")
+	}
+	if got := err.Error(); got != "confirmation required but --no-input is set; use --yes to auto-confirm" {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}
+
+func TestConfirm_Interactive_Yes(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.WriteString("y\n")
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	ok, err := Confirm("Delete?")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected true for 'y' input")
+	}
+}
+
+func TestConfirm_Interactive_No(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.WriteString("n\n")
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	ok, err := Confirm("Delete?")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected false for 'n' input")
+	}
+}
+
+func TestConfirm_Interactive_Empty_Default_No(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.WriteString("\n")
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	ok, err := Confirm("Delete?")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected false for empty input (default no)")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `--yes`/`-y` flag and `CONOHA_YES` env to skip confirmation prompts
- All destructive commands now require confirmation: server delete/resize/rebuild, volume delete, dns domain delete, lb delete
- `server create` shows a summary (name, flavor, image, volume, key, password) before prompting
- `--no-input` without `--yes` returns error with hint to use `--yes`

## Changed files
- `internal/config/env.go` — `EnvYes`, `IsYes()`
- `internal/prompt/prompt.go` — `Confirm()` checks `IsYes()` first
- `internal/prompt/prompt_test.go` — 5 test cases
- `cmd/root.go` — `--yes`/`-y` persistent flag
- `cmd/server/server.go` — create summary + confirm, delete/resize/rebuild confirm
- `cmd/volume/volume.go` — delete confirm with name lookup
- `cmd/dns/dns.go` — domain delete confirm
- `cmd/lb/lb.go` — delete confirm

## Test plan
- [x] `go test ./...` pass
- [x] `golangci-lint run ./...` 0 issues
- [x] `conoha server delete <id>` → prompt, N cancels
- [x] `conoha server delete <id> --yes` → immediate delete
- [x] `conoha server delete <id> --no-input` → error with `--yes` hint
- [x] `conoha server create --name test` → summary + confirm