### PR TITLE
Fix server create UX: pre-flight validation, filter flavors, skip volume type

### DIFF
--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -18,13 +19,8 @@ const (
 	userDataMaxSize = 16 * 1024 // 16 KiB
 )
 
-// volumeTypeChoices maps user-friendly names to API volume type values.
-var volumeTypeChoices = []prompt.SelectItem{
-	{Label: "boot-vps-default (c3j1-ds02-boot)", Value: "c3j1-ds02-boot"},
-	{Label: "boot-vps-gpu (c3j1-ds03-boot)", Value: "c3j1-ds03-boot"},
-	{Label: "boot-game-default (c3j1-ds01-boot)", Value: "c3j1-ds01-boot"},
-	{Label: "boot-game-gpu (c3j1-ds03-boot)", Value: "c3j1-ds03-boot"},
-}
+// defaultBootVolumeType is the only valid volume type for standard VPS server creation.
+const defaultBootVolumeType = "c3j1-ds02-boot"
 
 // bootVolumeSizes returns available boot volume size choices for the given flavor.
 // The 512MB plan (RAM < 1024) only supports 30GB boot volumes.
@@ -96,6 +92,19 @@ var createCmd = &cobra.Command{
 			imageID, err = selectImage(imageAPI)
 			if err != nil {
 				return err
+			}
+		}
+
+		// Pre-flight: validate image memory requirements (#32)
+		{
+			imageAPI := api.NewImageAPI(client)
+			img, err := imageAPI.GetImage(imageID)
+			if err != nil {
+				return fmt.Errorf("fetching image details: %w", err)
+			}
+			if img.MinRAM > 0 && flavor.RAM < img.MinRAM {
+				return fmt.Errorf("selected flavor %q has %s RAM, but image %q requires at least %s. Please choose a larger flavor",
+					flavor.Name, formatMB(flavor.RAM), img.Name, formatMB(img.MinRAM))
 			}
 		}
 
@@ -292,25 +301,41 @@ func resolveUserData(cmd *cobra.Command) (string, error) {
 	return base64.StdEncoding.EncodeToString(content), nil
 }
 
+// isUsableFlavor returns true if the flavor can be used via the public API.
+// Only Linux (g2l) hourly (-t-) flavors are supported.
+func isUsableFlavor(name string) bool {
+	return strings.HasPrefix(name, "g2l-t-")
+}
+
 func selectFlavor(compute *api.ComputeAPI) (*model.Flavor, error) {
 	flavors, err := compute.ListFlavors()
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(flavors, func(i, j int) bool {
-		if flavors[i].VCPUs != flavors[j].VCPUs {
-			return flavors[i].VCPUs < flavors[j].VCPUs
+	// Filter to only usable flavors (#34)
+	var usable []model.Flavor
+	for _, f := range flavors {
+		if isUsableFlavor(f.Name) {
+			usable = append(usable, f)
 		}
-		return flavors[i].RAM < flavors[j].RAM
+	}
+	if len(usable) == 0 {
+		return nil, fmt.Errorf("no usable flavors found (only Linux hourly flavors are supported via API)")
+	}
+	sort.Slice(usable, func(i, j int) bool {
+		if usable[i].VCPUs != usable[j].VCPUs {
+			return usable[i].VCPUs < usable[j].VCPUs
+		}
+		return usable[i].RAM < usable[j].RAM
 	})
-	items := make([]prompt.SelectItem, len(flavors))
-	flavorMap := make(map[string]*model.Flavor, len(flavors))
-	for i, f := range flavors {
+	items := make([]prompt.SelectItem, len(usable))
+	flavorMap := make(map[string]*model.Flavor, len(usable))
+	for i, f := range usable {
 		items[i] = prompt.SelectItem{
 			Label: fmt.Sprintf("%s (%d vCPU, %s RAM)", f.Name, f.VCPUs, formatMB(f.RAM)),
 			Value: f.ID,
 		}
-		flavorMap[f.ID] = &flavors[i]
+		flavorMap[f.ID] = &usable[i]
 	}
 	id, err := prompt.Select("Select flavor", items)
 	if err != nil {
@@ -438,10 +463,7 @@ func createBootVolume(volumeAPI *api.VolumeAPI, flavor *model.Flavor, imageID st
 		return "", false, fmt.Errorf("invalid volume size: %w", err)
 	}
 
-	volType, err := prompt.Select("Volume type", volumeTypeChoices)
-	if err != nil {
-		return "", false, err
-	}
+	volType := defaultBootVolumeType
 
 	fmt.Fprintf(os.Stderr, "Creating boot volume %q (%dGB, %s)...\n", volName, sizeGB, volType)
 	req := &model.VolumeCreateRequest{}

--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -80,6 +80,9 @@ var createCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("flavor %q not found: %w", flavorID, err)
 			}
+			if !isUsableFlavor(flavor.Name) {
+				fmt.Fprintf(os.Stderr, "Warning: flavor %q may not be supported via public API\n", flavor.Name)
+			}
 		} else {
 			flavor, err = selectFlavor(compute)
 			if err != nil {
@@ -95,17 +98,17 @@ var createCmd = &cobra.Command{
 			}
 		}
 
+		// Fetch image details (used for pre-flight validation and summary display)
+		imageAPI := api.NewImageAPI(client)
+		img, err := imageAPI.GetImage(imageID)
+		if err != nil {
+			return fmt.Errorf("fetching image details: %w", err)
+		}
+
 		// Pre-flight: validate image memory requirements (#32)
-		{
-			imageAPI := api.NewImageAPI(client)
-			img, err := imageAPI.GetImage(imageID)
-			if err != nil {
-				return fmt.Errorf("fetching image details: %w", err)
-			}
-			if img.MinRAM > 0 && flavor.RAM < img.MinRAM {
-				return fmt.Errorf("selected flavor %q has %s RAM, but image %q requires at least %s. Please choose a larger flavor",
-					flavor.Name, formatMB(flavor.RAM), img.Name, formatMB(img.MinRAM))
-			}
+		if img.MinRAM > 0 && flavor.RAM < img.MinRAM {
+			return fmt.Errorf("selected flavor %q has %s RAM, but image %q requires at least %s. Please choose a larger flavor",
+				flavor.Name, formatMB(flavor.RAM), img.Name, formatMB(img.MinRAM))
 		}
 
 		if keyName == "" {
@@ -168,12 +171,8 @@ var createCmd = &cobra.Command{
 			req.Server.ImageRef = imageID
 		}
 
-		// Resolve names for summary
-		imageAPI := api.NewImageAPI(client)
-		imageName := imageID
-		if img, err := imageAPI.GetImage(imageID); err == nil {
-			imageName = img.Name
-		}
+		// Use image name from earlier fetch
+		imageName := img.Name
 
 		// Print summary
 		fmt.Fprintln(os.Stderr, "=== Server Create Summary ===")

--- a/cmd/server/create_test.go
+++ b/cmd/server/create_test.go
@@ -150,6 +150,28 @@ func TestBootVolumeSizes(t *testing.T) {
 	}
 }
 
+func TestIsUsableFlavor(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"g2l-t-c1m512", true},
+		{"g2l-t-c2m1", true},
+		{"g2l-t-c4m4", true},
+		{"g2l-p-c1m512", false}, // prepaid
+		{"g2w-t-c2m1", false},   // Windows
+		{"g2d-t-c2m1", false},   // dedicated
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUsableFlavor(tt.name); got != tt.want {
+				t.Errorf("isUsableFlavor(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveUserData_MutualExclusion(t *testing.T) {
 	cmd := newTestCmd(map[string]string{
 		"user-data-raw": "echo hi",

--- a/cmd/server/list.go
+++ b/cmd/server/list.go
@@ -88,6 +88,10 @@ var showCmd = &cobra.Command{
 			flavorDisplay = fmt.Sprintf("%s (%d vCPU, %s RAM)", f.Name, f.VCPUs, formatMB(f.RAM))
 		}
 
+		// Fetch volume attachments once (used for image resolution and display)
+		volumeAPI := api.NewVolumeAPI(client)
+		attachments, _ := compute.ListVolumeAttachments(server.ID)
+
 		// Resolve image name
 		imageDisplay := "(not set — booted from volume)"
 		if server.ImageID != "" {
@@ -99,17 +103,18 @@ var showCmd = &cobra.Command{
 			}
 		} else {
 			// Try to resolve from boot volume metadata (#35)
-			volumeAPI := api.NewVolumeAPI(client)
-			if attachments, err := compute.ListVolumeAttachments(server.ID); err == nil {
-				for _, a := range attachments {
-					if a.Device == "/dev/vda" {
-						if vol, err := volumeAPI.GetVolume(a.VolumeID); err == nil {
-							if imgName := vol.ImageMetadata["image_name"]; imgName != "" {
-								imageDisplay = fmt.Sprintf("%s (booted from volume %s)", imgName, a.VolumeID[:8])
+			for _, a := range attachments {
+				if a.Device == "/dev/vda" {
+					if vol, err := volumeAPI.GetVolume(a.VolumeID); err == nil {
+						if imgName := vol.ImageMetadata["image_name"]; imgName != "" {
+							volID := a.VolumeID
+							if len(volID) > 8 {
+								volID = volID[:8]
 							}
+							imageDisplay = fmt.Sprintf("%s (booted from volume %s)", imgName, volID)
 						}
-						break
 					}
+					break
 				}
 			}
 		}
@@ -118,8 +123,7 @@ var showCmd = &cobra.Command{
 		printServerDetail(server, flavorDisplay, imageDisplay)
 
 		// Volume attachments (non-fatal)
-		if attachments, err := compute.ListVolumeAttachments(server.ID); err == nil && len(attachments) > 0 {
-			volumeAPI := api.NewVolumeAPI(client)
+		if len(attachments) > 0 {
 			fmt.Println("Volumes:")
 			for _, a := range attachments {
 				size := ""

--- a/cmd/server/list.go
+++ b/cmd/server/list.go
@@ -97,6 +97,21 @@ var showCmd = &cobra.Command{
 			} else {
 				imageDisplay = fmt.Sprintf("(deleted or unavailable) %s", server.ImageID)
 			}
+		} else {
+			// Try to resolve from boot volume metadata (#35)
+			volumeAPI := api.NewVolumeAPI(client)
+			if attachments, err := compute.ListVolumeAttachments(server.ID); err == nil {
+				for _, a := range attachments {
+					if a.Device == "/dev/vda" {
+						if vol, err := volumeAPI.GetVolume(a.VolumeID); err == nil {
+							if imgName := vol.ImageMetadata["image_name"]; imgName != "" {
+								imageDisplay = fmt.Sprintf("%s (booted from volume %s)", imgName, a.VolumeID[:8])
+							}
+						}
+						break
+					}
+				}
+			}
 		}
 
 		// Human-readable key-value output

--- a/internal/model/volume.go
+++ b/internal/model/volume.go
@@ -1,14 +1,15 @@
 package model
 
 type Volume struct {
-	ID          string   `json:"id" yaml:"id"`
-	Name        string   `json:"name" yaml:"name"`
-	Status      string   `json:"status" yaml:"status"`
-	Size        int      `json:"size" yaml:"size"`
-	VolumeType  string   `json:"volume_type" yaml:"volume_type"`
-	Description string   `json:"description" yaml:"description"`
-	CreatedAt   FlexTime `json:"created_at" yaml:"created_at"`
-	Bootable    string   `json:"bootable" yaml:"bootable"`
+	ID            string            `json:"id" yaml:"id"`
+	Name          string            `json:"name" yaml:"name"`
+	Status        string            `json:"status" yaml:"status"`
+	Size          int               `json:"size" yaml:"size"`
+	VolumeType    string            `json:"volume_type" yaml:"volume_type"`
+	Description   string            `json:"description" yaml:"description"`
+	CreatedAt     FlexTime          `json:"created_at" yaml:"created_at"`
+	Bootable      string            `json:"bootable" yaml:"bootable"`
+	ImageMetadata map[string]string `json:"volume_image_metadata,omitempty" yaml:"volume_image_metadata,omitempty"`
 }
 
 type VolumesResponse struct {


### PR DESCRIPTION
## Summary
- **#32** Pre-flight validation: check image `min_ram` against flavor RAM before creating boot volume
- **#33** Auto-select `boot-vps-default` volume type (skip prompt — only valid option for standard VPS)
- **#34** Filter flavor list to `g2l-t-*` only (Linux hourly billing, API-usable). Removes prepaid, Windows, Database flavors
- **#35** Show source image name for volume-booted servers in `server show` via `volume_image_metadata`

## Test plan
- [x] `go test ./...` all pass
- [x] `golangci-lint run ./...` clean
- [ ] Manual: `conoha server create` with 512MB flavor + image requiring 1024MB → clear error before volume creation
- [ ] Manual: `conoha server create` → no volume type prompt, auto-selects boot-vps-default
- [ ] Manual: `conoha server create` → only `g2l-t-*` flavors shown
- [ ] Manual: `conoha server show <volume-booted-server>` → shows source image name

Closes #32, #33, #34, #35