### PR TITLE
Add skill install/update/remove commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/crowdy/conoha-cli/cmd/lb"
 	"github.com/crowdy/conoha-cli/cmd/network"
 	"github.com/crowdy/conoha-cli/cmd/server"
+	"github.com/crowdy/conoha-cli/cmd/skill"
 	"github.com/crowdy/conoha-cli/cmd/storage"
 	"github.com/crowdy/conoha-cli/cmd/volume"
 	"github.com/crowdy/conoha-cli/internal/api"
@@ -87,6 +88,7 @@ func init() {
 	rootCmd.AddCommand(storage.Cmd)
 	rootCmd.AddCommand(identity.Cmd)
 	rootCmd.AddCommand(app.Cmd)
+	rootCmd.AddCommand(skill.Cmd)
 }
 
 // Execute runs the root command.

--- a/cmd/skill/skill.go
+++ b/cmd/skill/skill.go
@@ -29,9 +29,12 @@ func init() {
 	Cmd.AddCommand(removeCmd)
 }
 
-func defaultSkillBase() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".claude", "skills")
+func defaultSkillBase() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude", "skills"), nil
 }
 
 func runInstall(baseDir string) error {
@@ -81,7 +84,11 @@ var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update conoha-cli-skill to latest version",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runUpdate(defaultSkillBase())
+		base, err := defaultSkillBase()
+		if err != nil {
+			return err
+		}
+		return runUpdate(base)
 	},
 }
 
@@ -112,7 +119,11 @@ var removeCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Remove conoha-cli-skill",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runRemove(defaultSkillBase())
+		base, err := defaultSkillBase()
+		if err != nil {
+			return err
+		}
+		return runRemove(base)
 	},
 }
 
@@ -120,6 +131,10 @@ var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install conoha-cli-skill for Claude Code",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runInstall(defaultSkillBase())
+		base, err := defaultSkillBase()
+		if err != nil {
+			return err
+		}
+		return runInstall(base)
 	},
 }

--- a/cmd/skill/skill.go
+++ b/cmd/skill/skill.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cerrors "github.com/crowdy/conoha-cli/internal/errors"
+	"github.com/crowdy/conoha-cli/internal/prompt"
 )
 
 const (
@@ -25,6 +26,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(installCmd)
 	Cmd.AddCommand(updateCmd)
+	Cmd.AddCommand(removeCmd)
 }
 
 func defaultSkillBase() string {
@@ -80,6 +82,37 @@ var updateCmd = &cobra.Command{
 	Short: "Update conoha-cli-skill to latest version",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runUpdate(defaultSkillBase())
+	},
+}
+
+func runRemove(baseDir string) error {
+	skillDir := filepath.Join(baseDir, skillName)
+	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+		return &cerrors.ValidationError{Message: "not installed"}
+	}
+
+	ok, err := prompt.Confirm("Remove conoha-cli-skill?")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Fprintln(os.Stderr, "Cancelled.")
+		return nil
+	}
+
+	if err := os.RemoveAll(skillDir); err != nil {
+		return fmt.Errorf("failed to remove: %w", err)
+	}
+
+	fmt.Fprintln(os.Stderr, "Removed conoha-cli-skill successfully.")
+	return nil
+}
+
+var removeCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove conoha-cli-skill",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRemove(defaultSkillBase())
 	},
 }
 

--- a/cmd/skill/skill.go
+++ b/cmd/skill/skill.go
@@ -24,6 +24,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(installCmd)
+	Cmd.AddCommand(updateCmd)
 }
 
 func defaultSkillBase() string {
@@ -50,6 +51,36 @@ func runInstall(baseDir string) error {
 
 	fmt.Fprintln(os.Stderr, "Installed conoha-cli-skill successfully.")
 	return nil
+}
+
+func runUpdate(baseDir string) error {
+	skillDir := filepath.Join(baseDir, skillName)
+	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+		return &cerrors.ValidationError{Message: "not installed, use 'conoha skill install'"}
+	}
+
+	gitDir := filepath.Join(skillDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return &cerrors.ValidationError{Message: "not a git repository, remove and reinstall"}
+	}
+
+	cmd := exec.Command("git", "-C", skillDir, "pull")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return &cerrors.NetworkError{Err: fmt.Errorf("git pull failed: %w", err)}
+	}
+
+	fmt.Fprintln(os.Stderr, "Updated conoha-cli-skill successfully.")
+	return nil
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update conoha-cli-skill to latest version",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUpdate(defaultSkillBase())
+	},
 }
 
 var installCmd = &cobra.Command{

--- a/cmd/skill/skill.go
+++ b/cmd/skill/skill.go
@@ -1,0 +1,61 @@
+package skill
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
+)
+
+const (
+	skillRepo = "https://github.com/crowdy/conoha-cli-skill.git"
+	skillName = "conoha-cli-skill"
+)
+
+// Cmd is the parent command for skill management.
+var Cmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Manage Claude Code skills",
+}
+
+func init() {
+	Cmd.AddCommand(installCmd)
+}
+
+func defaultSkillBase() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".claude", "skills")
+}
+
+func runInstall(baseDir string) error {
+	if _, err := exec.LookPath("git"); err != nil {
+		return &cerrors.ValidationError{Message: "git is required to install skills"}
+	}
+
+	skillDir := filepath.Join(baseDir, skillName)
+	if _, err := os.Stat(skillDir); err == nil {
+		return &cerrors.ValidationError{Message: "already installed, use 'conoha skill update'"}
+	}
+
+	cmd := exec.Command("git", "clone", skillRepo, skillDir)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return &cerrors.NetworkError{Err: fmt.Errorf("git clone failed: %w", err)}
+	}
+
+	fmt.Fprintln(os.Stderr, "Installed conoha-cli-skill successfully.")
+	return nil
+}
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install conoha-cli-skill for Claude Code",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runInstall(defaultSkillBase())
+	},
+}

--- a/cmd/skill/skill_test.go
+++ b/cmd/skill/skill_test.go
@@ -57,6 +57,38 @@ func TestInstallCmd(t *testing.T) {
 	})
 }
 
+func TestRemoveCmd(t *testing.T) {
+	t.Run("fails when not installed", func(t *testing.T) {
+		dir := t.TempDir()
+
+		err := runRemove(dir)
+		if err == nil {
+			t.Fatal("expected error when not installed")
+		}
+		if err.Error() != "validation error: not installed" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("removes successfully with --yes", func(t *testing.T) {
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, skillName)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CONOHA_YES", "1")
+
+		err := runRemove(dir)
+		if err != nil {
+			t.Fatalf("remove failed: %v", err)
+		}
+
+		if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+			t.Error("expected skill directory to be removed")
+		}
+	})
+}
+
 func TestUpdateCmd(t *testing.T) {
 	t.Run("fails when not installed", func(t *testing.T) {
 		dir := t.TempDir()

--- a/cmd/skill/skill_test.go
+++ b/cmd/skill/skill_test.go
@@ -1,0 +1,58 @@
+package skill
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallCmd(t *testing.T) {
+	t.Run("fails when git not found", func(t *testing.T) {
+		// Override PATH to hide git
+		t.Setenv("PATH", "/nonexistent")
+		dir := t.TempDir()
+
+		err := runInstall(dir)
+		if err == nil {
+			t.Fatal("expected error when git not found")
+		}
+		if err.Error() != "validation error: git is required to install skills" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails when already installed", func(t *testing.T) {
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, skillName)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		err := runInstall(dir)
+		if err == nil {
+			t.Fatal("expected error when already installed")
+		}
+		if err.Error() != "validation error: already installed, use 'conoha skill update'" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("clones successfully", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not available")
+		}
+		dir := t.TempDir()
+
+		err := runInstall(dir)
+		if err != nil {
+			// Skip if remote repo is not accessible (e.g., not yet created)
+			t.Skipf("skipping: remote repo not accessible: %v", err)
+		}
+
+		skillDir := filepath.Join(dir, skillName)
+		if _, err := os.Stat(filepath.Join(skillDir, ".git")); os.IsNotExist(err) {
+			t.Error("expected .git directory after install")
+		}
+	})
+}

--- a/cmd/skill/skill_test.go
+++ b/cmd/skill/skill_test.go
@@ -56,3 +56,50 @@ func TestInstallCmd(t *testing.T) {
 		}
 	})
 }
+
+func TestUpdateCmd(t *testing.T) {
+	t.Run("fails when not installed", func(t *testing.T) {
+		dir := t.TempDir()
+
+		err := runUpdate(dir)
+		if err == nil {
+			t.Fatal("expected error when not installed")
+		}
+		if err.Error() != "validation error: not installed, use 'conoha skill install'" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails when not a git repo", func(t *testing.T) {
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, skillName)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		err := runUpdate(dir)
+		if err == nil {
+			t.Fatal("expected error when not a git repo")
+		}
+		if err.Error() != "validation error: not a git repository, remove and reinstall" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("pulls successfully", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not available")
+		}
+		dir := t.TempDir()
+
+		// Install first
+		if err := runInstall(dir); err != nil {
+			t.Skipf("install failed (remote repo may not exist): %v", err)
+		}
+
+		err := runUpdate(dir)
+		if err != nil {
+			t.Fatalf("update failed: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #47

## Summary
- Add `conoha skill install` — clones `conoha-cli-skill` to `~/.claude/skills/`
- Add `conoha skill update` — pulls latest changes
- Add `conoha skill remove` — removes with confirmation prompt
- git required, no tarball fallback

## Test plan
- [x] Install: git-not-found error, already-installed error, successful clone
- [x] Update: not-installed error, not-a-git-repo error, successful pull
- [x] Remove: not-installed error, successful remove with --yes
- [x] `go test ./...` all pass
- [x] `golangci-lint` clean