### PR TITLE
v0.1.9: --wait for async operations and server ssh command

### DIFF
--- a/cmd/cmdutil/wait.go
+++ b/cmd/cmdutil/wait.go
@@ -1,0 +1,84 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	DefaultWaitInterval = 10 * time.Second
+	DefaultWaitTimeout  = 5 * time.Minute
+)
+
+// WaitConfig holds parameters for the polling loop.
+type WaitConfig struct {
+	Interval time.Duration
+	Timeout  time.Duration
+	Resource string // e.g. "server my-server"
+}
+
+// WaitFor polls checkFn until it returns done=true or an error occurs.
+// checkFn returns (done, status, error):
+//   - done=true:  success, stop polling
+//   - done=false: keep polling, print status
+//   - err!=nil:   abort with error
+func WaitFor(cfg WaitConfig, checkFn func() (done bool, status string, err error)) error {
+	if cfg.Interval == 0 {
+		cfg.Interval = DefaultWaitInterval
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultWaitTimeout
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	deadline := time.Now().Add(cfg.Timeout)
+	for {
+		done, status, err := checkFn()
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for %s (status: %s)", cfg.Resource, status)
+		}
+		if status != "" {
+			fmt.Fprintf(os.Stderr, "  %s status: %s\n", cfg.Resource, status)
+		}
+
+		select {
+		case <-ctx.Done():
+			fmt.Fprintf(os.Stderr, "\nInterrupted. Operation is still in progress on the server.\n")
+			return fmt.Errorf("interrupted while waiting for %s", cfg.Resource)
+		case <-time.After(cfg.Interval):
+		}
+	}
+}
+
+// AddWaitFlags adds --wait and --wait-timeout flags to a command.
+func AddWaitFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("wait", false, "wait for operation to complete")
+	cmd.Flags().Duration("wait-timeout", DefaultWaitTimeout, "maximum wait time")
+}
+
+// GetWaitConfig reads --wait and --wait-timeout flags from the command.
+// Returns nil if --wait is not set.
+func GetWaitConfig(cmd *cobra.Command, resource string) *WaitConfig {
+	wait, _ := cmd.Flags().GetBool("wait")
+	if !wait {
+		return nil
+	}
+	timeout, _ := cmd.Flags().GetDuration("wait-timeout")
+	return &WaitConfig{
+		Timeout:  timeout,
+		Resource: resource,
+	}
+}

--- a/cmd/cmdutil/wait_test.go
+++ b/cmd/cmdutil/wait_test.go
@@ -1,0 +1,72 @@
+package cmdutil
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitForImmediateSuccess(t *testing.T) {
+	err := WaitFor(WaitConfig{
+		Interval: 10 * time.Millisecond,
+		Timeout:  100 * time.Millisecond,
+		Resource: "test",
+	}, func() (bool, string, error) {
+		return true, "done", nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestWaitForTimeout(t *testing.T) {
+	err := WaitFor(WaitConfig{
+		Interval: 10 * time.Millisecond,
+		Timeout:  50 * time.Millisecond,
+		Resource: "test-resource",
+	}, func() (bool, string, error) {
+		return false, "PENDING", nil
+	})
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+}
+
+func TestWaitForError(t *testing.T) {
+	want := errors.New("something broke")
+	err := WaitFor(WaitConfig{
+		Interval: 10 * time.Millisecond,
+		Timeout:  100 * time.Millisecond,
+		Resource: "test",
+	}, func() (bool, string, error) {
+		return false, "", want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+}
+
+func TestWaitForEventualSuccess(t *testing.T) {
+	calls := 0
+	err := WaitFor(WaitConfig{
+		Interval: 10 * time.Millisecond,
+		Timeout:  1 * time.Second,
+		Resource: "test",
+	}, func() (bool, string, error) {
+		calls++
+		if calls >= 3 {
+			return true, "ACTIVE", nil
+		}
+		return false, "BUILD", nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if calls < 3 {
+		t.Fatalf("expected at least 3 calls, got %d", calls)
+	}
+}

--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -1,13 +1,10 @@
 package server
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"os"
-	"os/signal"
 	"sort"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -18,9 +15,7 @@ import (
 )
 
 const (
-	volumePollInterval = 10 * time.Second
-	volumePollTimeout  = 5 * time.Minute
-	userDataMaxSize    = 16 * 1024 // 16 KiB
+	userDataMaxSize = 16 * 1024 // 16 KiB
 )
 
 // volumeTypeChoices maps user-friendly names to API volume type values.
@@ -48,6 +43,7 @@ func init() {
 	createCmd.Flags().String("user-data-raw", "", "startup script string (inline)")
 	createCmd.Flags().String("user-data-url", "", "startup script URL (wrapped as #include)")
 	_ = createCmd.MarkFlagRequired("name")
+	cmdutil.AddWaitFlags(createCmd)
 }
 
 var createCmd = &cobra.Command{
@@ -196,6 +192,19 @@ var createCmd = &cobra.Command{
 			}
 			return err
 		}
+
+		if wc := cmdutil.GetWaitConfig(cmd, "server "+name); wc != nil {
+			fmt.Fprintf(os.Stderr, "Waiting for server %s to become active...\n", name)
+			if err := waitForServerStatus(compute, server.ID, "ACTIVE", wc); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Server %s is active.\n", name)
+			// Re-fetch to get final state with IP addresses
+			if s, err := compute.GetServer(server.ID); err == nil {
+				server = s
+			}
+		}
+
 		return cmdutil.FormatOutput(cmd, server)
 	},
 }
@@ -397,8 +406,7 @@ func createBootVolume(volumeAPI *api.VolumeAPI, imageID string) (string, bool, e
 	}
 
 	fmt.Fprintf(os.Stderr, "Waiting for volume %s to become available...\n", vol.ID)
-	vol, err = waitForVolume(volumeAPI, vol.ID)
-	if err != nil {
+	if err := waitForVolumeAvailable(volumeAPI, vol.ID); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: boot volume %s was created but may not be ready.\n", vol.ID)
 		fmt.Fprintf(os.Stderr, "You can delete it with: conoha volume delete %s\n", vol.ID)
 		return "", true, err
@@ -439,34 +447,36 @@ func selectExistingVolume(volumeAPI *api.VolumeAPI) (string, bool, error) {
 	return id, false, nil
 }
 
-// waitForVolume polls until the volume reaches "available" status.
-func waitForVolume(volumeAPI *api.VolumeAPI, id string) (*model.Volume, error) {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer stop()
-
-	deadline := time.Now().Add(volumePollTimeout)
-	for {
+// waitForVolumeAvailable polls until the volume reaches "available" status.
+func waitForVolumeAvailable(volumeAPI *api.VolumeAPI, id string) error {
+	return cmdutil.WaitFor(cmdutil.WaitConfig{Resource: "volume " + id}, func() (bool, string, error) {
 		vol, err := volumeAPI.GetVolume(id)
 		if err != nil {
-			return nil, fmt.Errorf("checking volume status: %w", err)
+			return false, "", fmt.Errorf("checking volume status: %w", err)
 		}
 		if vol.Status == "available" {
-			return vol, nil
+			return true, vol.Status, nil
 		}
 		if vol.Status == "error" {
-			return vol, fmt.Errorf("volume %s entered error state", id)
+			return false, vol.Status, fmt.Errorf("volume %s entered error state", id)
 		}
-		if time.Now().After(deadline) {
-			return vol, fmt.Errorf("timeout waiting for volume %s (status: %s)", id, vol.Status)
-		}
-		fmt.Fprintf(os.Stderr, "  volume %s status: %s\n", id, vol.Status)
+		return false, vol.Status, nil
+	})
+}
 
-		select {
-		case <-ctx.Done():
-			fmt.Fprintf(os.Stderr, "\nInterrupted. Volume creation is still in progress on the server.\n")
-			fmt.Fprintf(os.Stderr, "Check status with: conoha volume show %s\n", id)
-			return vol, fmt.Errorf("interrupted while waiting for volume %s", id)
-		case <-time.After(volumePollInterval):
+// waitForServerStatus polls until the server reaches the target status.
+func waitForServerStatus(compute *api.ComputeAPI, id, target string, wc *cmdutil.WaitConfig) error {
+	return cmdutil.WaitFor(*wc, func() (bool, string, error) {
+		s, err := compute.GetServer(id)
+		if err != nil {
+			return false, "", err
 		}
-	}
+		if s.Status == target {
+			return true, s.Status, nil
+		}
+		if s.Status == "ERROR" {
+			return false, s.Status, fmt.Errorf("server entered ERROR state")
+		}
+		return false, s.Status, nil
+	})
 }

--- a/cmd/server/lifecycle.go
+++ b/cmd/server/lifecycle.go
@@ -1,17 +1,24 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
+	"github.com/crowdy/conoha-cli/internal/api"
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
 func init() {
 	rebootCmd.Flags().Bool("hard", false, "perform hard reboot")
+	for _, c := range []*cobra.Command{deleteCmd, startCmd, stopCmd, rebootCmd} {
+		cmdutil.AddWaitFlags(c)
+	}
 }
 
 var deleteCmd = &cobra.Command{
@@ -39,6 +46,25 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "Server %s deleted\n", s.Name)
+
+		if wc := cmdutil.GetWaitConfig(cmd, "server "+s.Name); wc != nil {
+			fmt.Fprintf(os.Stderr, "Waiting for server %s to be removed...\n", s.Name)
+			if err := cmdutil.WaitFor(cmdutil.WaitConfig{Resource: wc.Resource, Timeout: wc.Timeout}, func() (bool, string, error) {
+				_, err := compute.GetServer(s.ID)
+				if err != nil {
+					var nfe *cerrors.NotFoundError
+					if errors.As(err, &nfe) {
+						return true, "", nil
+					}
+					return false, "", err
+				}
+				return false, "deleting", nil
+			}); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Server %s removed.\n", s.Name)
+		}
+
 		return nil
 	},
 }
@@ -60,6 +86,14 @@ var startCmd = &cobra.Command{
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "Server %s starting\n", args[0])
+
+		if wc := cmdutil.GetWaitConfig(cmd, "server "+args[0]); wc != nil {
+			if err := waitForServerStatus(compute, id, "ACTIVE", wc); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Server %s is active.\n", args[0])
+		}
+
 		return nil
 	},
 }
@@ -81,6 +115,14 @@ var stopCmd = &cobra.Command{
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "Server %s stopping\n", args[0])
+
+		if wc := cmdutil.GetWaitConfig(cmd, "server "+args[0]); wc != nil {
+			if err := waitForServerStatus(compute, id, "SHUTOFF", wc); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Server %s is stopped.\n", args[0])
+		}
+
 		return nil
 	},
 }
@@ -103,6 +145,16 @@ var rebootCmd = &cobra.Command{
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "Server %s rebooting\n", args[0])
+
+		if wc := cmdutil.GetWaitConfig(cmd, "server "+args[0]); wc != nil {
+			// Wait for server to enter REBOOT state first, then wait for ACTIVE.
+			// Without this, the poll may see ACTIVE before the reboot starts.
+			if err := waitForServerReboot(compute, id, wc); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Server %s is active.\n", args[0])
+		}
+
 		return nil
 	},
 }
@@ -163,6 +215,28 @@ var rebuildCmd = &cobra.Command{
 		fmt.Fprintf(os.Stderr, "Server %s rebuilding with image %s\n", args[0], args[1])
 		return nil
 	},
+}
+
+// waitForServerReboot waits for the server to enter a reboot state, then waits for ACTIVE.
+// This avoids the race where the server is still ACTIVE when polling starts.
+func waitForServerReboot(compute *api.ComputeAPI, id string, wc *cmdutil.WaitConfig) error {
+	// Phase 1: wait for server to leave ACTIVE (enter REBOOT/HARD_REBOOT)
+	_ = cmdutil.WaitFor(cmdutil.WaitConfig{
+		Resource: wc.Resource,
+		Timeout:  30 * time.Second,
+		Interval: 2 * time.Second,
+	}, func() (bool, string, error) {
+		s, err := compute.GetServer(id)
+		if err != nil {
+			return false, "", err
+		}
+		if s.Status != "ACTIVE" {
+			return true, s.Status, nil
+		}
+		return false, s.Status, nil
+	})
+	// Phase 2: wait for ACTIVE
+	return waitForServerStatus(compute, id, "ACTIVE", wc)
 }
 
 var consoleCmd = &cobra.Command{

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -31,6 +31,7 @@ func init() {
 	Cmd.AddCommand(metadataCmd)
 	Cmd.AddCommand(attachVolumeCmd)
 	Cmd.AddCommand(detachVolumeCmd)
+	Cmd.AddCommand(sshCmd)
 }
 
 func getComputeAPI(cmd *cobra.Command) (*api.ComputeAPI, error) {

--- a/cmd/server/ssh.go
+++ b/cmd/server/ssh.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/crowdy/conoha-cli/internal/model"
+)
+
+func init() {
+	sshCmd.Flags().StringP("user", "l", "root", "SSH user")
+	sshCmd.Flags().StringP("port", "p", "22", "SSH port")
+	sshCmd.Flags().StringP("identity", "i", "", "SSH private key path (overrides auto-detection)")
+}
+
+var sshCmd = &cobra.Command{
+	Use:   "ssh <id|name> [command...]",
+	Short: "SSH into a server",
+	Long:  "Connect to a server via SSH. Remaining arguments are passed as the remote command.",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		compute, err := getComputeAPI(cmd)
+		if err != nil {
+			return err
+		}
+
+		s, err := compute.FindServer(args[0])
+		if err != nil {
+			return err
+		}
+
+		ip, err := getServerIP(s)
+		if err != nil {
+			return err
+		}
+
+		user, _ := cmd.Flags().GetString("user")
+		port, _ := cmd.Flags().GetString("port")
+		identity, _ := cmd.Flags().GetString("identity")
+
+		if identity == "" {
+			identity = resolveKeyPath(s.KeyName)
+		}
+
+		sshArgs := []string{"ssh"}
+		sshArgs = append(sshArgs, "-l", user)
+		if port != "22" {
+			sshArgs = append(sshArgs, "-p", port)
+		}
+		if identity != "" {
+			sshArgs = append(sshArgs, "-i", identity)
+		}
+		sshArgs = append(sshArgs, ip)
+		sshArgs = append(sshArgs, args[1:]...)
+
+		sshPath, err := exec.LookPath("ssh")
+		if err != nil {
+			return fmt.Errorf("ssh not found in PATH: %w", err)
+		}
+
+		// NOTE: syscall.Exec replaces the process (Unix only).
+		// Windows is not supported for this command.
+		return syscall.Exec(sshPath, sshArgs, os.Environ())
+	},
+}
+
+// getServerIP extracts the best IP address from server addresses.
+// Prefers floating IPv4 over fixed IPv4.
+func getServerIP(s *model.Server) (string, error) {
+	var fixedIP, floatingIP string
+
+	for _, addrs := range s.Addresses {
+		for _, a := range addrs {
+			if a.Version != 4 {
+				continue
+			}
+			switch a.Type {
+			case "floating":
+				floatingIP = a.Addr
+			case "fixed":
+				if fixedIP == "" {
+					fixedIP = a.Addr
+				}
+			}
+		}
+	}
+
+	if floatingIP != "" {
+		return floatingIP, nil
+	}
+	if fixedIP != "" {
+		return fixedIP, nil
+	}
+	return "", fmt.Errorf("no IPv4 address found for server %s", s.Name)
+}
+
+// resolveKeyPath returns the SSH private key path for a server's key name.
+// Returns empty string if no key is associated or the file doesn't exist.
+func resolveKeyPath(keyName string) string {
+	if keyName == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	keyPath := filepath.Join(home, ".ssh", "conoha_"+keyName)
+	if _, err := os.Stat(keyPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: key file %s not found, connecting without key\n", keyPath)
+		return ""
+	}
+	return keyPath
+}

--- a/cmd/server/ssh_test.go
+++ b/cmd/server/ssh_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/crowdy/conoha-cli/internal/model"
+)
+
+func TestGetServerIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		server  *model.Server
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "floating preferred over fixed",
+			server: &model.Server{
+				Name: "test",
+				Addresses: map[string][]model.Address{
+					"net1": {
+						{Addr: "10.0.0.1", Version: 4, Type: "fixed"},
+						{Addr: "203.0.113.1", Version: 4, Type: "floating"},
+					},
+				},
+			},
+			want: "203.0.113.1",
+		},
+		{
+			name: "fixed only",
+			server: &model.Server{
+				Name: "test",
+				Addresses: map[string][]model.Address{
+					"net1": {
+						{Addr: "10.0.0.1", Version: 4, Type: "fixed"},
+					},
+				},
+			},
+			want: "10.0.0.1",
+		},
+		{
+			name: "ipv6 only returns error",
+			server: &model.Server{
+				Name: "test",
+				Addresses: map[string][]model.Address{
+					"net1": {
+						{Addr: "2001:db8::1", Version: 6, Type: "fixed"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no addresses",
+			server: &model.Server{
+				Name:      "test",
+				Addresses: map[string][]model.Address{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple networks",
+			server: &model.Server{
+				Name: "test",
+				Addresses: map[string][]model.Address{
+					"net1": {
+						{Addr: "10.0.0.1", Version: 4, Type: "fixed"},
+					},
+					"net2": {
+						{Addr: "192.168.0.1", Version: 4, Type: "floating"},
+					},
+				},
+			},
+			want: "192.168.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getServerIP(tt.server)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveKeyPath(t *testing.T) {
+	// Empty key name should return empty
+	if got := resolveKeyPath(""); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+
+	// Non-existent key file should return empty (with warning)
+	if got := resolveKeyPath("nonexistent-key-12345"); got != "" {
+		t.Errorf("expected empty for non-existent key, got %q", got)
+	}
+}

--- a/cmd/volume/volume.go
+++ b/cmd/volume/volume.go
@@ -31,6 +31,7 @@ func init() {
 	createCmd.Flags().String("description", "", "volume description")
 	_ = createCmd.MarkFlagRequired("name")
 	_ = createCmd.MarkFlagRequired("size")
+	cmdutil.AddWaitFlags(createCmd)
 }
 
 var listCmd = &cobra.Command{
@@ -96,10 +97,20 @@ var createCmd = &cobra.Command{
 		req.Volume.VolumeType = volType
 		req.Volume.Description = desc
 
-		vol, err := api.NewVolumeAPI(client).CreateVolume(req)
+		volumeAPI := api.NewVolumeAPI(client)
+		vol, err := volumeAPI.CreateVolume(req)
 		if err != nil {
 			return err
 		}
+
+		if wc := cmdutil.GetWaitConfig(cmd, "volume "+name); wc != nil {
+			fmt.Fprintf(os.Stderr, "Waiting for volume %s to become available...\n", name)
+			if err := waitForVolumeAvailable(volumeAPI, vol.ID, wc); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Volume %s is available.\n", name)
+		}
+
 		return cmdutil.FormatOutput(cmd, vol)
 	},
 }
@@ -225,4 +236,21 @@ func init() {
 	backupCmd.AddCommand(backupListCmd)
 	backupCmd.AddCommand(backupShowCmd)
 	backupCmd.AddCommand(backupRestoreCmd)
+}
+
+// waitForVolumeAvailable polls until the volume reaches "available" status.
+func waitForVolumeAvailable(volumeAPI *api.VolumeAPI, id string, wc *cmdutil.WaitConfig) error {
+	return cmdutil.WaitFor(*wc, func() (bool, string, error) {
+		v, err := volumeAPI.GetVolume(id)
+		if err != nil {
+			return false, "", err
+		}
+		if v.Status == "available" {
+			return true, v.Status, nil
+		}
+		if v.Status == "error" {
+			return false, v.Status, fmt.Errorf("volume %s entered error state", id)
+		}
+		return false, v.Status, nil
+	})
 }


### PR DESCRIPTION
## Summary
- Add shared `cmdutil.WaitFor` polling helper with `--wait` / `--wait-timeout` flags
- Add `--wait` support to `server create/delete/start/stop/reboot` and `volume create`
- Refactor existing `waitForVolume` to use shared helper
- Add `server ssh` command with `--user`/`-l`, `--port`/`-p`, `--identity`/`-i` flags
- Handle reboot wait race (wait for non-ACTIVE before waiting for ACTIVE)
- Re-fetch server after `--wait` completes to show final state with IPs

## Test plan
- [x] `go test ./...` all pass
- [x] `golangci-lint run ./...` 0 issues
- [x] Unit tests for `WaitFor` (immediate success, timeout, error, eventual success)
- [x] Unit tests for `getServerIP` (floating preferred, fixed only, IPv6 only, no addresses, multiple networks)
- [x] Unit tests for `resolveKeyPath` (empty key, non-existent file)
- [x] Manual: `conoha server create --name test --wait` waits for ACTIVE
- [x] Manual: `conoha server stop <id> --wait` waits for SHUTOFF
- [x] Manual: `conoha server ssh <id>` connects via SSH