### PR TITLE
Fix external endpoint hostnames for image and load-balancer

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -39,7 +39,15 @@ func NewClient(region, token, tenantID string) *Client {
 	}
 }
 
-// intServiceMap maps external service names to internal API path segments.
+// extServiceMap maps logical service names to external API hostnames
+// where they differ from the logical name.
+var extServiceMap = map[string]string{
+	"image":         "image-service",
+	"load-balancer": "lbaas",
+}
+
+// intServiceMap maps logical service names to internal API path segments
+// where they differ from the logical name.
 var intServiceMap = map[string]string{
 	"image":      "image-service",
 	"networking": "network",
@@ -59,7 +67,11 @@ func (c *Client) BaseURL(service string) string {
 		}
 		return ep
 	}
-	return fmt.Sprintf("https://%s.%s.conoha.io", service, c.Region)
+	hostname := service
+	if mapped, ok := extServiceMap[hostname]; ok {
+		hostname = mapped
+	}
+	return fmt.Sprintf("https://%s.%s.conoha.io", hostname, c.Region)
 }
 
 // Do executes an HTTP request with auth headers and error handling.

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -136,6 +136,28 @@ func TestBaseURL(t *testing.T) {
 	}
 }
 
+func TestBaseURLWithExtServiceMap(t *testing.T) {
+	client := NewClient("c3j1", "tok", "tenant1")
+
+	tests := []struct {
+		service  string
+		expected string
+	}{
+		{"image", "https://image-service.c3j1.conoha.io"},
+		{"load-balancer", "https://lbaas.c3j1.conoha.io"},
+		{"compute", "https://compute.c3j1.conoha.io"},
+		{"networking", "https://networking.c3j1.conoha.io"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.service, func(t *testing.T) {
+			url := client.BaseURL(tt.service)
+			if url != tt.expected {
+				t.Errorf("BaseURL(%q) = %q, want %q", tt.service, url, tt.expected)
+			}
+		})
+	}
+}
+
 func TestBaseURLWithEndpointOverride(t *testing.T) {
 	t.Setenv("CONOHA_ENDPOINT", "https://staging.internal.gmo.jp")
 	client := NewClient("c3j1", "tok", "tenant1")


### PR DESCRIPTION
## Summary
- `image` service was resolving to `image.c3j1.conoha.io` instead of `image-service.c3j1.conoha.io`
- `load-balancer` service was resolving to `load-balancer.c3j1.conoha.io` instead of `lbaas.c3j1.conoha.io`
- Added `extServiceMap` for logical service name → hostname mapping in `BaseURL()`

## Test plan
- [x] Unit tests for all service hostname mappings added
- [x] `conoha server create` succeeds (image endpoint reachable)
- [x] `conoha lb list` succeeds (lbaas endpoint reachable)