### PR TITLE
Include server IDs in duplicate name/nametag errors

### DIFF
--- a/internal/api/compute.go
+++ b/internal/api/compute.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/crowdy/conoha-cli/internal/model"
 )
@@ -67,7 +68,11 @@ func (a *ComputeAPI) FindServer(idOrName string) (*model.Server, error) {
 		return nameMatched[0], nil
 	}
 	if len(nameMatched) > 1 {
-		return nil, fmt.Errorf("multiple servers found with name %q, use UUID instead", idOrName)
+		ids := make([]string, len(nameMatched))
+		for i, s := range nameMatched {
+			ids[i] = s.ID
+		}
+		return nil, fmt.Errorf("multiple servers found with name %q (%s), use UUID instead", idOrName, strings.Join(ids, ", "))
 	}
 
 	// Search by nametag (instance_name_tag metadata)
@@ -81,7 +86,11 @@ func (a *ComputeAPI) FindServer(idOrName string) (*model.Server, error) {
 		return tagMatched[0], nil
 	}
 	if len(tagMatched) > 1 {
-		return nil, fmt.Errorf("multiple servers found with nametag %q, use UUID instead", idOrName)
+		ids := make([]string, len(tagMatched))
+		for i, s := range tagMatched {
+			ids[i] = s.ID
+		}
+		return nil, fmt.Errorf("multiple servers found with nametag %q (%s), use UUID instead", idOrName, strings.Join(ids, ", "))
 	}
 
 	// Fall back to ID lookup (in case it's a short/non-UUID ID)

--- a/internal/api/compute_test.go
+++ b/internal/api/compute_test.go
@@ -218,6 +218,9 @@ func TestFindServer(t *testing.T) {
 		if !strings.Contains(err.Error(), "multiple servers found with name") {
 			t.Errorf("expected 'multiple servers found with name' in error, got: %v", err)
 		}
+		if !strings.Contains(err.Error(), "srv-dup-1") || !strings.Contains(err.Error(), "srv-dup-2") {
+			t.Errorf("expected server IDs in error, got: %v", err)
+		}
 	})
 
 	t.Run("duplicate nametag returns error", func(t *testing.T) {
@@ -254,6 +257,9 @@ func TestFindServer(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "multiple servers") {
 			t.Errorf("expected 'multiple servers' in error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "srv-dup-1") || !strings.Contains(err.Error(), "srv-dup-2") {
+			t.Errorf("expected server IDs in error, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Closes #46

## Summary
- When duplicate servers match by name or nametag, include matching server IDs in the error message
- Before: `multiple servers found with nametag "my-tag", use UUID instead`
- After: `multiple servers found with nametag "my-tag" (srv-dup-1, srv-dup-2), use UUID instead`
- Applied to both name and nametag duplicate errors

## Test plan
- [x] Updated existing duplicate name/nametag tests to verify IDs appear in error messages
- [x] All FindServer tests pass
- [x] `go test ./...` all pass
- [x] `golangci-lint` clean