### PR TITLE
Detect duplicate server names in FindServer

### DIFF
--- a/internal/api/compute.go
+++ b/internal/api/compute.go
@@ -57,23 +57,30 @@ func (a *ComputeAPI) FindServer(idOrName string) (*model.Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	var nameMatched []*model.Server
 	for i := range servers {
 		if servers[i].Name == idOrName {
-			return &servers[i], nil
+			nameMatched = append(nameMatched, &servers[i])
 		}
+	}
+	if len(nameMatched) == 1 {
+		return nameMatched[0], nil
+	}
+	if len(nameMatched) > 1 {
+		return nil, fmt.Errorf("multiple servers found with name %q, use UUID instead", idOrName)
 	}
 
 	// Search by nametag (instance_name_tag metadata)
-	var matched []*model.Server
+	var tagMatched []*model.Server
 	for i := range servers {
 		if tag, ok := servers[i].Metadata["instance_name_tag"]; ok && tag == idOrName {
-			matched = append(matched, &servers[i])
+			tagMatched = append(tagMatched, &servers[i])
 		}
 	}
-	if len(matched) == 1 {
-		return matched[0], nil
+	if len(tagMatched) == 1 {
+		return tagMatched[0], nil
 	}
-	if len(matched) > 1 {
+	if len(tagMatched) > 1 {
 		return nil, fmt.Errorf("multiple servers found with nametag %q, use UUID instead", idOrName)
 	}
 

--- a/internal/api/compute_test.go
+++ b/internal/api/compute_test.go
@@ -189,6 +189,37 @@ func TestFindServer(t *testing.T) {
 		}
 	})
 
+	t.Run("duplicate name returns error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"servers": []map[string]any{
+					{
+						"id":     "srv-dup-1",
+						"name":   "dup-name",
+						"status": "ACTIVE",
+					},
+					{
+						"id":     "srv-dup-2",
+						"name":   "dup-name",
+						"status": "ACTIVE",
+					},
+				},
+			})
+		}))
+		defer ts.Close()
+		t.Setenv("CONOHA_ENDPOINT", ts.URL)
+
+		api := NewComputeAPI(newTestClient(ts))
+		_, err := api.FindServer("dup-name")
+		if err == nil {
+			t.Fatal("expected error for duplicate name, got nil")
+		}
+		if !strings.Contains(err.Error(), "multiple servers found with name") {
+			t.Errorf("expected 'multiple servers found with name' in error, got: %v", err)
+		}
+	})
+
 	t.Run("duplicate nametag returns error", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Closes #45

## Summary
- Apply duplicate-detection pattern (already used for nametag) to name matching in `FindServer`
- If multiple servers share the same name, return error: `"multiple servers found with name %q, use UUID instead"`
- Add test for duplicate name detection

## Test plan
- [x] Existing FindServer tests pass (by UUID, by name, by nametag, name-wins-over-nametag, duplicate nametag)
- [x] New "duplicate name returns error" test passes
- [x] `go test ./...` all pass
- [x] `golangci-lint` clean