### PR TITLE
Fix CI lint: upgrade golangci-lint-action to v7 for Go 1.26 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
golangci-lint v1.64.8 (installed by action v6) was built with Go 1.24, which is incompatible with Go 1.26.1. Action v7 installs golangci-lint v2.x which supports Go 1.26.