### PR TITLE
Fix security group output: render single structs as table

### DIFF
--- a/docs/superpowers/plans/2026-03-31-app-samples-impl.md
+++ b/docs/superpowers/plans/2026-03-31-app-samples-impl.md
@@ -1,0 +1,1341 @@
+# conoha-cli-app-samples Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the `conoha-cli-app-samples` repository with 5 sample apps (hello-world, nextjs, fastapi-ai-chatbot, rails-postgresql, wordpress-mysql) that demonstrate `conoha app deploy`.
+
+**Architecture:** Flat directory structure — each sample is a self-contained directory with compose.yml, Dockerfile (where applicable), source code, and Japanese README. All code comments and app output are in English.
+
+**Tech Stack:** Docker, Docker Compose, nginx, Node.js/Next.js, Python/FastAPI, Ruby/Rails, WordPress, MySQL, PostgreSQL, Ollama
+
+---
+
+### Task 1: Repository scaffolding
+
+**Files:**
+- Create: `/home/tkim/dev/crowdy/conoha-cli-app-samples/README.md`
+- Create: `/home/tkim/dev/crowdy/conoha-cli-app-samples/LICENSE`
+- Create: `/home/tkim/dev/crowdy/conoha-cli-app-samples/.gitignore`
+
+- [ ] **Step 1: Create the directory and initialize git**
+
+```bash
+mkdir -p /home/tkim/dev/crowdy/conoha-cli-app-samples
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git init
+```
+
+- [ ] **Step 2: Create LICENSE (MIT)**
+
+Create `/home/tkim/dev/crowdy/conoha-cli-app-samples/LICENSE`:
+
+```
+MIT License
+
+Copyright (c) 2026 crowdy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+- [ ] **Step 3: Create .gitignore**
+
+Create `/home/tkim/dev/crowdy/conoha-cli-app-samples/.gitignore`:
+
+```
+.env
+.env.server
+.DS_Store
+node_modules/
+tmp/
+log/
+*.log
+```
+
+- [ ] **Step 4: Create root README.md**
+
+Create `/home/tkim/dev/crowdy/conoha-cli-app-samples/README.md`:
+
+```markdown
+# conoha-cli-app-samples
+
+[conoha-cli](https://github.com/crowdy/conoha-cli) の `app deploy` コマンドで使えるサンプルアプリ集です。
+
+各サンプルディレクトリにはすぐにデプロイできる `compose.yml`、`Dockerfile`、ソースコードが含まれています。
+
+## 前提条件
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペアが設定済み（`conoha keypair create` で作成可能）
+
+## 使い方
+
+```bash
+# 1. このリポジトリをクローン
+git clone https://github.com/crowdy/conoha-cli-app-samples.git
+cd conoha-cli-app-samples
+
+# 2. サーバーを作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# 3. サンプルを選んでデプロイ
+cd hello-world
+conoha app init myserver --app-name hello-world
+conoha app deploy myserver --app-name hello-world
+
+# 4. 動作確認
+conoha app logs myserver --app-name hello-world
+```
+
+## サンプル一覧
+
+| サンプル | スタック | 説明 | 推奨フレーバー |
+|---------|---------|------|--------------|
+| [hello-world](hello-world/) | nginx + 静的HTML | 最もシンプルなサンプル | g2l-t-1 (1GB) |
+| [nextjs](nextjs/) | Next.js (standalone) | Next.js デフォルトページ | g2l-t-2 (2GB) |
+| [fastapi-ai-chatbot](fastapi-ai-chatbot/) | FastAPI + Ollama | AI チャットボット | g2l-t-4 (4GB) |
+| [rails-postgresql](rails-postgresql/) | Rails + PostgreSQL | Rails scaffold アプリ | g2l-t-2 (2GB) |
+| [wordpress-mysql](wordpress-mysql/) | WordPress + MySQL | WordPress ブログ | g2l-t-2 (2GB) |
+
+## 自分のアプリをデプロイするには
+
+`compose.yml`（または `docker-compose.yml`）があるディレクトリであれば、同じ手順でデプロイできます。
+
+```bash
+cd your-app
+conoha app init myserver --app-name your-app
+conoha app deploy myserver --app-name your-app
+```
+
+`Dockerfile` でビルドする場合は `compose.yml` の `build: .` を使ってください。
+
+## 関連リンク
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) — ConoHa VPS3 CLI ツール
+- [ドキュメント](https://conoha-cli.jp) — チュートリアル・コマンドリファレンス
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add LICENSE .gitignore README.md
+git commit -m "Initial repo scaffolding with README, LICENSE, gitignore"
+```
+
+---
+
+### Task 2: hello-world sample
+
+**Files:**
+- Create: `hello-world/README.md`
+- Create: `hello-world/Dockerfile`
+- Create: `hello-world/compose.yml`
+- Create: `hello-world/.dockerignore`
+- Create: `hello-world/index.html`
+
+- [ ] **Step 1: Create hello-world/Dockerfile**
+
+```dockerfile
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html
+```
+
+- [ ] **Step 2: Create hello-world/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"
+```
+
+- [ ] **Step 3: Create hello-world/.dockerignore**
+
+```
+README.md
+.git
+```
+
+- [ ] **Step 4: Create hello-world/index.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hello ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f5f5f5;
+    }
+    .container {
+      text-align: center;
+      padding: 2rem;
+    }
+    h1 { color: #333; font-size: 2.5rem; }
+    p { color: #666; font-size: 1.2rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Hello from ConoHa!</h1>
+    <p>Deployed with <code>conoha app deploy</code></p>
+  </div>
+</body>
+</html>
+```
+
+- [ ] **Step 5: Create hello-world/README.md**
+
+```markdown
+# hello-world
+
+nginx で静的HTMLを配信する最もシンプルなサンプルです。初めて `conoha app deploy` を試す方におすすめです。
+
+## 構成
+
+- nginx (Alpine)
+- ポート: 80
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-1 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name hello-world
+
+# デプロイ
+conoha app deploy myserver --app-name hello-world
+```
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>` にアクセスすると「Hello from ConoHa!」と表示されます。
+
+## カスタマイズ
+
+`index.html` を編集して再度 `conoha app deploy` するだけで更新できます。
+```
+
+- [ ] **Step 6: Verify locally**
+
+```bash
+cd hello-world
+docker compose up -d --build
+curl http://localhost
+docker compose down
+cd ..
+```
+
+Expected: HTML page with "Hello from ConoHa!" is returned.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hello-world/
+git commit -m "Add hello-world sample (nginx + static HTML)"
+```
+
+---
+
+### Task 3: nextjs sample
+
+**Files:**
+- Create: `nextjs/README.md`
+- Create: `nextjs/Dockerfile`
+- Create: `nextjs/compose.yml`
+- Create: `nextjs/.dockerignore`
+- Create: `nextjs/package.json`
+- Create: `nextjs/next.config.ts`
+- Create: `nextjs/tsconfig.json`
+- Create: `nextjs/app/layout.tsx`
+- Create: `nextjs/app/page.tsx`
+- Create: `nextjs/app/globals.css`
+- Create: `nextjs/public/` (empty, or favicon)
+
+- [ ] **Step 1: Create nextjs/package.json**
+
+```json
+{
+  "name": "conoha-nextjs-sample",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "15.3.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.7.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create nextjs/next.config.ts**
+
+```typescript
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  output: "standalone",
+};
+
+export default nextConfig;
+```
+
+- [ ] **Step 3: Create nextjs/tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+```
+
+- [ ] **Step 4: Create nextjs/app/globals.css**
+
+```css
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+}
+```
+
+- [ ] **Step 5: Create nextjs/app/layout.tsx**
+
+```tsx
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Next.js on ConoHa",
+  description: "Next.js app deployed with conoha app deploy",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+- [ ] **Step 6: Create nextjs/app/page.tsx**
+
+```tsx
+export default function Home() {
+  return (
+    <main
+      style={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: "100vh",
+      }}
+    >
+      <div style={{ textAlign: "center", padding: "2rem" }}>
+        <h1 style={{ fontSize: "2.5rem", marginBottom: "1rem" }}>
+          Next.js on ConoHa
+        </h1>
+        <p style={{ fontSize: "1.2rem", color: "#666" }}>
+          Deployed with <code>conoha app deploy</code>
+        </p>
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 7: Create nextjs/Dockerfile**
+
+```dockerfile
+# Stage 1: Install dependencies
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+
+# Stage 2: Build the application
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Stage 3: Production runner
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+CMD ["node", "server.js"]
+```
+
+- [ ] **Step 8: Create nextjs/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+```
+
+- [ ] **Step 9: Create nextjs/.dockerignore**
+
+```
+README.md
+.git
+node_modules
+.next
+```
+
+- [ ] **Step 10: Create nextjs/README.md**
+
+```markdown
+# nextjs
+
+Next.js アプリをスタンドアロンモードでデプロイするサンプルです。マルチステージビルドで軽量なイメージを生成します。
+
+## 構成
+
+- Node.js 22 + Next.js 15 (standalone output)
+- ポート: 3000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name nextjs
+
+# デプロイ
+conoha app deploy myserver --app-name nextjs
+```
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:3000` にアクセスすると「Next.js on ConoHa」と表示されます。
+
+## カスタマイズ
+
+- `app/page.tsx` を編集してページ内容を変更
+- `app/` 以下にファイルを追加して App Router でルーティング
+- `next.config.ts` で Next.js の設定を変更
+```
+
+- [ ] **Step 11: Verify locally**
+
+```bash
+cd nextjs
+docker compose up -d --build
+curl http://localhost:3000
+docker compose down
+cd ..
+```
+
+Expected: HTML page with "Next.js on ConoHa" text.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add nextjs/
+git commit -m "Add Next.js sample (standalone multi-stage build)"
+```
+
+---
+
+### Task 4: fastapi-ai-chatbot sample
+
+**Files:**
+- Create: `fastapi-ai-chatbot/README.md`
+- Create: `fastapi-ai-chatbot/Dockerfile`
+- Create: `fastapi-ai-chatbot/compose.yml`
+- Create: `fastapi-ai-chatbot/.dockerignore`
+- Create: `fastapi-ai-chatbot/requirements.txt`
+- Create: `fastapi-ai-chatbot/main.py`
+- Create: `fastapi-ai-chatbot/templates/index.html`
+
+- [ ] **Step 1: Create fastapi-ai-chatbot/requirements.txt**
+
+```
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
+httpx==0.28.1
+jinja2==3.1.6
+```
+
+- [ ] **Step 2: Create fastapi-ai-chatbot/main.py**
+
+```python
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+OLLAMA_URL = "http://ollama:11434"
+MODEL = "tinyllama"
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.post("/chat")
+async def chat(req: ChatRequest):
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{OLLAMA_URL}/api/generate",
+            json={"model": MODEL, "prompt": req.message, "stream": False},
+        )
+        response.raise_for_status()
+        data = response.json()
+    return {"response": data.get("response", "")}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+```
+
+- [ ] **Step 3: Create fastapi-ai-chatbot/templates/index.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Chatbot</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 600px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+    }
+    h1 { color: #333; }
+    #messages {
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 1rem;
+      min-height: 300px;
+      max-height: 500px;
+      overflow-y: auto;
+      background: #fff;
+      margin-bottom: 1rem;
+    }
+    .msg { margin-bottom: 0.5rem; padding: 0.5rem; border-radius: 4px; }
+    .user { background: #e3f2fd; }
+    .bot { background: #f5f5f5; }
+    form { display: flex; gap: 0.5rem; }
+    input {
+      flex: 1;
+      padding: 0.5rem;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      font-size: 1rem;
+    }
+    button {
+      padding: 0.5rem 1.5rem;
+      background: #1976d2;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 1rem;
+    }
+    button:disabled { opacity: 0.5; }
+  </style>
+</head>
+<body>
+  <h1>AI Chatbot</h1>
+  <p>Powered by Ollama (tinyllama)</p>
+  <div id="messages"></div>
+  <form id="chatForm">
+    <input type="text" id="input" placeholder="Type a message..." autocomplete="off" required>
+    <button type="submit" id="btn">Send</button>
+  </form>
+  <script>
+    const form = document.getElementById("chatForm");
+    const input = document.getElementById("input");
+    const messages = document.getElementById("messages");
+    const btn = document.getElementById("btn");
+
+    function addMessage(text, cls) {
+      const div = document.createElement("div");
+      div.className = "msg " + cls;
+      div.textContent = text;
+      messages.appendChild(div);
+      messages.scrollTop = messages.scrollHeight;
+    }
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const msg = input.value.trim();
+      if (!msg) return;
+      addMessage(msg, "user");
+      input.value = "";
+      btn.disabled = true;
+      try {
+        const res = await fetch("/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message: msg }),
+        });
+        const data = await res.json();
+        addMessage(data.response, "bot");
+      } catch {
+        addMessage("Error: could not reach the server.", "bot");
+      }
+      btn.disabled = false;
+      input.focus();
+    });
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 4: Create fastapi-ai-chatbot/Dockerfile**
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+- [ ] **Step 5: Create fastapi-ai-chatbot/compose.yml**
+
+```yaml
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - ollama
+
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama_data:/root/.ollama
+    # Pull the model on first start
+    entrypoint: ["/bin/sh", "-c", "ollama serve & sleep 5 && ollama pull tinyllama && wait"]
+
+volumes:
+  ollama_data:
+```
+
+- [ ] **Step 6: Create fastapi-ai-chatbot/.dockerignore**
+
+```
+README.md
+.git
+__pycache__
+*.pyc
+.venv
+```
+
+- [ ] **Step 7: Create fastapi-ai-chatbot/README.md**
+
+```markdown
+# fastapi-ai-chatbot
+
+FastAPI と Ollama を使ったシンプルな AI チャットボットです。ブラウザから質問すると LLM が回答します。
+
+## 構成
+
+- Python 3.12 + FastAPI（アプリサーバー）
+- Ollama + tinyllama モデル（LLM）
+- ポート: 8000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（4GB以上推奨）
+conoha server create --name myserver --flavor g2l-t-4 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name chatbot
+
+# デプロイ
+conoha app deploy myserver --app-name chatbot
+```
+
+初回起動時に tinyllama モデルのダウンロード（約600MB）が自動で行われます。完了まで数分かかります。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:8000` にアクセスするとチャット画面が表示されます。
+
+## カスタマイズ
+
+- `compose.yml` の `ollama pull tinyllama` を別のモデル（例: `gemma3:1b`）に変更
+- `main.py` の `MODEL` 変数を合わせて変更
+- より大きなモデルを使う場合はメモリの多いフレーバーを選択
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add fastapi-ai-chatbot/
+git commit -m "Add FastAPI + Ollama AI chatbot sample"
+```
+
+---
+
+### Task 5: rails-postgresql sample
+
+**Files:**
+- Create: `rails-postgresql/README.md`
+- Create: `rails-postgresql/Dockerfile`
+- Create: `rails-postgresql/compose.yml`
+- Create: `rails-postgresql/.dockerignore`
+- Create: `rails-postgresql/Gemfile`
+- Create: `rails-postgresql/Gemfile.lock` (empty)
+- Create: `rails-postgresql/Rakefile`
+- Create: `rails-postgresql/config.ru`
+- Create: `rails-postgresql/bin/rails`
+- Create: `rails-postgresql/bin/docker-entrypoint`
+- Create: `rails-postgresql/config/application.rb`
+- Create: `rails-postgresql/config/environment.rb`
+- Create: `rails-postgresql/config/database.yml`
+- Create: `rails-postgresql/config/routes.rb`
+- Create: `rails-postgresql/config/environments/production.rb`
+- Create: `rails-postgresql/app/controllers/application_controller.rb`
+- Create: `rails-postgresql/app/controllers/posts_controller.rb`
+- Create: `rails-postgresql/app/models/application_record.rb`
+- Create: `rails-postgresql/app/models/post.rb`
+- Create: `rails-postgresql/app/views/layouts/application.html.erb`
+- Create: `rails-postgresql/app/views/posts/index.html.erb`
+- Create: `rails-postgresql/app/views/posts/_form.html.erb`
+- Create: `rails-postgresql/db/migrate/20260101000000_create_posts.rb`
+- Create: `rails-postgresql/db/schema.rb`
+
+- [ ] **Step 1: Create rails-postgresql/Gemfile**
+
+```ruby
+source "https://rubygems.org"
+
+gem "rails", "~> 8.0"
+gem "pg", "~> 1.5"
+gem "puma", "~> 6.5"
+```
+
+- [ ] **Step 2: Create rails-postgresql/Gemfile.lock**
+
+Create an empty file. The Docker build will run `bundle install` which generates the real lock file.
+
+```
+(empty file)
+```
+
+- [ ] **Step 3: Create rails-postgresql/Rakefile**
+
+```ruby
+require_relative "config/application"
+Rails.application.load_tasks
+```
+
+- [ ] **Step 4: Create rails-postgresql/config.ru**
+
+```ruby
+require_relative "config/environment"
+run Rails.application
+```
+
+- [ ] **Step 5: Create rails-postgresql/bin/rails**
+
+```ruby
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/application"
+require "rails/command"
+Rails::Command.invoke("application", ARGV)
+```
+
+Make executable: `chmod +x rails-postgresql/bin/rails`
+
+- [ ] **Step 6: Create rails-postgresql/bin/docker-entrypoint**
+
+```bash
+#!/bin/bash
+set -e
+
+# Run database migrations automatically
+rails db:prepare
+
+exec "$@"
+```
+
+Make executable: `chmod +x rails-postgresql/bin/docker-entrypoint`
+
+- [ ] **Step 7: Create rails-postgresql/config/application.rb**
+
+```ruby
+require_relative "boot" rescue nil
+require "rails"
+require "active_model/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
+
+module ConohaRailsSample
+  class Application < Rails::Application
+    config.load_defaults 8.0
+    config.eager_load = true
+    config.secret_key_base = ENV.fetch("SECRET_KEY_BASE") { SecureRandom.hex(64) }
+  end
+end
+```
+
+- [ ] **Step 8: Create rails-postgresql/config/environment.rb**
+
+```ruby
+require_relative "application"
+Rails.application.initialize!
+```
+
+- [ ] **Step 9: Create rails-postgresql/config/database.yml**
+
+```yaml
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  host: <%= ENV.fetch("DB_HOST", "db") %>
+  username: <%= ENV.fetch("DB_USER", "postgres") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "postgres") %>
+
+production:
+  <<: *default
+  database: <%= ENV.fetch("DB_NAME", "app_production") %>
+
+development:
+  <<: *default
+  database: app_development
+```
+
+- [ ] **Step 10: Create rails-postgresql/config/routes.rb**
+
+```ruby
+Rails.application.routes.draw do
+  root "posts#index"
+  resources :posts, only: [:index, :create, :destroy]
+end
+```
+
+- [ ] **Step 11: Create rails-postgresql/config/environments/production.rb**
+
+```ruby
+require "active_support/core_ext/integer/time"
+
+Rails.application.configure do
+  config.enable_reloading = false
+  config.eager_load = true
+  config.consider_all_requests_local = false
+  config.public_file_server.enabled = true
+  config.log_level = :info
+  config.log_tags = [:request_id]
+  config.action_controller.perform_caching = true
+end
+```
+
+- [ ] **Step 12: Create rails-postgresql/app/controllers/application_controller.rb**
+
+```ruby
+class ApplicationController < ActionController::Base
+  allow_browser versions: :modern
+end
+```
+
+- [ ] **Step 13: Create rails-postgresql/app/controllers/posts_controller.rb**
+
+```ruby
+class PostsController < ApplicationController
+  def index
+    @posts = Post.order(created_at: :desc)
+    @post = Post.new
+  end
+
+  def create
+    Post.create!(post_params)
+    redirect_to root_path
+  end
+
+  def destroy
+    Post.find(params[:id]).destroy
+    redirect_to root_path
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :body)
+  end
+end
+```
+
+- [ ] **Step 14: Create rails-postgresql/app/models/application_record.rb**
+
+```ruby
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+```
+
+- [ ] **Step 15: Create rails-postgresql/app/models/post.rb**
+
+```ruby
+class Post < ApplicationRecord
+  validates :title, presence: true
+end
+```
+
+- [ ] **Step 16: Create rails-postgresql/app/views/layouts/application.html.erb**
+
+```erb
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rails on ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 700px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 { margin-bottom: 1rem; }
+    .post { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; }
+    .post h2 { margin: 0 0 0.5rem; font-size: 1.2rem; }
+    .post p { margin: 0; color: #666; }
+    form { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; }
+    input, textarea { width: 100%; padding: 0.5rem; margin-bottom: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; box-sizing: border-box; }
+    textarea { height: 80px; resize: vertical; }
+    button { padding: 0.5rem 1.5rem; background: #1976d2; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .delete { background: #d32f2f; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+  </style>
+</head>
+<body>
+  <%= yield %>
+</body>
+</html>
+```
+
+- [ ] **Step 17: Create rails-postgresql/app/views/posts/index.html.erb**
+
+```erb
+<h1>Rails on ConoHa</h1>
+
+<%= render "form", post: @post %>
+
+<% @posts.each do |post| %>
+  <div class="post">
+    <h2><%= post.title %></h2>
+    <p><%= post.body %></p>
+    <%= button_to "Delete", post_path(post), method: :delete, class: "delete" %>
+  </div>
+<% end %>
+```
+
+- [ ] **Step 18: Create rails-postgresql/app/views/posts/_form.html.erb**
+
+```erb
+<%= form_with model: post do |f| %>
+  <%= f.text_field :title, placeholder: "Title" %>
+  <%= f.text_area :body, placeholder: "Body (optional)" %>
+  <%= f.submit "Create Post" %>
+<% end %>
+```
+
+- [ ] **Step 19: Create rails-postgresql/db/migrate/20260101000000_create_posts.rb**
+
+```ruby
+class CreatePosts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :posts do |t|
+      t.string :title, null: false
+      t.text :body
+      t.timestamps
+    end
+  end
+end
+```
+
+- [ ] **Step 20: Create rails-postgresql/db/schema.rb**
+
+```ruby
+ActiveRecord::Schema[8.0].define(version: 2026_01_01_000000) do
+  create_table "posts", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end
+```
+
+- [ ] **Step 21: Create rails-postgresql/Dockerfile**
+
+```dockerfile
+FROM ruby:3.3-slim AS builder
+WORKDIR /app
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs 4
+
+FROM ruby:3.3-slim
+WORKDIR /app
+RUN apt-get update -qq && apt-get install -y libpq5 && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+COPY . .
+RUN chmod +x bin/docker-entrypoint
+ENV RAILS_ENV=production
+EXPOSE 3000
+ENTRYPOINT ["bin/docker-entrypoint"]
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb", "-b", "tcp://0.0.0.0:3000"]
+```
+
+Note: No puma.rb config needed — command-line flags are sufficient. Replace CMD:
+
+```dockerfile
+CMD ["bundle", "exec", "puma", "-b", "tcp://0.0.0.0:3000"]
+```
+
+- [ ] **Step 22: Create rails-postgresql/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - RAILS_ENV=production
+      - DB_HOST=db
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=app_production
+      - SECRET_KEY_BASE=placeholder_change_me_in_production
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  db_data:
+```
+
+- [ ] **Step 23: Create rails-postgresql/.dockerignore**
+
+```
+README.md
+.git
+tmp
+log
+node_modules
+```
+
+- [ ] **Step 24: Create rails-postgresql/README.md**
+
+```markdown
+# rails-postgresql
+
+Rails と PostgreSQL を使ったシンプルな投稿アプリです。scaffold 相当の CRUD 機能を持ちます。
+
+## 構成
+
+- Ruby 3.3 + Rails 8.0
+- PostgreSQL 17
+- ポート: 3000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name rails-app
+
+# デプロイ
+conoha app deploy myserver --app-name rails-app
+```
+
+DB マイグレーションはコンテナ起動時に自動実行されます。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:3000` にアクセスすると投稿一覧ページが表示されます。
+
+## カスタマイズ
+
+- `app/controllers/` と `app/views/` を編集して機能を追加
+- `db/migrate/` に新しいマイグレーションを追加してスキーマを変更
+- 本番環境では `compose.yml` の `SECRET_KEY_BASE` と `DB_PASSWORD` を `.env.server` で管理
+```
+
+- [ ] **Step 25: Commit**
+
+```bash
+git add rails-postgresql/
+git commit -m "Add Rails + PostgreSQL sample (CRUD posts app)"
+```
+
+---
+
+### Task 6: wordpress-mysql sample
+
+**Files:**
+- Create: `wordpress-mysql/README.md`
+- Create: `wordpress-mysql/compose.yml`
+- Create: `wordpress-mysql/.dockerignore`
+
+- [ ] **Step 1: Create wordpress-mysql/compose.yml**
+
+```yaml
+services:
+  wordpress:
+    image: wordpress:latest
+    ports:
+      - "80:80"
+    environment:
+      - WORDPRESS_DB_HOST=db
+      - WORDPRESS_DB_USER=wordpress
+      - WORDPRESS_DB_PASSWORD=${MYSQL_PASSWORD:-wordpress}
+      - WORDPRESS_DB_NAME=wordpress
+    volumes:
+      - wp_data:/var/www/html
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: mysql:8.0
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-rootpassword}
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-wordpress}
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  wp_data:
+  db_data:
+```
+
+- [ ] **Step 2: Create wordpress-mysql/.dockerignore**
+
+```
+README.md
+.git
+```
+
+- [ ] **Step 3: Create wordpress-mysql/README.md**
+
+```markdown
+# wordpress-mysql
+
+WordPress と MySQL の公式 Docker イメージを使ったサンプルです。Dockerfile 不要で、`compose.yml` だけでデプロイできます。
+
+## 構成
+
+- WordPress (公式イメージ)
+- MySQL 8.0 (公式イメージ)
+- ポート: 80
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name wordpress
+
+# 環境変数を設定（パスワードを変更してください）
+conoha app env set myserver --app-name wordpress \
+  MYSQL_ROOT_PASSWORD=your_root_password \
+  MYSQL_PASSWORD=your_wp_password
+
+# デプロイ
+conoha app deploy myserver --app-name wordpress
+```
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>` にアクセスすると WordPress のセットアップ画面が表示されます。
+
+## カスタマイズ
+
+- テーマやプラグインは WordPress 管理画面からインストール
+- 本番環境では必ず `conoha app env set` でパスワードを変更してください
+- HTTPS が必要な場合はリバースプロキシ（nginx）を追加
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add wordpress-mysql/
+git commit -m "Add WordPress + MySQL sample (official images only)"
+```
+
+---
+
+### Task 7: Create GitHub repository and push
+
+- [ ] **Step 1: Create the remote repository**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+gh repo create crowdy/conoha-cli-app-samples --public --source=. --description "Sample apps for conoha-cli app deploy"
+```
+
+- [ ] **Step 2: Push all commits**
+
+```bash
+git push -u origin main
+```
+
+- [ ] **Step 3: Verify on GitHub**
+
+```bash
+gh repo view crowdy/conoha-cli-app-samples --web
+```

--- a/docs/superpowers/plans/2026-03-31-app-samples-tier1-impl.md
+++ b/docs/superpowers/plans/2026-03-31-app-samples-tier1-impl.md
@@ -1,0 +1,1533 @@
+# App Samples Tier 1 Additions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 4 Tier 1 samples (spring-boot-postgresql, express-mongodb, laravel-mysql, django-postgresql) to the existing `conoha-cli-app-samples` repo and update the root README.
+
+**Architecture:** Each sample is a flat top-level directory following established patterns — compose.yml + Dockerfile + minimal source code + Japanese README. All code comments and app output in English. Each sample is independently deployable via `conoha app deploy`.
+
+**Tech Stack:** Spring Boot 3 / Java 21, Express.js / MongoDB, Laravel 11 / PHP 8.3 / MySQL, Django 5 / PostgreSQL
+
+**Repo:** `/home/tkim/dev/crowdy/conoha-cli-app-samples`
+
+---
+
+### Task 1: spring-boot-postgresql
+
+**Files:**
+- Create: `spring-boot-postgresql/README.md`
+- Create: `spring-boot-postgresql/Dockerfile`
+- Create: `spring-boot-postgresql/compose.yml`
+- Create: `spring-boot-postgresql/.dockerignore`
+- Create: `spring-boot-postgresql/pom.xml`
+- Create: `spring-boot-postgresql/src/main/java/com/example/app/Application.java`
+- Create: `spring-boot-postgresql/src/main/java/com/example/app/Post.java`
+- Create: `spring-boot-postgresql/src/main/java/com/example/app/PostRepository.java`
+- Create: `spring-boot-postgresql/src/main/java/com/example/app/PostController.java`
+- Create: `spring-boot-postgresql/src/main/resources/application.properties`
+- Create: `spring-boot-postgresql/src/main/resources/templates/index.html`
+
+- [ ] **Step 1: Create spring-boot-postgresql/pom.xml**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.4</version>
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>conoha-spring-sample</artifactId>
+    <version>1.0.0</version>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+- [ ] **Step 2: Create spring-boot-postgresql/src/main/resources/application.properties**
+
+```properties
+spring.datasource.url=jdbc:postgresql://${DB_HOST:db}:5432/${DB_NAME:app_production}
+spring.datasource.username=${DB_USER:postgres}
+spring.datasource.password=${DB_PASSWORD:postgres}
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=false
+server.port=8080
+```
+
+- [ ] **Step 3: Create spring-boot-postgresql/src/main/java/com/example/app/Application.java**
+
+```java
+package com.example.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}
+```
+
+- [ ] **Step 4: Create spring-boot-postgresql/src/main/java/com/example/app/Post.java**
+
+```java
+package com.example.app;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "posts")
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String body;
+
+    public Post() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public String getBody() { return body; }
+    public void setBody(String body) { this.body = body; }
+}
+```
+
+- [ ] **Step 5: Create spring-boot-postgresql/src/main/java/com/example/app/PostRepository.java**
+
+```java
+package com.example.app;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}
+```
+
+- [ ] **Step 6: Create spring-boot-postgresql/src/main/java/com/example/app/PostController.java**
+
+```java
+package com.example.app;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class PostController {
+    private final PostRepository repository;
+
+    public PostController(PostRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping("/")
+    public String index(Model model) {
+        model.addAttribute("posts", repository.findAll());
+        model.addAttribute("post", new Post());
+        return "index";
+    }
+
+    @PostMapping("/posts")
+    public String create(Post post) {
+        repository.save(post);
+        return "redirect:/";
+    }
+
+    @PostMapping("/posts/{id}/delete")
+    public String delete(@PathVariable Long id) {
+        repository.deleteById(id);
+        return "redirect:/";
+    }
+}
+```
+
+- [ ] **Step 7: Create spring-boot-postgresql/src/main/resources/templates/index.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Spring Boot on ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 700px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 { margin-bottom: 1rem; }
+    .post { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; }
+    .post h2 { margin: 0 0 0.5rem; font-size: 1.2rem; }
+    .post p { margin: 0; color: #666; }
+    form.inline { display: inline; }
+    .form-box { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; }
+    input, textarea { width: 100%; padding: 0.5rem; margin-bottom: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; box-sizing: border-box; }
+    textarea { height: 80px; resize: vertical; }
+    button { padding: 0.5rem 1.5rem; background: #1976d2; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .delete { background: #d32f2f; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+  </style>
+</head>
+<body>
+  <h1>Spring Boot on ConoHa</h1>
+  <div class="form-box">
+    <form th:action="@{/posts}" method="post" th:object="${post}">
+      <input type="text" th:field="*{title}" placeholder="Title" required>
+      <textarea th:field="*{body}" placeholder="Body (optional)"></textarea>
+      <button type="submit">Create Post</button>
+    </form>
+  </div>
+  <div th:each="p : ${posts}" class="post">
+    <h2 th:text="${p.title}">Title</h2>
+    <p th:text="${p.body}">Body</p>
+    <form th:action="@{/posts/{id}/delete(id=${p.id})}" method="post" class="inline">
+      <button type="submit" class="delete">Delete</button>
+    </form>
+  </div>
+</body>
+</html>
+```
+
+- [ ] **Step 8: Create spring-boot-postgresql/Dockerfile**
+
+```dockerfile
+# Stage 1: Build with Maven
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+COPY pom.xml .
+RUN apk add --no-cache maven && mvn dependency:go-offline -B
+COPY src ./src
+RUN mvn package -DskipTests -B
+
+# Stage 2: Production runner
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+EXPOSE 8080
+CMD ["java", "-jar", "app.jar"]
+```
+
+- [ ] **Step 9: Create spring-boot-postgresql/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - DB_HOST=db
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=app_production
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  db_data:
+```
+
+- [ ] **Step 10: Create spring-boot-postgresql/.dockerignore**
+
+```
+README.md
+.git
+target
+.idea
+*.iml
+```
+
+- [ ] **Step 11: Create spring-boot-postgresql/README.md**
+
+```markdown
+# spring-boot-postgresql
+
+Spring Boot と PostgreSQL を使ったシンプルな投稿アプリです。JPA による CRUD 機能を持ちます。
+
+## 構成
+
+- Java 21 + Spring Boot 3.4
+- PostgreSQL 17
+- ポート: 8080
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name spring-app
+
+# デプロイ
+conoha app deploy myserver --app-name spring-app
+```
+
+初回ビルドは Maven 依存関係のダウンロードに数分かかります。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:8080` にアクセスすると投稿一覧ページが表示されます。
+
+## カスタマイズ
+
+- `src/main/java/com/example/app/` にエンティティやコントローラーを追加
+- `src/main/resources/templates/` に Thymeleaf テンプレートを追加
+- 本番環境では `DB_PASSWORD` を `.env.server` で管理
+```
+
+- [ ] **Step 12: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add spring-boot-postgresql/
+git commit -m "Add Spring Boot + PostgreSQL sample (JPA CRUD app)"
+```
+
+---
+
+### Task 2: express-mongodb
+
+**Files:**
+- Create: `express-mongodb/README.md`
+- Create: `express-mongodb/Dockerfile`
+- Create: `express-mongodb/compose.yml`
+- Create: `express-mongodb/.dockerignore`
+- Create: `express-mongodb/package.json`
+- Create: `express-mongodb/app.js`
+- Create: `express-mongodb/views/index.ejs`
+
+- [ ] **Step 1: Create express-mongodb/package.json**
+
+```json
+{
+  "name": "conoha-express-sample",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^5.1.0",
+    "ejs": "^3.1.10",
+    "mongoose": "^8.13.2"
+  }
+}
+```
+
+- [ ] **Step 2: Create express-mongodb/app.js**
+
+```javascript
+const express = require("express");
+const mongoose = require("mongoose");
+
+const app = express();
+const PORT = 3000;
+
+app.set("view engine", "ejs");
+app.use(express.urlencoded({ extended: true }));
+
+// Connect to MongoDB
+const mongoURL = process.env.MONGO_URL || "mongodb://db:27017/app";
+mongoose.connect(mongoURL);
+
+// Post schema
+const postSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  body: String,
+  createdAt: { type: Date, default: Date.now },
+});
+const Post = mongoose.model("Post", postSchema);
+
+// Routes
+app.get("/", async (req, res) => {
+  const posts = await Post.find().sort({ createdAt: -1 });
+  res.render("index", { posts });
+});
+
+app.post("/posts", async (req, res) => {
+  await Post.create({ title: req.body.title, body: req.body.body });
+  res.redirect("/");
+});
+
+app.post("/posts/:id/delete", async (req, res) => {
+  await Post.findByIdAndDelete(req.params.id);
+  res.redirect("/");
+});
+
+app.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+```
+
+- [ ] **Step 3: Create express-mongodb/views/index.ejs**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Express on ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 700px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 { margin-bottom: 1rem; }
+    .post { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; }
+    .post h2 { margin: 0 0 0.5rem; font-size: 1.2rem; }
+    .post p { margin: 0; color: #666; }
+    .form-box { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; }
+    input, textarea { width: 100%; padding: 0.5rem; margin-bottom: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; box-sizing: border-box; }
+    textarea { height: 80px; resize: vertical; }
+    button { padding: 0.5rem 1.5rem; background: #1976d2; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .delete { background: #d32f2f; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+    form.inline { display: inline; }
+  </style>
+</head>
+<body>
+  <h1>Express on ConoHa</h1>
+  <div class="form-box">
+    <form action="/posts" method="post">
+      <input type="text" name="title" placeholder="Title" required>
+      <textarea name="body" placeholder="Body (optional)"></textarea>
+      <button type="submit">Create Post</button>
+    </form>
+  </div>
+  <% posts.forEach(post => { %>
+    <div class="post">
+      <h2><%= post.title %></h2>
+      <p><%= post.body %></p>
+      <form action="/posts/<%= post._id %>/delete" method="post" class="inline">
+        <button type="submit" class="delete">Delete</button>
+      </form>
+    </div>
+  <% }) %>
+</body>
+</html>
+```
+
+- [ ] **Step 4: Create express-mongodb/Dockerfile**
+
+```dockerfile
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY . .
+EXPOSE 3000
+CMD ["node", "app.js"]
+```
+
+- [ ] **Step 5: Create express-mongodb/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - MONGO_URL=mongodb://db:27017/app
+    depends_on:
+      - db
+
+  db:
+    image: mongo:8
+    volumes:
+      - db_data:/data/db
+
+volumes:
+  db_data:
+```
+
+- [ ] **Step 6: Create express-mongodb/.dockerignore**
+
+```
+README.md
+.git
+node_modules
+```
+
+- [ ] **Step 7: Create express-mongodb/README.md**
+
+```markdown
+# express-mongodb
+
+Express.js と MongoDB を使ったシンプルな投稿アプリです。Mongoose による CRUD 機能を持ちます。
+
+## 構成
+
+- Node.js 22 + Express.js 5
+- MongoDB 8
+- ポート: 3000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name express-app
+
+# デプロイ
+conoha app deploy myserver --app-name express-app
+```
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:3000` にアクセスすると投稿一覧ページが表示されます。
+
+## カスタマイズ
+
+- `app.js` にルートを追加して機能を拡張
+- `views/` に EJS テンプレートを追加
+- MongoDB は認証なしで起動するため、本番環境では認証設定を追加
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add express-mongodb/
+git commit -m "Add Express.js + MongoDB sample (Mongoose CRUD app)"
+```
+
+---
+
+### Task 3: laravel-mysql
+
+**Files:**
+- Create: `laravel-mysql/README.md`
+- Create: `laravel-mysql/Dockerfile`
+- Create: `laravel-mysql/compose.yml`
+- Create: `laravel-mysql/.dockerignore`
+- Create: `laravel-mysql/composer.json`
+- Create: `laravel-mysql/artisan`
+- Create: `laravel-mysql/public/index.php`
+- Create: `laravel-mysql/bootstrap/app.php`
+- Create: `laravel-mysql/bootstrap/providers.php`
+- Create: `laravel-mysql/config/app.php`
+- Create: `laravel-mysql/config/database.php`
+- Create: `laravel-mysql/routes/web.php`
+- Create: `laravel-mysql/app/Models/Post.php`
+- Create: `laravel-mysql/app/Http/Controllers/PostController.php`
+- Create: `laravel-mysql/app/Providers/AppServiceProvider.php`
+- Create: `laravel-mysql/resources/views/posts/index.blade.php`
+- Create: `laravel-mysql/database/migrations/2026_01_01_000000_create_posts_table.php`
+- Create: `laravel-mysql/bin/docker-entrypoint`
+
+- [ ] **Step 1: Create laravel-mysql/composer.json**
+
+```json
+{
+    "name": "conoha/laravel-sample",
+    "type": "project",
+    "require": {
+        "php": "^8.3",
+        "laravel/framework": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": []
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}
+```
+
+- [ ] **Step 2: Create laravel-mysql/artisan**
+
+```php
+#!/usr/bin/env php
+<?php
+
+use Illuminate\Foundation\Application;
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/vendor/autoload.php';
+
+$app = require_once __DIR__.'/bootstrap/app.php';
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$status = $kernel->handle(
+    $input = new Symfony\Component\Console\Input\ArgvInput,
+    new Symfony\Component\Console\Output\ConsoleOutput
+);
+$kernel->terminate($input, $status);
+exit($status);
+```
+
+Make executable: `chmod +x laravel-mysql/artisan`
+
+- [ ] **Step 3: Create laravel-mysql/public/index.php**
+
+```php
+<?php
+
+use Illuminate\Http\Request;
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+$kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
+$response = $kernel->handle($request = Request::capture());
+$response->send();
+$kernel->terminate($request, $response);
+```
+
+- [ ] **Step 4: Create laravel-mysql/bootstrap/app.php**
+
+```php
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(web: __DIR__.'/../routes/web.php')
+    ->withMiddleware(function (Middleware $middleware) {})
+    ->withExceptions(function (Exceptions $exceptions) {})
+    ->create();
+```
+
+- [ ] **Step 5: Create laravel-mysql/bootstrap/providers.php**
+
+```php
+<?php
+
+return [
+    App\Providers\AppServiceProvider::class,
+];
+```
+
+- [ ] **Step 6: Create laravel-mysql/config/app.php**
+
+```php
+<?php
+
+return [
+    'name' => 'Laravel on ConoHa',
+    'env' => env('APP_ENV', 'production'),
+    'debug' => (bool) env('APP_DEBUG', false),
+    'url' => env('APP_URL', 'http://localhost'),
+    'timezone' => 'Asia/Tokyo',
+    'locale' => 'en',
+    'key' => env('APP_KEY'),
+    'maintenance' => ['driver' => 'file'],
+];
+```
+
+- [ ] **Step 7: Create laravel-mysql/config/database.php**
+
+```php
+<?php
+
+return [
+    'default' => 'mysql',
+    'connections' => [
+        'mysql' => [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', 'db'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => env('DB_DATABASE', 'laravel'),
+            'username' => env('DB_USERNAME', 'laravel'),
+            'password' => env('DB_PASSWORD', 'laravel'),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+        ],
+    ],
+    'migrations' => [
+        'table' => 'migrations',
+    ],
+];
+```
+
+- [ ] **Step 8: Create laravel-mysql/app/Providers/AppServiceProvider.php**
+
+```php
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void {}
+    public function boot(): void {}
+}
+```
+
+- [ ] **Step 9: Create laravel-mysql/app/Models/Post.php**
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    protected $fillable = ['title', 'body'];
+}
+```
+
+- [ ] **Step 10: Create laravel-mysql/app/Http/Controllers/PostController.php**
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\Request;
+
+class PostController
+{
+    public function index()
+    {
+        $posts = Post::orderBy('created_at', 'desc')->get();
+        return view('posts.index', compact('posts'));
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate(['title' => 'required|string|max:255']);
+        Post::create($request->only('title', 'body'));
+        return redirect('/');
+    }
+
+    public function destroy(Post $post)
+    {
+        $post->delete();
+        return redirect('/');
+    }
+}
+```
+
+- [ ] **Step 11: Create laravel-mysql/routes/web.php**
+
+```php
+<?php
+
+use App\Http\Controllers\PostController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', [PostController::class, 'index']);
+Route::post('/posts', [PostController::class, 'store']);
+Route::delete('/posts/{post}', [PostController::class, 'destroy']);
+```
+
+- [ ] **Step 12: Create laravel-mysql/resources/views/posts/index.blade.php**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Laravel on ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 700px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 { margin-bottom: 1rem; }
+    .post { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; }
+    .post h2 { margin: 0 0 0.5rem; font-size: 1.2rem; }
+    .post p { margin: 0; color: #666; }
+    .form-box { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; }
+    input, textarea { width: 100%; padding: 0.5rem; margin-bottom: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; box-sizing: border-box; }
+    textarea { height: 80px; resize: vertical; }
+    button { padding: 0.5rem 1.5rem; background: #1976d2; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .delete { background: #d32f2f; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+    form.inline { display: inline; }
+  </style>
+</head>
+<body>
+  <h1>Laravel on ConoHa</h1>
+  <div class="form-box">
+    <form action="/posts" method="post">
+      @csrf
+      <input type="text" name="title" placeholder="Title" required>
+      <textarea name="body" placeholder="Body (optional)"></textarea>
+      <button type="submit">Create Post</button>
+    </form>
+  </div>
+  @foreach ($posts as $post)
+    <div class="post">
+      <h2>{{ $post->title }}</h2>
+      <p>{{ $post->body }}</p>
+      <form action="/posts/{{ $post->id }}" method="post" class="inline">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="delete">Delete</button>
+      </form>
+    </div>
+  @endforeach
+</body>
+</html>
+```
+
+- [ ] **Step 13: Create laravel-mysql/database/migrations/2026_01_01_000000_create_posts_table.php**
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('body')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};
+```
+
+- [ ] **Step 14: Create laravel-mysql/bin/docker-entrypoint**
+
+```bash
+#!/bin/bash
+set -e
+
+# Generate app key if not set
+if [ -z "$APP_KEY" ]; then
+    php artisan key:generate --force
+fi
+
+# Run database migrations
+php artisan migrate --force
+
+exec "$@"
+```
+
+Make executable: `chmod +x laravel-mysql/bin/docker-entrypoint`
+
+- [ ] **Step 15: Create laravel-mysql/Dockerfile**
+
+```dockerfile
+FROM composer:2 AS deps
+WORKDIR /app
+COPY composer.json ./
+RUN composer install --no-dev --no-scripts --prefer-dist
+
+FROM php:8.3-apache
+RUN docker-php-ext-install pdo_mysql
+RUN a2enmod rewrite
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \
+    && sed -ri -e 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf
+WORKDIR /var/www/html
+COPY --from=deps /app/vendor ./vendor
+COPY . .
+RUN chown -R www-data:www-data storage bootstrap/cache 2>/dev/null || true
+RUN chmod +x bin/docker-entrypoint
+EXPOSE 80
+ENTRYPOINT ["bin/docker-entrypoint"]
+CMD ["apache2-foreground"]
+```
+
+- [ ] **Step 16: Create laravel-mysql/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"
+    environment:
+      - APP_ENV=production
+      - APP_DEBUG=false
+      - DB_HOST=db
+      - DB_DATABASE=laravel
+      - DB_USERNAME=laravel
+      - DB_PASSWORD=laravel
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: mysql:8.0
+    environment:
+      - MYSQL_ROOT_PASSWORD=rootpassword
+      - MYSQL_DATABASE=laravel
+      - MYSQL_USER=laravel
+      - MYSQL_PASSWORD=laravel
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  db_data:
+```
+
+- [ ] **Step 17: Create laravel-mysql/.dockerignore**
+
+```
+README.md
+.git
+vendor
+node_modules
+storage/logs/*
+```
+
+- [ ] **Step 18: Create required Laravel directories**
+
+```bash
+mkdir -p laravel-mysql/storage/framework/{sessions,views,cache}
+mkdir -p laravel-mysql/storage/logs
+mkdir -p laravel-mysql/bootstrap/cache
+touch laravel-mysql/storage/framework/sessions/.gitkeep
+touch laravel-mysql/storage/framework/views/.gitkeep
+touch laravel-mysql/storage/framework/cache/.gitkeep
+touch laravel-mysql/storage/logs/.gitkeep
+touch laravel-mysql/bootstrap/cache/.gitkeep
+```
+
+- [ ] **Step 19: Create laravel-mysql/README.md**
+
+```markdown
+# laravel-mysql
+
+Laravel と MySQL を使ったシンプルな投稿アプリです。Eloquent ORM による CRUD 機能を持ちます。
+
+## 構成
+
+- PHP 8.3 + Laravel 11
+- MySQL 8.0
+- ポート: 80
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name laravel-app
+
+# デプロイ
+conoha app deploy myserver --app-name laravel-app
+```
+
+DB マイグレーションと APP_KEY 生成はコンテナ起動時に自動実行されます。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>` にアクセスすると投稿一覧ページが表示されます。
+
+## カスタマイズ
+
+- `app/Http/Controllers/` にコントローラーを追加
+- `resources/views/` に Blade テンプレートを追加
+- `database/migrations/` にマイグレーションを追加してスキーマを変更
+- 本番環境では `DB_PASSWORD` を `.env.server` で管理
+```
+
+- [ ] **Step 20: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add laravel-mysql/
+git commit -m "Add Laravel + MySQL sample (Eloquent CRUD app)"
+```
+
+---
+
+### Task 4: django-postgresql
+
+**Files:**
+- Create: `django-postgresql/README.md`
+- Create: `django-postgresql/Dockerfile`
+- Create: `django-postgresql/compose.yml`
+- Create: `django-postgresql/.dockerignore`
+- Create: `django-postgresql/requirements.txt`
+- Create: `django-postgresql/manage.py`
+- Create: `django-postgresql/config/settings.py`
+- Create: `django-postgresql/config/urls.py`
+- Create: `django-postgresql/config/wsgi.py`
+- Create: `django-postgresql/posts/models.py`
+- Create: `django-postgresql/posts/views.py`
+- Create: `django-postgresql/posts/urls.py`
+- Create: `django-postgresql/posts/forms.py`
+- Create: `django-postgresql/posts/admin.py`
+- Create: `django-postgresql/posts/apps.py`
+- Create: `django-postgresql/templates/posts/index.html`
+- Create: `django-postgresql/bin/docker-entrypoint`
+
+- [ ] **Step 1: Create django-postgresql/requirements.txt**
+
+```
+django==5.2
+psycopg[binary]==3.2.6
+gunicorn==23.0.0
+```
+
+- [ ] **Step 2: Create django-postgresql/manage.py**
+
+```python
+#!/usr/bin/env python
+import os
+import sys
+
+def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+if __name__ == "__main__":
+    main()
+```
+
+Make executable: `chmod +x django-postgresql/manage.py`
+
+- [ ] **Step 3: Create django-postgresql/config/settings.py**
+
+```python
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = os.environ.get("SECRET_KEY", "change-me-in-production")
+DEBUG = os.environ.get("DEBUG", "0") == "1"
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "posts",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+]
+
+ROOT_URLCONF = "config.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "config.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "HOST": os.environ.get("DB_HOST", "db"),
+        "NAME": os.environ.get("DB_NAME", "app_production"),
+        "USER": os.environ.get("DB_USER", "postgres"),
+        "PASSWORD": os.environ.get("DB_PASSWORD", "postgres"),
+    }
+}
+
+STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+```
+
+- [ ] **Step 4: Create django-postgresql/config/urls.py**
+
+```python
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("", include("posts.urls")),
+]
+```
+
+- [ ] **Step 5: Create django-postgresql/config/wsgi.py**
+
+```python
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+application = get_wsgi_application()
+```
+
+- [ ] **Step 6: Create django-postgresql/posts/apps.py**
+
+```python
+from django.apps import AppConfig
+
+class PostsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "posts"
+```
+
+- [ ] **Step 7: Create django-postgresql/posts/models.py**
+
+```python
+from django.db import models
+
+class Post(models.Model):
+    title = models.CharField(max_length=255)
+    body = models.TextField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return self.title
+```
+
+- [ ] **Step 8: Create django-postgresql/posts/forms.py**
+
+```python
+from django import forms
+from .models import Post
+
+class PostForm(forms.ModelForm):
+    class Meta:
+        model = Post
+        fields = ["title", "body"]
+        widgets = {
+            "title": forms.TextInput(attrs={"placeholder": "Title"}),
+            "body": forms.Textarea(attrs={"placeholder": "Body (optional)", "rows": 3}),
+        }
+```
+
+- [ ] **Step 9: Create django-postgresql/posts/views.py**
+
+```python
+from django.shortcuts import redirect, get_object_or_404
+from django.views.generic import ListView
+from .forms import PostForm
+from .models import Post
+
+class PostListView(ListView):
+    model = Post
+    template_name = "posts/index.html"
+    context_object_name = "posts"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form"] = PostForm()
+        return context
+
+def post_create(request):
+    if request.method == "POST":
+        form = PostForm(request.POST)
+        if form.is_valid():
+            form.save()
+    return redirect("/")
+
+def post_delete(request, pk):
+    if request.method == "POST":
+        post = get_object_or_404(Post, pk=pk)
+        post.delete()
+    return redirect("/")
+```
+
+- [ ] **Step 10: Create django-postgresql/posts/urls.py**
+
+```python
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("", views.PostListView.as_view(), name="post_list"),
+    path("posts/create/", views.post_create, name="post_create"),
+    path("posts/<int:pk>/delete/", views.post_delete, name="post_delete"),
+]
+```
+
+- [ ] **Step 11: Create django-postgresql/posts/admin.py**
+
+```python
+from django.contrib import admin
+from .models import Post
+
+admin.site.register(Post)
+```
+
+- [ ] **Step 12: Create django-postgresql/templates/posts/index.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Django on ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 700px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 { margin-bottom: 1rem; }
+    .post { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; }
+    .post h2 { margin: 0 0 0.5rem; font-size: 1.2rem; }
+    .post p { margin: 0; color: #666; }
+    .form-box { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; }
+    input, textarea { width: 100%; padding: 0.5rem; margin-bottom: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; box-sizing: border-box; }
+    textarea { height: 80px; resize: vertical; }
+    button { padding: 0.5rem 1.5rem; background: #1976d2; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .delete { background: #d32f2f; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+    form.inline { display: inline; }
+  </style>
+</head>
+<body>
+  <h1>Django on ConoHa</h1>
+  <div class="form-box">
+    <form action="{% url 'post_create' %}" method="post">
+      {% csrf_token %}
+      {{ form.title }}
+      {{ form.body }}
+      <button type="submit">Create Post</button>
+    </form>
+  </div>
+  {% for post in posts %}
+    <div class="post">
+      <h2>{{ post.title }}</h2>
+      <p>{{ post.body }}</p>
+      <form action="{% url 'post_delete' post.pk %}" method="post" class="inline">
+        {% csrf_token %}
+        <button type="submit" class="delete">Delete</button>
+      </form>
+    </div>
+  {% endfor %}
+</body>
+</html>
+```
+
+- [ ] **Step 13: Create django-postgresql/bin/docker-entrypoint**
+
+```bash
+#!/bin/bash
+set -e
+
+# Run database migrations
+python manage.py migrate --noinput
+
+# Collect static files
+python manage.py collectstatic --noinput
+
+exec "$@"
+```
+
+Make executable: `chmod +x django-postgresql/bin/docker-entrypoint`
+
+- [ ] **Step 14: Create django-postgresql/Dockerfile**
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+RUN apt-get update -qq && apt-get install -y libpq5 && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+RUN chmod +x bin/docker-entrypoint manage.py
+EXPOSE 8000
+ENTRYPOINT ["bin/docker-entrypoint"]
+CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000"]
+```
+
+- [ ] **Step 15: Create django-postgresql/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - DB_HOST=db
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=app_production
+      - SECRET_KEY=change-me-in-production
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  db_data:
+```
+
+- [ ] **Step 16: Create django-postgresql/.dockerignore**
+
+```
+README.md
+.git
+__pycache__
+*.pyc
+.venv
+staticfiles
+```
+
+- [ ] **Step 17: Create empty __init__.py files for Python packages**
+
+```bash
+touch django-postgresql/config/__init__.py
+touch django-postgresql/posts/__init__.py
+touch django-postgresql/posts/migrations/__init__.py
+```
+
+- [ ] **Step 18: Create django-postgresql/README.md**
+
+```markdown
+# django-postgresql
+
+Django と PostgreSQL を使ったシンプルな投稿アプリです。Django ORM による CRUD 機能と管理画面を持ちます。
+
+## 構成
+
+- Python 3.12 + Django 5.2
+- PostgreSQL 17
+- Gunicorn（アプリサーバー）
+- ポート: 8000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name django-app
+
+# デプロイ
+conoha app deploy myserver --app-name django-app
+```
+
+DB マイグレーションはコンテナ起動時に自動実行されます。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:8000` にアクセスすると投稿一覧ページが表示されます。
+
+Django 管理画面は `http://<サーバーIP>:8000/admin/` からアクセスできます（スーパーユーザーの作成が必要）。
+
+## カスタマイズ
+
+- `posts/` アプリを編集して機能を追加
+- `python manage.py startapp <name>` で新しいアプリを追加
+- `python manage.py createsuperuser` で管理画面のユーザーを作成
+- 本番環境では `SECRET_KEY` と `DB_PASSWORD` を `.env.server` で管理
+```
+
+- [ ] **Step 19: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add django-postgresql/
+git commit -m "Add Django + PostgreSQL sample (ORM CRUD app with admin)"
+```
+
+---
+
+### Task 5: Update root README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update the samples table in root README.md**
+
+Add 4 new rows to the サンプル一覧 table in `/home/tkim/dev/crowdy/conoha-cli-app-samples/README.md`. The table should now be:
+
+```markdown
+| サンプル | スタック | 説明 | 推奨フレーバー |
+|---------|---------|------|--------------|
+| [hello-world](hello-world/) | nginx + 静的HTML | 最もシンプルなサンプル | g2l-t-1 (1GB) |
+| [nextjs](nextjs/) | Next.js (standalone) | Next.js デフォルトページ | g2l-t-2 (2GB) |
+| [fastapi-ai-chatbot](fastapi-ai-chatbot/) | FastAPI + Ollama | AI チャットボット | g2l-t-4 (4GB) |
+| [rails-postgresql](rails-postgresql/) | Rails + PostgreSQL | Rails scaffold アプリ | g2l-t-2 (2GB) |
+| [wordpress-mysql](wordpress-mysql/) | WordPress + MySQL | WordPress ブログ | g2l-t-2 (2GB) |
+| [spring-boot-postgresql](spring-boot-postgresql/) | Spring Boot + PostgreSQL | JPA CRUD アプリ | g2l-t-2 (2GB) |
+| [express-mongodb](express-mongodb/) | Express.js + MongoDB | Mongoose CRUD アプリ | g2l-t-2 (2GB) |
+| [laravel-mysql](laravel-mysql/) | Laravel + MySQL | Eloquent CRUD アプリ | g2l-t-2 (2GB) |
+| [django-postgresql](django-postgresql/) | Django + PostgreSQL | Django ORM アプリ + 管理画面 | g2l-t-2 (2GB) |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add README.md
+git commit -m "Update root README with Tier 1 samples"
+```
+
+---
+
+### Task 6: Push to GitHub
+
+- [ ] **Step 1: Push all new commits**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git push origin main
+```

--- a/docs/superpowers/plans/2026-03-31-app-samples-tier2-impl.md
+++ b/docs/superpowers/plans/2026-03-31-app-samples-tier2-impl.md
@@ -1,0 +1,1582 @@
+# App Samples Tier 2 Additions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 5 Tier 2 samples (vite-react, sveltekit, go-fiber, nestjs-postgresql, rust-actix-web) to the existing `conoha-cli-app-samples` repo and update the root README.
+
+**Architecture:** Each sample is a flat top-level directory following established patterns — compose.yml + Dockerfile + minimal source code + Japanese README. All code comments and app output in English. Each sample is independently deployable via `conoha app deploy`.
+
+**Tech Stack:** Vite/React, SvelteKit, Go/Fiber, NestJS/TypeScript/PostgreSQL, Rust/Actix-web
+
+**Repo:** `/home/tkim/dev/crowdy/conoha-cli-app-samples`
+
+---
+
+### Task 1: vite-react
+
+Static React SPA built with Vite, served by nginx.
+
+**Files:**
+- Create: `vite-react/README.md`
+- Create: `vite-react/Dockerfile`
+- Create: `vite-react/compose.yml`
+- Create: `vite-react/.dockerignore`
+- Create: `vite-react/package.json`
+- Create: `vite-react/vite.config.ts`
+- Create: `vite-react/tsconfig.json`
+- Create: `vite-react/index.html`
+- Create: `vite-react/src/main.tsx`
+- Create: `vite-react/src/App.tsx`
+- Create: `vite-react/src/App.css`
+- Create: `vite-react/src/vite-env.d.ts`
+- Create: `vite-react/nginx.conf`
+
+- [ ] **Step 1: Create vite-react/package.json**
+
+```json
+{
+  "name": "conoha-vite-react-sample",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.4.1",
+    "typescript": "^5.7.0",
+    "vite": "^6.3.2"
+  }
+}
+```
+
+- [ ] **Step 2: Create vite-react/vite.config.ts**
+
+```typescript
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});
+```
+
+- [ ] **Step 3: Create vite-react/tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 4: Create vite-react/index.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React on ConoHa</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 5: Create vite-react/src/vite-env.d.ts**
+
+```typescript
+/// <reference types="vite/client" />
+```
+
+- [ ] **Step 6: Create vite-react/src/main.tsx**
+
+```tsx
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./App.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
+```
+
+- [ ] **Step 7: Create vite-react/src/App.tsx**
+
+```tsx
+import { useState } from "react";
+
+export default function App() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div className="container">
+      <h1>React on ConoHa</h1>
+      <p>Deployed with <code>conoha app deploy</code></p>
+      <div className="card">
+        <button onClick={() => setCount((c) => c + 1)}>
+          Count: {count}
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Create vite-react/src/App.css**
+
+```css
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  text-align: center;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  font-size: 1.2rem;
+  color: #666;
+  margin-bottom: 2rem;
+}
+
+.card {
+  padding: 1rem;
+}
+
+button {
+  padding: 0.75rem 2rem;
+  font-size: 1.1rem;
+  background: #1976d2;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+button:hover {
+  background: #1565c0;
+}
+```
+
+- [ ] **Step 9: Create vite-react/nginx.conf**
+
+```nginx
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+
+- [ ] **Step 10: Create vite-react/Dockerfile**
+
+```dockerfile
+# Stage 1: Build
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve with nginx
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+```
+
+- [ ] **Step 11: Create vite-react/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"
+```
+
+- [ ] **Step 12: Create vite-react/.dockerignore**
+
+```
+README.md
+.git
+node_modules
+dist
+```
+
+- [ ] **Step 13: Create vite-react/README.md**
+
+```markdown
+# vite-react
+
+Vite + React で構築した SPA を nginx で配信するサンプルです。フロントエンドプロジェクトのデプロイに最適です。
+
+## 構成
+
+- Vite 6 + React 19 + TypeScript
+- nginx（静的ファイル配信）
+- ポート: 80
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-1 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name react-app
+
+# デプロイ
+conoha app deploy myserver --app-name react-app
+```
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>` にアクセスするとカウンターアプリが表示されます。
+
+## カスタマイズ
+
+- `src/App.tsx` を編集してコンポーネントを変更
+- `npm install` で追加パッケージをインストール
+- `nginx.conf` でキャッシュ設定やリバースプロキシを追加
+```
+
+- [ ] **Step 14: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add vite-react/
+git commit -m "Add Vite + React sample (static SPA with nginx)"
+```
+
+---
+
+### Task 2: sveltekit
+
+SvelteKit app with adapter-node for server-side rendering.
+
+**Files:**
+- Create: `sveltekit/README.md`
+- Create: `sveltekit/Dockerfile`
+- Create: `sveltekit/compose.yml`
+- Create: `sveltekit/.dockerignore`
+- Create: `sveltekit/package.json`
+- Create: `sveltekit/svelte.config.js`
+- Create: `sveltekit/vite.config.ts`
+- Create: `sveltekit/tsconfig.json`
+- Create: `sveltekit/src/app.html`
+- Create: `sveltekit/src/app.css`
+- Create: `sveltekit/src/routes/+page.svelte`
+- Create: `sveltekit/src/routes/+layout.svelte`
+
+- [ ] **Step 1: Create sveltekit/package.json**
+
+```json
+{
+  "name": "conoha-sveltekit-sample",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-node": "^5.2.12",
+    "@sveltejs/kit": "^2.20.7",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "svelte": "^5.25.12",
+    "typescript": "^5.7.0",
+    "vite": "^6.3.2"
+  }
+}
+```
+
+- [ ] **Step 2: Create sveltekit/svelte.config.js**
+
+```javascript
+import adapter from "@sveltejs/adapter-node";
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  kit: {
+    adapter: adapter(),
+  },
+};
+
+export default config;
+```
+
+- [ ] **Step 3: Create sveltekit/vite.config.ts**
+
+```typescript
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [sveltekit()],
+});
+```
+
+- [ ] **Step 4: Create sveltekit/tsconfig.json**
+
+```json
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+- [ ] **Step 5: Create sveltekit/src/app.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body>
+    <div>%sveltekit.body%</div>
+  </body>
+</html>
+```
+
+- [ ] **Step 6: Create sveltekit/src/app.css**
+
+```css
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+```
+
+- [ ] **Step 7: Create sveltekit/src/routes/+layout.svelte**
+
+```svelte
+<script>
+  import "../app.css";
+  let { children } = $props();
+</script>
+
+{@render children()}
+```
+
+- [ ] **Step 8: Create sveltekit/src/routes/+page.svelte**
+
+```svelte
+<script lang="ts">
+  let count = $state(0);
+</script>
+
+<svelte:head>
+  <title>SvelteKit on ConoHa</title>
+</svelte:head>
+
+<div class="container">
+  <h1>SvelteKit on ConoHa</h1>
+  <p>Deployed with <code>conoha app deploy</code></p>
+  <div class="card">
+    <button onclick={() => count++}>
+      Count: {count}
+    </button>
+  </div>
+</div>
+
+<style>
+  .container {
+    text-align: center;
+    padding: 2rem;
+  }
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 1rem;
+  }
+  p {
+    font-size: 1.2rem;
+    color: #666;
+    margin-bottom: 2rem;
+  }
+  .card {
+    padding: 1rem;
+  }
+  button {
+    padding: 0.75rem 2rem;
+    font-size: 1.1rem;
+    background: #ff3e00;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  button:hover {
+    background: #d63600;
+  }
+</style>
+```
+
+- [ ] **Step 9: Create sveltekit/Dockerfile**
+
+```dockerfile
+# Stage 1: Build
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Production runner
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/build ./build
+COPY --from=builder /app/package.json ./
+RUN npm install --omit=dev
+EXPOSE 3000
+ENV PORT=3000
+CMD ["node", "build"]
+```
+
+- [ ] **Step 10: Create sveltekit/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+```
+
+- [ ] **Step 11: Create sveltekit/.dockerignore**
+
+```
+README.md
+.git
+node_modules
+build
+.svelte-kit
+```
+
+- [ ] **Step 12: Create sveltekit/README.md**
+
+```markdown
+# sveltekit
+
+SvelteKit アプリを adapter-node でデプロイするサンプルです。SSR 対応のモダンフレームワークです。
+
+## 構成
+
+- SvelteKit 2 + Svelte 5 + TypeScript
+- adapter-node（Node.js サーバー）
+- ポート: 3000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name sveltekit-app
+
+# デプロイ
+conoha app deploy myserver --app-name sveltekit-app
+```
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:3000` にアクセスするとカウンターアプリが表示されます。
+
+## カスタマイズ
+
+- `src/routes/` にファイルを追加してルーティング
+- `svelte.config.js` で SvelteKit の設定を変更
+- 静的サイトにしたい場合は `adapter-static` に変更
+```
+
+- [ ] **Step 13: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add sveltekit/
+git commit -m "Add SvelteKit sample (SSR with adapter-node)"
+```
+
+---
+
+### Task 3: go-fiber
+
+Minimal Go REST API with Fiber framework.
+
+**Files:**
+- Create: `go-fiber/README.md`
+- Create: `go-fiber/Dockerfile`
+- Create: `go-fiber/compose.yml`
+- Create: `go-fiber/.dockerignore`
+- Create: `go-fiber/go.mod`
+- Create: `go-fiber/go.sum` (empty)
+- Create: `go-fiber/main.go`
+
+- [ ] **Step 1: Create go-fiber/go.mod**
+
+```
+module conoha-go-fiber-sample
+
+go 1.24
+
+require github.com/gofiber/fiber/v2 v2.52.6
+
+require (
+	github.com/andybalholm/brotli v1.1.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.58.0 // indirect
+	github.com/valyala/tcplisten v1.0.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
+)
+```
+
+- [ ] **Step 2: Create go-fiber/go.sum (empty)**
+
+Create an empty file. Docker build will run `go mod download` which generates the real sum.
+
+- [ ] **Step 3: Create go-fiber/main.go**
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type Message struct {
+	ID        int       `json:"id"`
+	Text      string    `json:"text"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+var messages []Message
+var nextID = 1
+
+func main() {
+	app := fiber.New()
+
+	// Health check
+	app.Get("/health", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"status": "ok"})
+	})
+
+	// List messages
+	app.Get("/api/messages", func(c *fiber.Ctx) error {
+		return c.JSON(messages)
+	})
+
+	// Create message
+	app.Post("/api/messages", func(c *fiber.Ctx) error {
+		var body struct {
+			Text string `json:"text"`
+		}
+		if err := c.BodyParser(&body); err != nil {
+			return c.Status(400).JSON(fiber.Map{"error": "invalid request body"})
+		}
+		if body.Text == "" {
+			return c.Status(400).JSON(fiber.Map{"error": "text is required"})
+		}
+		msg := Message{
+			ID:        nextID,
+			Text:      body.Text,
+			CreatedAt: time.Now(),
+		}
+		nextID++
+		messages = append(messages, msg)
+		return c.Status(201).JSON(msg)
+	})
+
+	// Delete message
+	app.Delete("/api/messages/:id", func(c *fiber.Ctx) error {
+		id, err := c.ParamsInt("id")
+		if err != nil {
+			return c.Status(400).JSON(fiber.Map{"error": "invalid id"})
+		}
+		for i, msg := range messages {
+			if msg.ID == id {
+				messages = append(messages[:i], messages[i+1:]...)
+				return c.SendStatus(204)
+			}
+		}
+		return c.Status(404).JSON(fiber.Map{"error": "not found"})
+	})
+
+	// Serve index page
+	app.Get("/", func(c *fiber.Ctx) error {
+		c.Set("Content-Type", "text/html")
+		return c.SendString(indexHTML)
+	})
+
+	fmt.Println("Server running on port 3000")
+	log.Fatal(app.Listen(":3000"))
+}
+
+const indexHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Go Fiber on ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 700px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 { margin-bottom: 1rem; }
+    .msg { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 0.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .form-box { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; display: flex; gap: 0.5rem; }
+    input { flex: 1; padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; }
+    button { padding: 0.5rem 1.5rem; background: #00acd7; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .delete { background: #d32f2f; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+  </style>
+</head>
+<body>
+  <h1>Go Fiber on ConoHa</h1>
+  <div class="form-box">
+    <input type="text" id="input" placeholder="Type a message..." required>
+    <button onclick="send()">Send</button>
+  </div>
+  <div id="list"></div>
+  <script>
+    async function load() {
+      const res = await fetch("/api/messages");
+      const msgs = await res.json();
+      const list = document.getElementById("list");
+      list.innerHTML = (msgs || []).map(m =>
+        '<div class="msg"><span>' + m.text + '</span>' +
+        '<button class="delete" onclick="del(' + m.id + ')">Delete</button></div>'
+      ).join("");
+    }
+    async function send() {
+      const input = document.getElementById("input");
+      const text = input.value.trim();
+      if (!text) return;
+      await fetch("/api/messages", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({text})
+      });
+      input.value = "";
+      load();
+    }
+    async function del(id) {
+      await fetch("/api/messages/" + id, {method: "DELETE"});
+      load();
+    }
+    document.getElementById("input").addEventListener("keydown", e => {
+      if (e.key === "Enter") send();
+    });
+    load();
+  </script>
+</body>
+</html>`
+```
+
+- [ ] **Step 4: Create go-fiber/Dockerfile**
+
+```dockerfile
+# Stage 1: Build
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o server .
+
+# Stage 2: Production runner
+FROM alpine:3.21
+WORKDIR /app
+COPY --from=builder /app/server .
+EXPOSE 3000
+CMD ["./server"]
+```
+
+- [ ] **Step 5: Create go-fiber/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+```
+
+- [ ] **Step 6: Create go-fiber/.dockerignore**
+
+```
+README.md
+.git
+server
+```
+
+- [ ] **Step 7: Create go-fiber/README.md**
+
+```markdown
+# go-fiber
+
+Go と Fiber フレームワークで構築した高速 REST API サーバーです。インメモリでメッセージの CRUD を行います。
+
+## 構成
+
+- Go 1.24 + Fiber v2
+- ポート: 3000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-1 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name go-api
+
+# デプロイ
+conoha app deploy myserver --app-name go-api
+```
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:3000` にアクセスするとメッセージボードが表示されます。
+
+API エンドポイント:
+- `GET /api/messages` — メッセージ一覧
+- `POST /api/messages` — メッセージ作成（`{"text": "hello"}`）
+- `DELETE /api/messages/:id` — メッセージ削除
+- `GET /health` — ヘルスチェック
+
+## カスタマイズ
+
+- `main.go` にルートを追加して機能を拡張
+- データベースを追加する場合は GORM などの ORM を導入
+- バイナリサイズが小さいため起動が非常に高速
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add go-fiber/
+git commit -m "Add Go Fiber sample (high-performance REST API)"
+```
+
+---
+
+### Task 4: nestjs-postgresql
+
+NestJS TypeScript backend with TypeORM and PostgreSQL.
+
+**Files:**
+- Create: `nestjs-postgresql/README.md`
+- Create: `nestjs-postgresql/Dockerfile`
+- Create: `nestjs-postgresql/compose.yml`
+- Create: `nestjs-postgresql/.dockerignore`
+- Create: `nestjs-postgresql/package.json`
+- Create: `nestjs-postgresql/tsconfig.json`
+- Create: `nestjs-postgresql/tsconfig.build.json`
+- Create: `nestjs-postgresql/nest-cli.json`
+- Create: `nestjs-postgresql/src/main.ts`
+- Create: `nestjs-postgresql/src/app.module.ts`
+- Create: `nestjs-postgresql/src/post.entity.ts`
+- Create: `nestjs-postgresql/src/posts.controller.ts`
+- Create: `nestjs-postgresql/src/posts.service.ts`
+- Create: `nestjs-postgresql/views/index.hbs`
+
+- [ ] **Step 1: Create nestjs-postgresql/package.json**
+
+```json
+{
+  "name": "conoha-nestjs-sample",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:prod": "node dist/main"
+  },
+  "dependencies": {
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/typeorm": "^11.0.0",
+    "hbs": "^4.2.0",
+    "pg": "^8.13.0",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.20"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^11.0.0",
+    "typescript": "^5.7.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create nestjs-postgresql/tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}
+```
+
+- [ ] **Step 3: Create nestjs-postgresql/tsconfig.build.json**
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "test"]
+}
+```
+
+- [ ] **Step 4: Create nestjs-postgresql/nest-cli.json**
+
+```json
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}
+```
+
+- [ ] **Step 5: Create nestjs-postgresql/src/post.entity.ts**
+
+```typescript
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from "typeorm";
+
+@Entity("posts")
+export class Post {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ type: "text", nullable: true })
+  body: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}
+```
+
+- [ ] **Step 6: Create nestjs-postgresql/src/posts.service.ts**
+
+```typescript
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Post } from "./post.entity";
+
+@Injectable()
+export class PostsService {
+  constructor(
+    @InjectRepository(Post)
+    private readonly repo: Repository<Post>,
+  ) {}
+
+  findAll(): Promise<Post[]> {
+    return this.repo.find({ order: { createdAt: "DESC" } });
+  }
+
+  create(title: string, body: string): Promise<Post> {
+    const post = this.repo.create({ title, body });
+    return this.repo.save(post);
+  }
+
+  async remove(id: number): Promise<void> {
+    await this.repo.delete(id);
+  }
+}
+```
+
+- [ ] **Step 7: Create nestjs-postgresql/src/posts.controller.ts**
+
+```typescript
+import { Body, Controller, Get, Post as HttpPost, Param, Render, Redirect } from "@nestjs/common";
+import { PostsService } from "./posts.service";
+
+@Controller()
+export class PostsController {
+  constructor(private readonly postsService: PostsService) {}
+
+  @Get()
+  @Render("index")
+  async index() {
+    const posts = await this.postsService.findAll();
+    return { posts };
+  }
+
+  @HttpPost("posts")
+  @Redirect("/")
+  async create(@Body() body: { title: string; body: string }) {
+    await this.postsService.create(body.title, body.body);
+  }
+
+  @HttpPost("posts/:id/delete")
+  @Redirect("/")
+  async remove(@Param("id") id: string) {
+    await this.postsService.remove(Number(id));
+  }
+}
+```
+
+- [ ] **Step 8: Create nestjs-postgresql/src/app.module.ts**
+
+```typescript
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Post } from "./post.entity";
+import { PostsController } from "./posts.controller";
+import { PostsService } from "./posts.service";
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: "postgres",
+      host: process.env.DB_HOST || "db",
+      port: 5432,
+      username: process.env.DB_USER || "postgres",
+      password: process.env.DB_PASSWORD || "postgres",
+      database: process.env.DB_NAME || "app_production",
+      entities: [Post],
+      synchronize: true,
+    }),
+    TypeOrmModule.forFeature([Post]),
+  ],
+  controllers: [PostsController],
+  providers: [PostsService],
+})
+export class AppModule {}
+```
+
+- [ ] **Step 9: Create nestjs-postgresql/src/main.ts**
+
+```typescript
+import { NestFactory } from "@nestjs/core";
+import { NestExpressApplication } from "@nestjs/platform-express";
+import { join } from "path";
+import { AppModule } from "./app.module";
+
+async function bootstrap() {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  app.setBaseViewsDir(join(__dirname, "..", "views"));
+  app.setViewEngine("hbs");
+  await app.listen(3000);
+  console.log("Server running on port 3000");
+}
+bootstrap();
+```
+
+- [ ] **Step 10: Create nestjs-postgresql/views/index.hbs**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>NestJS on ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 700px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 { margin-bottom: 1rem; }
+    .post { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; }
+    .post h2 { margin: 0 0 0.5rem; font-size: 1.2rem; }
+    .post p { margin: 0; color: #666; }
+    .form-box { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; }
+    input, textarea { width: 100%; padding: 0.5rem; margin-bottom: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; box-sizing: border-box; }
+    textarea { height: 80px; resize: vertical; }
+    button { padding: 0.5rem 1.5rem; background: #e0234e; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .delete { background: #d32f2f; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+    form.inline { display: inline; }
+  </style>
+</head>
+<body>
+  <h1>NestJS on ConoHa</h1>
+  <div class="form-box">
+    <form action="/posts" method="post">
+      <input type="text" name="title" placeholder="Title" required>
+      <textarea name="body" placeholder="Body (optional)"></textarea>
+      <button type="submit">Create Post</button>
+    </form>
+  </div>
+  {{#each posts}}
+    <div class="post">
+      <h2>{{this.title}}</h2>
+      <p>{{this.body}}</p>
+      <form action="/posts/{{this.id}}/delete" method="post" class="inline">
+        <button type="submit" class="delete">Delete</button>
+      </form>
+    </div>
+  {{/each}}
+</body>
+</html>
+```
+
+- [ ] **Step 11: Create nestjs-postgresql/Dockerfile**
+
+```dockerfile
+# Stage 1: Build
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Production runner
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/views ./views
+COPY --from=builder /app/package.json ./
+RUN npm install --omit=dev
+EXPOSE 3000
+CMD ["node", "dist/main"]
+```
+
+- [ ] **Step 12: Create nestjs-postgresql/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - DB_HOST=db
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=app_production
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  db_data:
+```
+
+- [ ] **Step 13: Create nestjs-postgresql/.dockerignore**
+
+```
+README.md
+.git
+node_modules
+dist
+```
+
+- [ ] **Step 14: Create nestjs-postgresql/README.md**
+
+```markdown
+# nestjs-postgresql
+
+NestJS と PostgreSQL を使ったシンプルな投稿アプリです。TypeORM による CRUD 機能を持ちます。
+
+## 構成
+
+- Node.js 22 + NestJS 11 + TypeScript
+- TypeORM + PostgreSQL 17
+- ポート: 3000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name nestjs-app
+
+# デプロイ
+conoha app deploy myserver --app-name nestjs-app
+```
+
+テーブルはアプリ起動時に自動作成されます（TypeORM synchronize）。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:3000` にアクセスすると投稿一覧ページが表示されます。
+
+## カスタマイズ
+
+- `src/` にモジュール・コントローラー・サービスを追加
+- `nest g resource <name>` でリソース一式を自動生成
+- 本番環境では `DB_PASSWORD` を `.env.server` で管理
+- `synchronize: true` は開発用。本番ではマイグレーションを使用
+```
+
+- [ ] **Step 15: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add nestjs-postgresql/
+git commit -m "Add NestJS + PostgreSQL sample (TypeORM CRUD app)"
+```
+
+---
+
+### Task 5: rust-actix-web
+
+Minimal Rust REST API with Actix-web.
+
+**Files:**
+- Create: `rust-actix-web/README.md`
+- Create: `rust-actix-web/Dockerfile`
+- Create: `rust-actix-web/compose.yml`
+- Create: `rust-actix-web/.dockerignore`
+- Create: `rust-actix-web/Cargo.toml`
+- Create: `rust-actix-web/src/main.rs`
+
+- [ ] **Step 1: Create rust-actix-web/Cargo.toml**
+
+```toml
+[package]
+name = "conoha-rust-sample"
+version = "1.0.0"
+edition = "2024"
+
+[dependencies]
+actix-web = "4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+- [ ] **Step 2: Create rust-actix-web/src/main.rs**
+
+```rust
+use actix_web::{web, App, HttpServer, HttpResponse, Responder};
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+
+#[derive(Serialize, Clone)]
+struct Message {
+    id: u32,
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct CreateMessage {
+    text: String,
+}
+
+struct AppState {
+    messages: Mutex<Vec<Message>>,
+    next_id: Mutex<u32>,
+}
+
+async fn index() -> impl Responder {
+    HttpResponse::Ok().content_type("text/html").body(INDEX_HTML)
+}
+
+async fn list_messages(data: web::Data<AppState>) -> impl Responder {
+    let messages = data.messages.lock().unwrap();
+    HttpResponse::Ok().json(&*messages)
+}
+
+async fn create_message(
+    data: web::Data<AppState>,
+    body: web::Json<CreateMessage>,
+) -> impl Responder {
+    if body.text.is_empty() {
+        return HttpResponse::BadRequest().json(serde_json::json!({"error": "text is required"}));
+    }
+    let mut messages = data.messages.lock().unwrap();
+    let mut next_id = data.next_id.lock().unwrap();
+    let msg = Message {
+        id: *next_id,
+        text: body.text.clone(),
+    };
+    *next_id += 1;
+    messages.push(msg.clone());
+    HttpResponse::Created().json(msg)
+}
+
+async fn delete_message(
+    data: web::Data<AppState>,
+    path: web::Path<u32>,
+) -> impl Responder {
+    let id = path.into_inner();
+    let mut messages = data.messages.lock().unwrap();
+    if let Some(pos) = messages.iter().position(|m| m.id == id) {
+        messages.remove(pos);
+        HttpResponse::NoContent().finish()
+    } else {
+        HttpResponse::NotFound().json(serde_json::json!({"error": "not found"}))
+    }
+}
+
+async fn health() -> impl Responder {
+    HttpResponse::Ok().json(serde_json::json!({"status": "ok"}))
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let data = web::Data::new(AppState {
+        messages: Mutex::new(Vec::new()),
+        next_id: Mutex::new(1),
+    });
+
+    println!("Server running on port 3000");
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(data.clone())
+            .route("/", web::get().to(index))
+            .route("/health", web::get().to(health))
+            .route("/api/messages", web::get().to(list_messages))
+            .route("/api/messages", web::post().to(create_message))
+            .route("/api/messages/{id}", web::delete().to(delete_message))
+    })
+    .bind("0.0.0.0:3000")?
+    .run()
+    .await
+}
+
+const INDEX_HTML: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rust Actix on ConoHa</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 700px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f5f5f5;
+      color: #333;
+    }
+    h1 { margin-bottom: 1rem; }
+    .msg { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 0.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .form-box { background: #fff; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; display: flex; gap: 0.5rem; }
+    input { flex: 1; padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; }
+    button { padding: 0.5rem 1.5rem; background: #b7410e; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .delete { background: #d32f2f; font-size: 0.85rem; padding: 0.3rem 0.8rem; }
+  </style>
+</head>
+<body>
+  <h1>Rust Actix on ConoHa</h1>
+  <div class="form-box">
+    <input type="text" id="input" placeholder="Type a message..." required>
+    <button onclick="send()">Send</button>
+  </div>
+  <div id="list"></div>
+  <script>
+    async function load() {
+      const res = await fetch("/api/messages");
+      const msgs = await res.json();
+      document.getElementById("list").innerHTML = msgs.map(m =>
+        '<div class="msg"><span>' + m.text + '</span>' +
+        '<button class="delete" onclick="del(' + m.id + ')">Delete</button></div>'
+      ).join("");
+    }
+    async function send() {
+      const input = document.getElementById("input");
+      const text = input.value.trim();
+      if (!text) return;
+      await fetch("/api/messages", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({text})
+      });
+      input.value = "";
+      load();
+    }
+    async function del(id) {
+      await fetch("/api/messages/" + id, {method: "DELETE"});
+      load();
+    }
+    document.getElementById("input").addEventListener("keydown", e => {
+      if (e.key === "Enter") send();
+    });
+    load();
+  </script>
+</body>
+</html>"#;
+```
+
+- [ ] **Step 3: Create rust-actix-web/Dockerfile**
+
+```dockerfile
+# Stage 1: Build
+FROM rust:1.86-alpine AS builder
+WORKDIR /app
+RUN apk add --no-cache musl-dev
+COPY Cargo.toml ./
+RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src
+COPY src ./src
+RUN touch src/main.rs && cargo build --release
+
+# Stage 2: Production runner
+FROM alpine:3.21
+WORKDIR /app
+COPY --from=builder /app/target/release/conoha-rust-sample ./server
+EXPOSE 3000
+CMD ["./server"]
+```
+
+- [ ] **Step 4: Create rust-actix-web/compose.yml**
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+```
+
+- [ ] **Step 5: Create rust-actix-web/.dockerignore**
+
+```
+README.md
+.git
+target
+```
+
+- [ ] **Step 6: Create rust-actix-web/README.md**
+
+```markdown
+# rust-actix-web
+
+Rust と Actix-web で構築した高速 REST API サーバーです。インメモリでメッセージの CRUD を行います。
+
+## 構成
+
+- Rust 1.86 + Actix-web 4
+- ポート: 3000
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name rust-api
+
+# デプロイ
+conoha app deploy myserver --app-name rust-api
+```
+
+初回ビルドは Rust コンパイルに数分かかります。2回目以降はキャッシュで高速化されます。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:3000` にアクセスするとメッセージボードが表示されます。
+
+API エンドポイント:
+- `GET /api/messages` — メッセージ一覧
+- `POST /api/messages` — メッセージ作成（`{"text": "hello"}`）
+- `DELETE /api/messages/:id` — メッセージ削除
+- `GET /health` — ヘルスチェック
+
+## カスタマイズ
+
+- `src/main.rs` にルートを追加して機能を拡張
+- データベースを追加する場合は Diesel や SQLx を導入
+- バイナリサイズが非常に小さくメモリ効率が高い
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add rust-actix-web/
+git commit -m "Add Rust Actix-web sample (high-performance REST API)"
+```
+
+---
+
+### Task 6: Update root README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add 5 new rows to the samples table**
+
+Add after the django-postgresql row:
+
+```markdown
+| [vite-react](vite-react/) | Vite + React (静的SPA) | カウンターアプリ | g2l-t-1 (1GB) |
+| [sveltekit](sveltekit/) | SvelteKit (SSR) | カウンターアプリ | g2l-t-2 (2GB) |
+| [go-fiber](go-fiber/) | Go + Fiber | 高速 REST API | g2l-t-1 (1GB) |
+| [nestjs-postgresql](nestjs-postgresql/) | NestJS + PostgreSQL | TypeORM CRUD アプリ | g2l-t-2 (2GB) |
+| [rust-actix-web](rust-actix-web/) | Rust + Actix-web | 高速 REST API | g2l-t-2 (2GB) |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git add README.md
+git commit -m "Update root README with Tier 2 samples"
+```
+
+---
+
+### Task 7: Push to GitHub
+
+- [ ] **Step 1: Push all new commits**
+
+```bash
+cd /home/tkim/dev/crowdy/conoha-cli-app-samples
+git push origin main
+```

--- a/docs/superpowers/specs/2026-03-31-app-samples-design.md
+++ b/docs/superpowers/specs/2026-03-31-app-samples-design.md
@@ -1,0 +1,189 @@
+# conoha-cli-app-samples Design
+
+## Overview
+
+`github.com/crowdy/conoha-cli-app-samples` — `conoha app deploy`用のサンプルアプリ集。各サンプルはそのまま`cd`して`conoha app deploy`できる独立したディレクトリ。
+
+**Goals:**
+- `conoha app deploy`の使い方を実際のコードで示す
+- 各種フレームワークのDockerfile + compose.ymlのリファレンス
+- 最小限のアプリコードで、デプロイフローにフォーカス
+
+**Repository:** `github.com/crowdy/conoha-cli-app-samples` (public)
+**Local path:** `/home/tkim/dev/crowdy/conoha-cli-app-samples`
+**Language:** 日本語（README、コメント）
+**License:** MIT
+
+## Repo Structure
+
+```
+crowdy/conoha-cli-app-samples/
+├── README.md                    # リポ全体の説明・使い方
+├── LICENSE                      # MIT
+├── hello-world/                 # 最小サンプル（nginx静的HTML）
+│   ├── README.md
+│   ├── compose.yml
+│   ├── Dockerfile
+│   ├── .dockerignore
+│   └── index.html
+├── nextjs/                      # Next.js デフォルトページ
+│   ├── README.md
+│   ├── compose.yml
+│   ├── Dockerfile
+│   ├── .dockerignore
+│   └── (Next.js minimal source)
+├── fastapi-ai-chatbot/          # FastAPI + Ollama
+│   ├── README.md
+│   ├── compose.yml
+│   ├── Dockerfile
+│   ├── .dockerignore
+│   └── (Python source)
+├── rails-postgresql/            # Rails scaffold + PostgreSQL
+│   ├── README.md
+│   ├── compose.yml
+│   ├── Dockerfile
+│   ├── .dockerignore
+│   └── (Rails minimal source)
+└── wordpress-mysql/             # WordPress + MySQL
+    ├── README.md
+    ├── compose.yml
+    └── .dockerignore
+```
+
+## Deploy Flow
+
+All samples follow the same flow:
+
+```bash
+# 1. サーバー作成（まだない場合）
+conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+
+# 2. アプリ初期化（Docker + git bare repoのセットアップ）
+conoha app init myserver --app-name <sample-name>
+
+# 3. サンプルディレクトリに移動してデプロイ
+cd <sample-name>
+conoha app deploy myserver --app-name <sample-name>
+
+# 4. 動作確認
+conoha app logs myserver --app-name <sample-name>
+```
+
+## Sample Specifications
+
+### hello-world
+
+最もシンプルなサンプル。初めて`conoha app deploy`を試すユーザー向け。
+
+- **Stack:** nginx + 静的HTML
+- **Port:** 80
+- **Dockerfile:** nginx:alpine、index.htmlをCOPY
+- **compose.yml:** 単一コンテナ、port 80:80
+- **推奨フレーバー:** g2l-t-1（1GB RAM）
+
+### nextjs
+
+Next.jsのデフォルトページをデプロイ。
+
+- **Stack:** Node.js + Next.js (standalone output)
+- **Port:** 3000
+- **Dockerfile:** マルチステージビルド（deps → build → runner）、standalone output mode
+- **compose.yml:** 単一コンテナ、port 3000:3000
+- **ソース:** `create-next-app`のデフォルトページ相当（最小限）
+- **推奨フレーバー:** g2l-t-2（2GB RAM）
+
+### fastapi-ai-chatbot
+
+FastAPI + OllamaでシンプルなAIチャットボット。
+
+- **Stack:** Python + FastAPI + Ollama
+- **Port:** 8000（FastAPI）、11434（Ollama internal）
+- **Dockerfile:** python:3.12-slim、pip install
+- **compose.yml:** 2コンテナ（app + ollama）、depends_on
+- **ソース:** `/chat`エンドポイント1つ、Ollamaにプロキシ、シンプルなHTML UI
+- **推奨フレーバー:** g2l-t-4（4GB RAM、LLM用）
+- **モデル:** tinyllama（軽量、デモ用）
+
+### rails-postgresql
+
+Rails scaffoldで最小限のWebアプリ。
+
+- **Stack:** Ruby + Rails + PostgreSQL
+- **Port:** 3000
+- **Dockerfile:** ruby:3.3-slim、bundle install、assets precompile
+- **compose.yml:** 2コンテナ（web + db）、depends_on、volume for db data
+- **ソース:** `rails new` + 1つのscaffold（例: Post）
+- **entrypoint:** DB migration自動実行（`rails db:prepare`）
+- **推奨フレーバー:** g2l-t-2（2GB RAM）
+
+### wordpress-mysql
+
+WordPress + MySQL。Dockerfileなし、公式イメージのみ。
+
+- **Stack:** WordPress (official) + MySQL (official)
+- **Port:** 80
+- **Dockerfile:** なし（公式イメージを直接使用）
+- **compose.yml:** 2コンテナ（wordpress + db）、volumes for wp-content and db data、environment variables
+- **推奨フレーバー:** g2l-t-2（2GB RAM）
+- **備考:** `.env.server`でDB password等を設定する使い方を示す
+
+## Each Sample README Structure
+
+```markdown
+# <Sample Name>
+
+<1行説明>
+
+## 構成
+
+- <stack components>
+- ポート: <port>
+
+## 前提条件
+
+- conoha-cli がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キーペア設定済み
+
+## デプロイ
+
+​```bash
+# サーバー作成（まだない場合）
+conoha server create --name myserver --flavor <recommended> --image ubuntu-24.04 --key mykey
+
+# アプリ初期化
+conoha app init myserver --app-name <name>
+
+# デプロイ
+conoha app deploy myserver --app-name <name>
+​```
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:<port>` にアクセス。
+
+## カスタマイズ
+
+<フレームワーク固有のカスタマイズポイント>
+```
+
+## Root README Structure
+
+1. **このリポジトリについて** — conoha-cli app deploy用サンプルアプリ集の説明
+2. **前提条件** — conoha-cli, ConoHa VPS3 account, SSH keypair
+3. **使い方** — 共通デプロイフロー（server create → app init → app deploy）
+4. **サンプル一覧** — テーブル（名前、スタック、説明、推奨フレーバー）
+5. **自分のアプリをデプロイするには** — compose.yml + DockerfileがあればOKという説明
+6. **関連リンク** — conoha-cli本体、ドキュメントサイト
+
+## .env.server Integration
+
+WordPress等、環境変数でシークレットを渡す必要があるサンプルでは、`.env.server`の使い方を説明:
+
+```bash
+# サーバー上に環境変数ファイルを配置
+conoha app env set myserver --app-name wordpress MYSQL_ROOT_PASSWORD=secret
+conoha app env set myserver --app-name wordpress MYSQL_DATABASE=wordpress
+```
+
+deploy時に`/opt/conoha/<app-name>.env.server`が存在すれば、自動的に`.env`としてコピーされる。

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -17,9 +17,13 @@ func (f *CSVFormatter) Format(w io.Writer, data any) error {
 		val = val.Elem()
 	}
 
-	// Handle slice of structs
+	// Handle single struct by wrapping as one-element slice
 	if val.Kind() != reflect.Slice {
-		return fmt.Errorf("csv formatter requires a slice, got %T", data)
+		if val.Kind() == reflect.Struct {
+			val = reflect.Append(reflect.MakeSlice(reflect.SliceOf(val.Type()), 0, 1), val)
+		} else {
+			return fmt.Errorf("csv formatter requires a struct or slice, got %T", data)
+		}
 	}
 	if val.Len() == 0 {
 		return nil

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -96,12 +96,23 @@ func TestCSVFormatter(t *testing.T) {
 	}
 }
 
-func TestCSVFormatterNonSlice(t *testing.T) {
+func TestCSVFormatterSingleStruct(t *testing.T) {
 	var buf bytes.Buffer
 	f := &CSVFormatter{}
 	err := f.Format(&buf, testItem{Name: "a", Value: 1})
-	if err == nil {
-		t.Error("expected error for non-slice input")
+	if err != nil {
+		t.Fatalf("Format() error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (header + 1 row), got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "name") {
+		t.Errorf("expected header with 'name', got: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "a") {
+		t.Errorf("expected data with 'a', got: %s", lines[1])
 	}
 }
 

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -161,6 +161,45 @@ func TestNewWithOptions(t *testing.T) {
 	}
 }
 
+func TestTableFormatterSingleStruct(t *testing.T) {
+	var buf bytes.Buffer
+	f := &TableFormatter{}
+	data := testItem{Name: "server1", Value: 100}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format() error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "NAME") {
+		t.Errorf("expected header NAME, got: %s", out)
+	}
+	if !strings.Contains(out, "server1") {
+		t.Errorf("expected 'server1' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "100") {
+		t.Errorf("expected '100' in output, got: %s", out)
+	}
+}
+
+func TestTableFormatterSingleStructPointer(t *testing.T) {
+	var buf bytes.Buffer
+	f := &TableFormatter{}
+	data := &testItem{Name: "server2", Value: 200}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format() error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "NAME") {
+		t.Errorf("expected header NAME, got: %s", out)
+	}
+	if !strings.Contains(out, "server2") {
+		t.Errorf("expected 'server2' in output, got: %s", out)
+	}
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		format string

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -18,10 +18,14 @@ func (f *TableFormatter) Format(w io.Writer, data any) error {
 		val = val.Elem()
 	}
 
-	// If not a slice, just print the value
+	// If not a slice, wrap single struct as one-row table
 	if val.Kind() != reflect.Slice {
-		_, err := fmt.Fprintf(w, "%v\n", data)
-		return err
+		if val.Kind() == reflect.Struct {
+			val = reflect.Append(reflect.MakeSlice(reflect.SliceOf(val.Type()), 0, 1), val)
+		} else {
+			_, err := fmt.Fprintf(w, "%v\n", data)
+			return err
+		}
 	}
 
 	if val.Len() == 0 {


### PR DESCRIPTION
## Summary
- Fix table formatter to properly render single struct results instead of raw Go struct dumps
- Affected commands: `security-group create`, `security-group show`, `security-group-rule create`
- Add tests for single struct and pointer-to-struct table formatting

## Root Cause
`TableFormatter.Format()` used `fmt.Sprintf("%v")` for non-slice data, producing output like `&{id name ...}` instead of a formatted table.

## Fix
When data is a single struct (or pointer to struct), wrap it as a one-element slice so it renders with headers and tabwriter formatting, consistent with list commands.

Fixes #39

## Test plan
- [x] New tests: `TestTableFormatterSingleStruct`, `TestTableFormatterSingleStructPointer`
- [x] All existing tests pass (`make test`)
- [x] Lint clean (`make lint`)