### PR TITLE
Remove unused RenameServer function

### DIFF
--- a/internal/api/compute.go
+++ b/internal/api/compute.go
@@ -71,19 +71,6 @@ func (a *ComputeAPI) FindServer(idOrName string) (*model.Server, error) {
 	return s, nil
 }
 
-// RenameServer updates the server name.
-func (a *ComputeAPI) RenameServer(id, newName string) (*model.Server, error) {
-	url := fmt.Sprintf("%s/servers/%s", a.baseURL(), id)
-	body := map[string]any{
-		"server": map[string]string{"name": newName},
-	}
-	var resp model.ServerDetail
-	if err := a.Client.Put(url, body, &resp); err != nil {
-		return nil, err
-	}
-	return &resp.Server, nil
-}
-
 // CreateServer creates a new server.
 func (a *ComputeAPI) CreateServer(req *model.ServerCreateRequest) (*model.Server, error) {
 	url := fmt.Sprintf("%s/servers", a.baseURL())

--- a/internal/api/compute_test.go
+++ b/internal/api/compute_test.go
@@ -127,44 +127,6 @@ func TestFindServer(t *testing.T) {
 	})
 }
 
-func TestRenameServer(t *testing.T) {
-	const serverID = "srv-999"
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut {
-			t.Errorf("expected PUT, got %s", r.Method)
-		}
-		if !strings.HasSuffix(r.URL.Path, "/v2.1/servers/"+serverID) {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		var body map[string]any
-		json.NewDecoder(r.Body).Decode(&body)
-		serverMap, ok := body["server"].(map[string]any)
-		if !ok {
-			t.Errorf("expected 'server' key in body")
-		} else if serverMap["name"] != "new-name" {
-			t.Errorf("expected name 'new-name', got %v", serverMap["name"])
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"server": map[string]any{
-				"id":   serverID,
-				"name": "new-name",
-			},
-		})
-	}))
-	defer ts.Close()
-	t.Setenv("CONOHA_ENDPOINT", ts.URL)
-
-	api := NewComputeAPI(newTestClient(ts))
-	server, err := api.RenameServer(serverID, "new-name")
-	if err != nil {
-		t.Fatalf("RenameServer() error: %v", err)
-	}
-	if server.Name != "new-name" {
-		t.Errorf("expected name 'new-name', got %q", server.Name)
-	}
-}
-
 func TestCreateServer(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {


### PR DESCRIPTION
## Summary
- Remove `RenameServer()` from `internal/api/compute.go` and its test
- This function used `PUT /servers/{id}` which returns 405 on ConoHa VPS3
- The `server rename` command already correctly uses `UpdateServerMetadata()` (POST `/servers/{id}/metadata`)

## Test plan
- [x] `go test ./...` all pass
- [x] `conoha server rename` confirmed working via POST metadata (PR #31 comment)