### PR TITLE
v0.1.8: List UX improvements

### DIFF
--- a/cmd/cmdutil/format.go
+++ b/cmd/cmdutil/format.go
@@ -1,0 +1,61 @@
+package cmdutil
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/crowdy/conoha-cli/internal/output"
+)
+
+// FormatOutput applies filter, sort, and formats data to stdout.
+func FormatOutput(cmd *cobra.Command, data any) error {
+	var err error
+
+	// Apply filters
+	filters, _ := cmd.Flags().GetStringArray("filter")
+	data, err = output.FilterRows(data, filters)
+	if err != nil {
+		return err
+	}
+
+	// Apply sort
+	sortBy, _ := cmd.Flags().GetString("sort-by")
+	data, err = output.SortRows(data, sortBy)
+	if err != nil {
+		return err
+	}
+
+	// Format output
+	noHeaders, _ := cmd.Flags().GetBool("no-headers")
+	opts := output.Options{Format: GetFormat(cmd), NoHeaders: noHeaders}
+	return output.NewWithOptions(opts).Format(os.Stdout, data)
+}
+
+// FormatBytes formats a byte count as a human-readable string.
+func FormatBytes(bytes int64) string {
+	if bytes == 0 {
+		return "0 B"
+	}
+
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+		tb = 1024 * gb
+	)
+
+	switch {
+	case bytes >= tb:
+		return fmt.Sprintf("%.1f TB", float64(bytes)/float64(tb))
+	case bytes >= gb:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(gb))
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%d KB", bytes/kb)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}

--- a/cmd/cmdutil/format_test.go
+++ b/cmd/cmdutil/format_test.go
@@ -1,0 +1,29 @@
+package cmdutil
+
+import "testing"
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{512, "512 B"},
+		{1024, "1 KB"},
+		{1536, "1 KB"},
+		{10240, "10 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+		{1073741824, "1.0 GB"},
+		{1610612736, "1.5 GB"},
+		{1099511627776, "1.0 TB"},
+		{2199023255552, "2.0 TB"},
+	}
+	for _, tt := range tests {
+		got := FormatBytes(tt.input)
+		if got != tt.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/cmd/dns/dns.go
+++ b/cmd/dns/dns.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -53,7 +52,7 @@ func init() {
 			for i, d := range domains {
 				rows[i] = row{ID: d.ID, Name: d.Name, TTL: d.TTL}
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+			return cmdutil.FormatOutput(cmd, rows)
 		},
 	}
 
@@ -68,7 +67,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, domain)
+			return cmdutil.FormatOutput(cmd, domain)
 		},
 	}
 
@@ -86,7 +85,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, domain)
+			return cmdutil.FormatOutput(cmd, domain)
 		},
 	}
 	domainCreateCmd.Flags().String("name", "", "domain name (required)")
@@ -145,7 +144,7 @@ func init() {
 			for i, r := range records {
 				rows[i] = row{ID: r.ID, Name: r.Name, Type: r.Type, Data: r.Data, TTL: r.TTL}
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+			return cmdutil.FormatOutput(cmd, rows)
 		},
 	}
 	recordListCmd.Flags().String("domain-id", "", "domain ID (required)")
@@ -174,7 +173,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, record)
+			return cmdutil.FormatOutput(cmd, record)
 		},
 	}
 	recordCreateCmd.Flags().String("domain-id", "", "domain ID (required)")

--- a/cmd/flavor/flavor.go
+++ b/cmd/flavor/flavor.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
-	"github.com/crowdy/conoha-cli/internal/output"
 )
 
 var Cmd = &cobra.Command{
@@ -61,10 +60,10 @@ var listCmd = &cobra.Command{
 			}
 		}
 
-		format := cmdutil.GetFormat(cmd)
-		if err := output.New(format).Format(os.Stdout, rows); err != nil {
+		if err := cmdutil.FormatOutput(cmd, rows); err != nil {
 			return err
 		}
+		format := cmdutil.GetFormat(cmd)
 		if format == "" || format == "table" {
 			fmt.Fprintln(os.Stderr, "\nNote: Some flavors may be restricted to prevent abuse. If you cannot use a flavor,")
 			fmt.Fprintln(os.Stderr, "please contact ConoHa support: https://www.conoha.jp/conoha/contact/")
@@ -87,7 +86,7 @@ var showCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, flavor)
+		return cmdutil.FormatOutput(cmd, flavor)
 	},
 }
 

--- a/cmd/identity/identity.go
+++ b/cmd/identity/identity.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -38,7 +37,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, creds)
+			return cmdutil.FormatOutput(cmd, creds)
 		},
 	}
 
@@ -53,7 +52,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, cred)
+			return cmdutil.FormatOutput(cmd, cred)
 		},
 	}
 
@@ -104,7 +103,7 @@ func init() {
 			for i, u := range users {
 				rows[i] = row{ID: u.ID, Name: u.Name, Enabled: u.Enabled}
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+			return cmdutil.FormatOutput(cmd, rows)
 		},
 	}
 
@@ -145,7 +144,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, roles)
+			return cmdutil.FormatOutput(cmd, roles)
 		},
 	}
 

--- a/cmd/image/image.go
+++ b/cmd/image/image.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -37,16 +36,17 @@ var listCmd = &cobra.Command{
 		}
 
 		type row struct {
-			ID      string `json:"id"`
-			Name    string `json:"name"`
-			Status  string `json:"status"`
-			MinDisk int    `json:"min_disk"`
+			ID         string `json:"id"`
+			Name       string `json:"name"`
+			Status     string `json:"status"`
+			MinDisk    int    `json:"min_disk"`
+			Visibility string `json:"visibility"`
 		}
 		rows := make([]row, len(images))
 		for i, img := range images {
-			rows[i] = row{ID: img.ID, Name: img.Name, Status: img.Status, MinDisk: img.MinDisk}
+			rows[i] = row{ID: img.ID, Name: img.Name, Status: img.Status, MinDisk: img.MinDisk, Visibility: img.Visibility}
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+		return cmdutil.FormatOutput(cmd, rows)
 	},
 }
 
@@ -63,7 +63,7 @@ var showCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, img)
+		return cmdutil.FormatOutput(cmd, img)
 	},
 }
 

--- a/cmd/keypair/keypair.go
+++ b/cmd/keypair/keypair.go
@@ -10,7 +10,6 @@ import (
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
 	"github.com/crowdy/conoha-cli/internal/model"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -64,7 +63,7 @@ var listCmd = &cobra.Command{
 		for i, k := range keypairs {
 			rows[i] = row{Name: k.Name, Fingerprint: k.Fingerprint}
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+		return cmdutil.FormatOutput(cmd, rows)
 	},
 }
 

--- a/cmd/lb/lb.go
+++ b/cmd/lb/lb.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -56,7 +55,7 @@ var listCmd = &cobra.Command{
 		for i, l := range lbs {
 			rows[i] = row{ID: l.ID, Name: l.Name, Status: l.ProvisioningStatus, VIP: l.VipAddress}
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+		return cmdutil.FormatOutput(cmd, rows)
 	},
 }
 
@@ -73,7 +72,7 @@ var showCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, lb)
+		return cmdutil.FormatOutput(cmd, lb)
 	},
 }
 
@@ -91,7 +90,7 @@ var createCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, lb)
+		return cmdutil.FormatOutput(cmd, lb)
 	},
 }
 
@@ -135,7 +134,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, items)
+			return cmdutil.FormatOutput(cmd, items)
 		},
 	}
 	listenerCmd.AddCommand(listenerListCmd)
@@ -156,7 +155,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, items)
+			return cmdutil.FormatOutput(cmd, items)
 		},
 	}
 	poolCmd.AddCommand(poolListCmd)
@@ -178,7 +177,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, items)
+			return cmdutil.FormatOutput(cmd, items)
 		},
 	}
 	memberListCmd.Flags().String("pool-id", "", "pool ID (required)")
@@ -201,7 +200,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, items)
+			return cmdutil.FormatOutput(cmd, items)
 		},
 	}
 	healthMonitorCmd.AddCommand(hmListCmd)

--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -53,7 +52,7 @@ var listCmd = &cobra.Command{
 		for i, n := range networks {
 			rows[i] = row{ID: n.ID, Name: n.Name, Status: n.Status}
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+		return cmdutil.FormatOutput(cmd, rows)
 	},
 }
 
@@ -70,7 +69,7 @@ var createCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, net)
+		return cmdutil.FormatOutput(cmd, net)
 	},
 }
 
@@ -129,7 +128,7 @@ func init() {
 			for i, s := range subnets {
 				rows[i] = row{ID: s.ID, Name: s.Name, NetworkID: s.NetworkID, CIDR: s.CIDR}
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+			return cmdutil.FormatOutput(cmd, rows)
 		},
 	}
 
@@ -149,7 +148,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, subnet)
+			return cmdutil.FormatOutput(cmd, subnet)
 		},
 	}
 	subnetCreateCmd.Flags().String("network-id", "", "network ID (required)")
@@ -219,7 +218,7 @@ func init() {
 			for i, p := range ports {
 				rows[i] = row{ID: p.ID, Name: p.Name, NetworkID: p.NetworkID, Status: p.Status}
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+			return cmdutil.FormatOutput(cmd, rows)
 		},
 	}
 
@@ -237,7 +236,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, port)
+			return cmdutil.FormatOutput(cmd, port)
 		},
 	}
 	portCreateCmd.Flags().String("network-id", "", "network ID (required)")
@@ -276,8 +275,9 @@ func init() {
 
 // Security Group subcommands
 var sgCmd = &cobra.Command{
-	Use:   "security-group",
-	Short: "Manage security groups",
+	Use:     "security-group",
+	Aliases: []string{"sg"},
+	Short:   "Manage security groups",
 }
 
 func init() {
@@ -303,7 +303,7 @@ func init() {
 			for i, sg := range sgs {
 				rows[i] = row{ID: sg.ID, Name: sg.Name, Description: sg.Description}
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+			return cmdutil.FormatOutput(cmd, rows)
 		},
 	}
 
@@ -320,7 +320,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, sg)
+			return cmdutil.FormatOutput(cmd, sg)
 		},
 	}
 
@@ -338,7 +338,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, sg)
+			return cmdutil.FormatOutput(cmd, sg)
 		},
 	}
 	sgCreateCmd.Flags().String("name", "", "security group name (required)")
@@ -378,8 +378,9 @@ func init() {
 
 // Security Group Rule subcommands
 var sgRuleCmd = &cobra.Command{
-	Use:   "security-group-rule",
-	Short: "Manage security group rules",
+	Use:     "security-group-rule",
+	Aliases: []string{"sgr"},
+	Short:   "Manage security group rules",
 }
 
 func init() {
@@ -395,7 +396,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rules)
+			return cmdutil.FormatOutput(cmd, rules)
 		},
 	}
 
@@ -427,7 +428,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rule)
+			return cmdutil.FormatOutput(cmd, rule)
 		},
 	}
 	sgRuleCreateCmd.Flags().String("security-group-id", "", "security group ID (required)")
@@ -488,7 +489,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, policies)
+			return cmdutil.FormatOutput(cmd, policies)
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,9 @@ var rootCmd = &cobra.Command{
 		if flagYes {
 			_ = os.Setenv(config.EnvYes, "1")
 		}
+		if flagNoColor {
+			_ = os.Setenv(config.EnvNoColor, "1")
+		}
 	},
 }
 
@@ -64,6 +67,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&flagVerbose, "verbose", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&flagNoColor, "no-color", false, "disable color output")
 	rootCmd.PersistentFlags().BoolVarP(&flagYes, "yes", "y", false, "skip confirmation prompts")
+	rootCmd.PersistentFlags().Bool("no-headers", false, "hide table/CSV headers")
+	rootCmd.PersistentFlags().StringArray("filter", nil, "filter rows by key=value (repeatable)")
+	rootCmd.PersistentFlags().String("sort-by", "", "sort rows by field name")
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(completionCmd)

--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -14,7 +14,6 @@ import (
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
 	"github.com/crowdy/conoha-cli/internal/model"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -197,7 +196,7 @@ var createCmd = &cobra.Command{
 			}
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, server)
+		return cmdutil.FormatOutput(cmd, server)
 	},
 }
 

--- a/cmd/server/list.go
+++ b/cmd/server/list.go
@@ -3,11 +3,13 @@ package server
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
+	"github.com/crowdy/conoha-cli/internal/api"
 	"github.com/crowdy/conoha-cli/internal/model"
 	"github.com/crowdy/conoha-cli/internal/output"
 )
@@ -56,7 +58,7 @@ var listCmd = &cobra.Command{
 			}
 		}
 
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+		return cmdutil.FormatOutput(cmd, rows)
 	},
 }
 
@@ -65,10 +67,11 @@ var showCmd = &cobra.Command{
 	Short: "Show server details",
 	Args:  cmdutil.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		compute, err := getComputeAPI(cmd)
+		client, err := cmdutil.NewClient(cmd)
 		if err != nil {
 			return err
 		}
+		compute := api.NewComputeAPI(client)
 		server, err := compute.FindServer(args[0])
 		if err != nil {
 			return err
@@ -81,6 +84,37 @@ var showCmd = &cobra.Command{
 
 		// Human-readable key-value output
 		printServerDetail(server)
+
+		// Volume attachments (non-fatal)
+		if attachments, err := compute.ListVolumeAttachments(server.ID); err == nil && len(attachments) > 0 {
+			volumeAPI := api.NewVolumeAPI(client)
+			fmt.Println("Volumes:")
+			for _, a := range attachments {
+				size := ""
+				if vol, err := volumeAPI.GetVolume(a.VolumeID); err == nil {
+					size = fmt.Sprintf(" %dGB", vol.Size)
+				}
+				fmt.Printf("  %s %s%s\n", a.VolumeID, a.Device, size)
+			}
+		}
+
+		// Ports (non-fatal)
+		networkAPI := api.NewNetworkAPI(client)
+		if ports, err := networkAPI.ListPortsByDevice(server.ID); err == nil && len(ports) > 0 {
+			fmt.Println("Ports:")
+			for _, p := range ports {
+				var ips []string
+				for _, ip := range p.FixedIPs {
+					ips = append(ips, ip.IPAddress)
+				}
+				sgs := ""
+				if len(p.SecurityGroups) > 0 {
+					sgs = " sg=[" + strings.Join(p.SecurityGroups, ",") + "]"
+				}
+				fmt.Printf("  %s mac=%s ips=[%s]%s\n", p.ID, p.MACAddress, strings.Join(ips, ","), sgs)
+			}
+		}
+
 		return nil
 	},
 }

--- a/cmd/storage/storage.go
+++ b/cmd/storage/storage.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -26,6 +25,8 @@ func init() {
 	Cmd.AddCommand(rmCmd)
 	Cmd.AddCommand(publishCmd)
 	Cmd.AddCommand(unpublishCmd)
+
+	cpCmd.Flags().BoolP("recursive", "r", false, "copy directories recursively")
 }
 
 var accountCmd = &cobra.Command{
@@ -39,7 +40,17 @@ var accountCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, info)
+		type row struct {
+			ContainerCount int    `json:"container_count"`
+			ObjectCount    int    `json:"object_count"`
+			BytesUsed      string `json:"bytes_used"`
+		}
+		r := row{
+			ContainerCount: info.ContainerCount,
+			ObjectCount:    info.ObjectCount,
+			BytesUsed:      cmdutil.FormatBytes(info.BytesUsed),
+		}
+		return cmdutil.FormatOutput(cmd, r)
 	},
 }
 
@@ -57,7 +68,16 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, containers)
+			type row struct {
+				Name  string `json:"name"`
+				Count int    `json:"count"`
+				Size  string `json:"size"`
+			}
+			rows := make([]row, len(containers))
+			for i, c := range containers {
+				rows[i] = row{Name: c.Name, Count: c.Count, Size: cmdutil.FormatBytes(c.Bytes)}
+			}
+			return cmdutil.FormatOutput(cmd, rows)
 		},
 	}
 
@@ -113,7 +133,17 @@ var lsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, objects)
+		type row struct {
+			Name         string `json:"name"`
+			ContentType  string `json:"content_type"`
+			Size         string `json:"size"`
+			LastModified string `json:"last_modified"`
+		}
+		rows := make([]row, len(objects))
+		for i, o := range objects {
+			rows[i] = row{Name: o.Name, ContentType: o.ContentType, Size: cmdutil.FormatBytes(o.Bytes), LastModified: o.LastModified}
+		}
+		return cmdutil.FormatOutput(cmd, rows)
 	},
 }
 
@@ -124,35 +154,138 @@ Use container/object format for remote paths.
 
 Examples:
   conoha storage cp myfile.txt mycontainer/myfile.txt    # upload
-  conoha storage cp mycontainer/myfile.txt ./myfile.txt  # download`,
+  conoha storage cp mycontainer/myfile.txt ./myfile.txt  # download
+  conoha storage cp -r ./dir mycontainer/prefix          # recursive upload
+  conoha storage cp -r mycontainer/prefix ./dir          # recursive download`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := cmdutil.NewClient(cmd)
 		if err != nil {
 			return err
 		}
 		storageAPI := api.NewObjectStorageAPI(client)
+		recursive, _ := cmd.Flags().GetBool("recursive")
 
 		src, dst := args[0], args[1]
 
-		// Determine direction: if src contains "/" and doesn't exist locally, it's a download
-		if _, err := os.Stat(src); err != nil {
+		// Determine direction: if src doesn't exist locally, it's a download
+		srcInfo, srcErr := os.Stat(src)
+
+		if srcErr != nil {
 			// Download: src is remote
-			container, object := splitPath(src)
-			if container == "" || object == "" {
+			container, prefix := splitPath(src)
+			if container == "" {
 				return fmt.Errorf("remote path must be container/object")
 			}
-			return storageAPI.DownloadObject(container, object, dst)
+			if recursive {
+				return recursiveDownload(storageAPI, container, prefix, dst)
+			}
+			if prefix == "" {
+				return fmt.Errorf("remote path must be container/object")
+			}
+			return storageAPI.DownloadObject(container, prefix, dst)
 		}
+
 		// Upload: src is local
-		container, object := splitPath(dst)
+		container, prefix := splitPath(dst)
 		if container == "" {
 			return fmt.Errorf("remote path must be container/object")
 		}
+
+		if recursive {
+			if !srcInfo.IsDir() {
+				return fmt.Errorf("source %q is not a directory; use -r with directories", src)
+			}
+			return recursiveUpload(storageAPI, src, container, prefix)
+		}
+
+		object := prefix
 		if object == "" {
 			object = filepath.Base(src)
 		}
 		return storageAPI.UploadObject(container, object, src)
 	},
+}
+
+func recursiveUpload(storageAPI *api.ObjectStorageAPI, localDir, container, prefix string) error {
+	var files []string
+	err := filepath.WalkDir(localDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking directory: %w", err)
+	}
+
+	var failed int
+	for i, path := range files {
+		rel, _ := filepath.Rel(localDir, path)
+		object := rel
+		if prefix != "" {
+			object = prefix + "/" + rel
+		}
+		fmt.Fprintf(os.Stderr, "Copying [%d/%d] %s\n", i+1, len(files), rel)
+		if err := storageAPI.UploadObject(container, object, path); err != nil {
+			fmt.Fprintf(os.Stderr, "  Warning: failed to upload %s: %v\n", rel, err)
+			failed++
+		}
+	}
+	fmt.Fprintf(os.Stderr, "Done: %d/%d files uploaded\n", len(files)-failed, len(files))
+	if failed > 0 {
+		return fmt.Errorf("%d file(s) failed to upload", failed)
+	}
+	return nil
+}
+
+func recursiveDownload(storageAPI *api.ObjectStorageAPI, container, prefix, localDir string) error {
+	objects, err := storageAPI.ListObjectsWithPrefix(container, prefix)
+	if err != nil {
+		return err
+	}
+	if len(objects) == 0 {
+		return fmt.Errorf("no objects found with prefix %q in container %q", prefix, container)
+	}
+
+	var failed int
+	for i, obj := range objects {
+		// Compute relative path from prefix
+		rel := obj.Name
+		if prefix != "" {
+			rel = obj.Name[len(prefix):]
+			if len(rel) > 0 && rel[0] == '/' {
+				rel = rel[1:]
+			}
+		}
+		if rel == "" {
+			continue
+		}
+		localPath := filepath.Join(localDir, rel)
+
+		// Create parent directories
+		if dir := filepath.Dir(localPath); dir != "." {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				fmt.Fprintf(os.Stderr, "  Warning: failed to create directory %s: %v\n", dir, err)
+				failed++
+				continue
+			}
+		}
+
+		fmt.Fprintf(os.Stderr, "Copying [%d/%d] %s\n", i+1, len(objects), rel)
+		if err := storageAPI.DownloadObject(container, obj.Name, localPath); err != nil {
+			fmt.Fprintf(os.Stderr, "  Warning: failed to download %s: %v\n", obj.Name, err)
+			failed++
+		}
+	}
+	fmt.Fprintf(os.Stderr, "Done: %d/%d files downloaded\n", len(objects)-failed, len(objects))
+	if failed > 0 {
+		return fmt.Errorf("%d file(s) failed to download", failed)
+	}
+	return nil
 }
 
 var rmCmd = &cobra.Command{
@@ -193,6 +326,8 @@ var publishCmd = &cobra.Command{
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "Container %s is now public\n", args[0])
+		fmt.Fprintf(os.Stderr, "Public URL: https://object-storage.%s.conoha.io/v1/AUTH_%s/%s\n",
+			client.Region, client.TenantID, args[0])
 		return nil
 	},
 }

--- a/cmd/volume/volume.go
+++ b/cmd/volume/volume.go
@@ -9,7 +9,6 @@ import (
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
 	"github.com/crowdy/conoha-cli/internal/model"
-	"github.com/crowdy/conoha-cli/internal/output"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
@@ -57,7 +56,7 @@ var listCmd = &cobra.Command{
 		for i, v := range volumes {
 			rows[i] = row{ID: v.ID, Name: v.Name, Status: v.Status, Size: v.Size}
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+		return cmdutil.FormatOutput(cmd, rows)
 	},
 }
 
@@ -74,7 +73,7 @@ var showCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, vol)
+		return cmdutil.FormatOutput(cmd, vol)
 	},
 }
 
@@ -101,7 +100,7 @@ var createCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, vol)
+		return cmdutil.FormatOutput(cmd, vol)
 	},
 }
 
@@ -151,7 +150,7 @@ var typesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, types)
+		return cmdutil.FormatOutput(cmd, types)
 	},
 }
 
@@ -185,7 +184,7 @@ func init() {
 			for i, b := range backups {
 				rows[i] = row{ID: b.ID, Name: b.Name, Status: b.Status, VolumeID: b.VolumeID, Size: b.Size}
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, rows)
+			return cmdutil.FormatOutput(cmd, rows)
 		},
 	}
 
@@ -202,7 +201,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return output.New(cmdutil.GetFormat(cmd)).Format(os.Stdout, backup)
+			return cmdutil.FormatOutput(cmd, backup)
 		},
 	}
 

--- a/internal/api/compute.go
+++ b/internal/api/compute.go
@@ -232,6 +232,16 @@ func (a *ComputeAPI) DetachVolume(serverID, volumeID string) error {
 	return a.Client.Delete(url)
 }
 
+// ListVolumeAttachments returns volumes attached to a server.
+func (a *ComputeAPI) ListVolumeAttachments(serverID string) ([]model.VolumeAttachment, error) {
+	url := fmt.Sprintf("%s/servers/%s/os-volume_attachments", a.baseURL(), serverID)
+	var resp model.VolumeAttachmentsResponse
+	if err := a.Client.Get(url, &resp); err != nil {
+		return nil, err
+	}
+	return resp.VolumeAttachments, nil
+}
+
 // GetServerMetadata returns server metadata.
 func (a *ComputeAPI) GetServerMetadata(id string) (map[string]string, error) {
 	url := fmt.Sprintf("%s/servers/%s/metadata", a.baseURL(), id)

--- a/internal/api/network.go
+++ b/internal/api/network.go
@@ -111,6 +111,16 @@ func (a *NetworkAPI) DeletePort(id string) error {
 	return a.Client.Delete(url)
 }
 
+// ListPortsByDevice returns ports associated with a device (server).
+func (a *NetworkAPI) ListPortsByDevice(deviceID string) ([]model.Port, error) {
+	url := fmt.Sprintf("%s/ports?device_id=%s", a.baseURL(), deviceID)
+	var resp model.PortsResponse
+	if err := a.Client.Get(url, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Ports, nil
+}
+
 func (a *NetworkAPI) ListSecurityGroups() ([]model.SecurityGroup, error) {
 	url := fmt.Sprintf("%s/security-groups", a.baseURL())
 	var resp model.SecurityGroupsResponse

--- a/internal/api/objectstorage.go
+++ b/internal/api/objectstorage.go
@@ -81,6 +81,16 @@ func (a *ObjectStorageAPI) ListObjects(container string) ([]model.StorageObject,
 	return objects, nil
 }
 
+// ListObjectsWithPrefix returns objects in a container filtered by prefix.
+func (a *ObjectStorageAPI) ListObjectsWithPrefix(container, prefix string) ([]model.StorageObject, error) {
+	url := fmt.Sprintf("%s/%s?format=json&prefix=%s", a.baseURL(), container, prefix)
+	var objects []model.StorageObject
+	if err := a.Client.Get(url, &objects); err != nil {
+		return nil, err
+	}
+	return objects, nil
+}
+
 func (a *ObjectStorageAPI) UploadObject(container, objectName, localPath string) error {
 	file, err := os.Open(localPath)
 	if err != nil {

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -16,6 +16,7 @@ const (
 	EnvEndpointMode = "CONOHA_ENDPOINT_MODE"
 	EnvDebug        = "CONOHA_DEBUG"
 	EnvYes          = "CONOHA_YES"
+	EnvNoColor      = "CONOHA_NO_COLOR"
 )
 
 // EnvOr returns the environment variable value if set, otherwise the fallback.
@@ -34,4 +35,14 @@ func IsNoInput() bool {
 // IsYes returns true if confirmation prompts should be auto-confirmed.
 func IsYes() bool {
 	return os.Getenv(EnvYes) == "1" || os.Getenv(EnvYes) == "true"
+}
+
+// IsNoColor returns true if color output should be disabled.
+// Supports both CONOHA_NO_COLOR and the standard NO_COLOR env var.
+func IsNoColor() bool {
+	if v := os.Getenv(EnvNoColor); v == "1" || v == "true" {
+		return true
+	}
+	_, noColor := os.LookupEnv("NO_COLOR")
+	return noColor
 }

--- a/internal/model/network.go
+++ b/internal/model/network.go
@@ -25,12 +25,14 @@ type SubnetsResponse struct {
 }
 
 type Port struct {
-	ID         string    `json:"id" yaml:"id"`
-	Name       string    `json:"name" yaml:"name"`
-	NetworkID  string    `json:"network_id" yaml:"network_id"`
-	Status     string    `json:"status" yaml:"status"`
-	MACAddress string    `json:"mac_address" yaml:"mac_address"`
-	FixedIPs   []FixedIP `json:"fixed_ips" yaml:"fixed_ips"`
+	ID             string    `json:"id" yaml:"id"`
+	Name           string    `json:"name" yaml:"name"`
+	NetworkID      string    `json:"network_id" yaml:"network_id"`
+	DeviceID       string    `json:"device_id" yaml:"device_id"`
+	Status         string    `json:"status" yaml:"status"`
+	MACAddress     string    `json:"mac_address" yaml:"mac_address"`
+	FixedIPs       []FixedIP `json:"fixed_ips" yaml:"fixed_ips"`
+	SecurityGroups []string  `json:"security_groups" yaml:"security_groups"`
 }
 
 type FixedIP struct {

--- a/internal/model/server.go
+++ b/internal/model/server.go
@@ -93,6 +93,17 @@ type KeypairsResponse struct {
 	Keypairs []KeypairWrapper `json:"keypairs"`
 }
 
+type VolumeAttachment struct {
+	ID       string `json:"id" yaml:"id"`
+	VolumeID string `json:"volumeId" yaml:"volume_id"`
+	Device   string `json:"device" yaml:"device"`
+	ServerID string `json:"serverId" yaml:"server_id"`
+}
+
+type VolumeAttachmentsResponse struct {
+	VolumeAttachments []VolumeAttachment `json:"volumeAttachments"`
+}
+
 type KeypairCreateRequest struct {
 	Keypair struct {
 		Name      string `json:"name"`

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -7,7 +7,9 @@ import (
 	"reflect"
 )
 
-type CSVFormatter struct{}
+type CSVFormatter struct {
+	NoHeaders bool
+}
 
 func (f *CSVFormatter) Format(w io.Writer, data any) error {
 	val := reflect.ValueOf(data)
@@ -33,17 +35,19 @@ func (f *CSVFormatter) Format(w io.Writer, data any) error {
 	}
 	elemType := elem.Type()
 
-	headers := make([]string, elemType.NumField())
-	for i := 0; i < elemType.NumField(); i++ {
-		field := elemType.Field(i)
-		name := field.Tag.Get("json")
-		if name == "" || name == "-" {
-			name = field.Name
+	if !f.NoHeaders {
+		headers := make([]string, elemType.NumField())
+		for i := 0; i < elemType.NumField(); i++ {
+			field := elemType.Field(i)
+			name := field.Tag.Get("json")
+			if name == "" || name == "-" {
+				name = field.Name
+			}
+			headers[i] = name
 		}
-		headers[i] = name
-	}
-	if err := writer.Write(headers); err != nil {
-		return err
+		if err := writer.Write(headers); err != nil {
+			return err
+		}
 	}
 
 	// Write rows

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -7,16 +7,27 @@ type Formatter interface {
 	Format(w io.Writer, data any) error
 }
 
+// Options configures output formatting behavior.
+type Options struct {
+	Format    string
+	NoHeaders bool
+}
+
 // New creates a formatter for the given format name.
 func New(format string) Formatter {
-	switch format {
+	return NewWithOptions(Options{Format: format})
+}
+
+// NewWithOptions creates a formatter with the given options.
+func NewWithOptions(opts Options) Formatter {
+	switch opts.Format {
 	case "json":
 		return &JSONFormatter{}
 	case "yaml":
 		return &YAMLFormatter{}
 	case "csv":
-		return &CSVFormatter{}
+		return &CSVFormatter{NoHeaders: opts.NoHeaders}
 	default:
-		return &TableFormatter{}
+		return &TableFormatter{NoHeaders: opts.NoHeaders}
 	}
 }

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -105,6 +105,62 @@ func TestCSVFormatterNonSlice(t *testing.T) {
 	}
 }
 
+func TestTableFormatterNoHeaders(t *testing.T) {
+	var buf bytes.Buffer
+	f := &TableFormatter{NoHeaders: true}
+	data := []testItem{{Name: "server1", Value: 100}}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format() error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "NAME") {
+		t.Errorf("expected no header NAME with NoHeaders, got: %s", out)
+	}
+	if !strings.Contains(out, "server1") {
+		t.Errorf("expected 'server1' in output, got: %s", out)
+	}
+}
+
+func TestCSVFormatterNoHeaders(t *testing.T) {
+	var buf bytes.Buffer
+	f := &CSVFormatter{NoHeaders: true}
+	data := []testItem{{Name: "a", Value: 1}, {Name: "b", Value: 2}}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format() error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (no header), got %d", len(lines))
+	}
+	if strings.Contains(lines[0], "name") && !strings.Contains(lines[0], "a") {
+		t.Errorf("first line should be data, not header: %s", lines[0])
+	}
+}
+
+func TestNewWithOptions(t *testing.T) {
+	f := NewWithOptions(Options{Format: "table", NoHeaders: true})
+	tf, ok := f.(*TableFormatter)
+	if !ok {
+		t.Fatal("expected TableFormatter")
+	}
+	if !tf.NoHeaders {
+		t.Error("expected NoHeaders=true")
+	}
+
+	f = NewWithOptions(Options{Format: "csv", NoHeaders: true})
+	cf, ok := f.(*CSVFormatter)
+	if !ok {
+		t.Fatal("expected CSVFormatter")
+	}
+	if !cf.NoHeaders {
+		t.Error("expected NoHeaders=true")
+	}
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		format string

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -8,7 +8,9 @@ import (
 	"text/tabwriter"
 )
 
-type TableFormatter struct{}
+type TableFormatter struct {
+	NoHeaders bool
+}
 
 func (f *TableFormatter) Format(w io.Writer, data any) error {
 	val := reflect.ValueOf(data)
@@ -35,17 +37,19 @@ func (f *TableFormatter) Format(w io.Writer, data any) error {
 	}
 	elemType := elem.Type()
 
-	headers := make([]string, elemType.NumField())
-	for i := 0; i < elemType.NumField(); i++ {
-		field := elemType.Field(i)
-		name := field.Tag.Get("json")
-		if name == "" || name == "-" {
-			name = field.Name
+	if !f.NoHeaders {
+		headers := make([]string, elemType.NumField())
+		for i := 0; i < elemType.NumField(); i++ {
+			field := elemType.Field(i)
+			name := field.Tag.Get("json")
+			if name == "" || name == "-" {
+				name = field.Name
+			}
+			headers[i] = strings.ToUpper(name)
 		}
-		headers[i] = strings.ToUpper(name)
-	}
-	if _, err := fmt.Fprintln(tw, strings.Join(headers, "\t")); err != nil {
-		return err
+		if _, err := fmt.Fprintln(tw, strings.Join(headers, "\t")); err != nil {
+			return err
+		}
 	}
 
 	// Write rows

--- a/internal/output/transform.go
+++ b/internal/output/transform.go
@@ -1,0 +1,166 @@
+package output
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// FilterRows filters a slice of structs by the given key=value filters.
+// Filters are ANDed. Field names are matched against json tags (case-insensitive).
+// Non-slice data is returned as-is.
+func FilterRows(data any, filters []string) (any, error) {
+	if len(filters) == 0 {
+		return data, nil
+	}
+
+	val := reflect.ValueOf(data)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	if val.Kind() != reflect.Slice {
+		return data, nil
+	}
+	if val.Len() == 0 {
+		return data, nil
+	}
+
+	// Parse filters
+	type filterPair struct {
+		field string
+		value string
+	}
+	var parsed []filterPair
+	for _, f := range filters {
+		parts := strings.SplitN(f, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid filter %q: expected key=value", f)
+		}
+		parsed = append(parsed, filterPair{field: strings.ToLower(parts[0]), value: strings.ToLower(parts[1])})
+	}
+
+	// Build field index map from json tags
+	elem := val.Index(0)
+	if elem.Kind() == reflect.Ptr {
+		elem = elem.Elem()
+	}
+	elemType := elem.Type()
+	fieldIndex := make(map[string]int, elemType.NumField())
+	var fieldNames []string
+	for i := 0; i < elemType.NumField(); i++ {
+		field := elemType.Field(i)
+		name := field.Tag.Get("json")
+		if name == "" || name == "-" {
+			name = field.Name
+		}
+		lower := strings.ToLower(name)
+		fieldIndex[lower] = i
+		fieldNames = append(fieldNames, name)
+	}
+
+	// Validate filter fields
+	for _, fp := range parsed {
+		if _, ok := fieldIndex[fp.field]; !ok {
+			return nil, fmt.Errorf("unknown field %q; available fields: %s", fp.field, strings.Join(fieldNames, ", "))
+		}
+	}
+
+	// Filter
+	result := reflect.MakeSlice(val.Type(), 0, val.Len())
+	for i := 0; i < val.Len(); i++ {
+		row := val.Index(i)
+		if row.Kind() == reflect.Ptr {
+			row = row.Elem()
+		}
+		match := true
+		for _, fp := range parsed {
+			idx := fieldIndex[fp.field]
+			fieldVal := strings.ToLower(fmt.Sprintf("%v", row.Field(idx).Interface()))
+			if fieldVal != fp.value {
+				match = false
+				break
+			}
+		}
+		if match {
+			result = reflect.Append(result, val.Index(i))
+		}
+	}
+	return result.Interface(), nil
+}
+
+// SortRows sorts a slice of structs by the given field name.
+// Field name is matched against json tags (case-insensitive).
+// Non-slice data is returned as-is.
+func SortRows(data any, sortBy string) (any, error) {
+	if sortBy == "" {
+		return data, nil
+	}
+
+	val := reflect.ValueOf(data)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	if val.Kind() != reflect.Slice {
+		return data, nil
+	}
+	if val.Len() <= 1 {
+		return data, nil
+	}
+
+	// Find field index
+	elem := val.Index(0)
+	if elem.Kind() == reflect.Ptr {
+		elem = elem.Elem()
+	}
+	elemType := elem.Type()
+	sortByLower := strings.ToLower(sortBy)
+	fieldIdx := -1
+	var fieldNames []string
+	for i := 0; i < elemType.NumField(); i++ {
+		field := elemType.Field(i)
+		name := field.Tag.Get("json")
+		if name == "" || name == "-" {
+			name = field.Name
+		}
+		fieldNames = append(fieldNames, name)
+		if strings.ToLower(name) == sortByLower {
+			fieldIdx = i
+		}
+	}
+	if fieldIdx < 0 {
+		return nil, fmt.Errorf("unknown field %q; available fields: %s", sortBy, strings.Join(fieldNames, ", "))
+	}
+
+	// Make a sortable copy
+	sorted := reflect.MakeSlice(val.Type(), val.Len(), val.Len())
+	reflect.Copy(sorted, val)
+
+	sort.SliceStable(sorted.Interface(), func(i, j int) bool {
+		a := sorted.Index(i)
+		b := sorted.Index(j)
+		if a.Kind() == reflect.Ptr {
+			a = a.Elem()
+		}
+		if b.Kind() == reflect.Ptr {
+			b = b.Elem()
+		}
+		fa := a.Field(fieldIdx)
+		fb := b.Field(fieldIdx)
+
+		switch fa.Kind() {
+		case reflect.String:
+			return strings.ToLower(fa.String()) < strings.ToLower(fb.String())
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return fa.Int() < fb.Int()
+		case reflect.Float32, reflect.Float64:
+			return fa.Float() < fb.Float()
+		case reflect.Bool:
+			return !fa.Bool() && fb.Bool()
+		default:
+			return fmt.Sprintf("%v", fa.Interface()) < fmt.Sprintf("%v", fb.Interface())
+		}
+	})
+
+	return sorted.Interface(), nil
+}

--- a/internal/output/transform_test.go
+++ b/internal/output/transform_test.go
@@ -1,0 +1,172 @@
+package output
+
+import (
+	"reflect"
+	"testing"
+)
+
+type filterTestItem struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
+func TestFilterRows(t *testing.T) {
+	data := []filterTestItem{
+		{Name: "a", Status: "ACTIVE", Count: 1},
+		{Name: "b", Status: "STOPPED", Count: 2},
+		{Name: "c", Status: "ACTIVE", Count: 3},
+	}
+
+	t.Run("single filter", func(t *testing.T) {
+		result, err := FilterRows(data, []string{"status=ACTIVE"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(rows))
+		}
+		if rows[0].Name != "a" || rows[1].Name != "c" {
+			t.Errorf("unexpected rows: %+v", rows)
+		}
+	})
+
+	t.Run("multiple filters (AND)", func(t *testing.T) {
+		result, err := FilterRows(data, []string{"status=ACTIVE", "name=c"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 1 || rows[0].Name != "c" {
+			t.Errorf("expected [c], got %+v", rows)
+		}
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		result, err := FilterRows(data, []string{"status=active"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(rows))
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		result, err := FilterRows(data, []string{"name=z"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 0 {
+			t.Errorf("expected 0 rows, got %d", len(rows))
+		}
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		_, err := FilterRows(data, []string{"unknown=x"})
+		if err == nil {
+			t.Error("expected error for unknown field")
+		}
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		_, err := FilterRows(data, []string{"badfilter"})
+		if err == nil {
+			t.Error("expected error for invalid filter format")
+		}
+	})
+
+	t.Run("empty filters", func(t *testing.T) {
+		result, err := FilterRows(data, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(result, data) {
+			t.Error("expected original data returned")
+		}
+	})
+
+	t.Run("non-slice", func(t *testing.T) {
+		item := filterTestItem{Name: "x"}
+		result, err := FilterRows(item, []string{"name=x"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(result, item) {
+			t.Error("expected original item returned for non-slice")
+		}
+	})
+}
+
+func TestSortRows(t *testing.T) {
+	data := []filterTestItem{
+		{Name: "charlie", Status: "ACTIVE", Count: 3},
+		{Name: "alpha", Status: "STOPPED", Count: 1},
+		{Name: "bravo", Status: "ACTIVE", Count: 2},
+	}
+
+	t.Run("sort by string", func(t *testing.T) {
+		result, err := SortRows(data, "name")
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if rows[0].Name != "alpha" || rows[1].Name != "bravo" || rows[2].Name != "charlie" {
+			t.Errorf("unexpected sort order: %+v", rows)
+		}
+	})
+
+	t.Run("sort by int", func(t *testing.T) {
+		result, err := SortRows(data, "count")
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if rows[0].Count != 1 || rows[1].Count != 2 || rows[2].Count != 3 {
+			t.Errorf("unexpected sort order: %+v", rows)
+		}
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		_, err := SortRows(data, "unknown")
+		if err == nil {
+			t.Error("expected error for unknown field")
+		}
+	})
+
+	t.Run("empty sort-by", func(t *testing.T) {
+		result, err := SortRows(data, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(result, data) {
+			t.Error("expected original data returned")
+		}
+	})
+
+	t.Run("non-slice", func(t *testing.T) {
+		item := filterTestItem{Name: "x"}
+		result, err := SortRows(item, "name")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(result, item) {
+			t.Error("expected original item returned for non-slice")
+		}
+	})
+
+	t.Run("does not mutate original", func(t *testing.T) {
+		original := make([]filterTestItem, len(data))
+		copy(original, data)
+		_, err := SortRows(data, "name")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(data, original) {
+			t.Error("original data was mutated")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `--no-headers`, `--filter key=value`, `--sort-by field` persistent flags to all list commands via new `FormatOutput` helper
- Add `--no-color` infrastructure (`CONOHA_NO_COLOR` + `NO_COLOR` standard env var support)
- Add network command aliases: `security-group` → `sg`, `security-group-rule` → `sgr`
- Add `visibility` column to `image list`
- Add human-readable byte sizes to `storage account`, `storage container list`, `storage ls`
- Add public URL output after `storage publish`
- Add `storage cp --recursive` / `-r` for recursive upload/download with progress
- Add volume attachments and port details (IPs, MAC, security groups) to `server show`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (new tests for FilterRows, SortRows, FormatBytes, NoHeaders)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `conoha server list --filter status=ACTIVE`
- [x] `conoha server list --sort-by name`
- [x] `conoha server list --no-headers`
- [x] `conoha server list --no-headers --format csv`
- [x] `conoha network sg list` (alias test)
- [x] `conoha network sgr list` (alias test)
- [x] `conoha image list` (visibility column)
- [x] `conoha storage container list` (human-readable bytes)
- [x] `conoha storage publish <container>` (public URL output)
- [x] `conoha server show <id>` (volume/port info)
- [x] `conoha storage cp -r ./dir container/prefix` (recursive upload)
- [x] `conoha storage cp -r container/prefix ./dir` (recursive download)