### PR TITLE
Add app reset command

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -112,7 +112,9 @@ conoha server rename <server-id-or-name> new-name
 
 ## Claude Code Skill
 
-ConoHa CLI includes infrastructure automation skills for Claude Code. Once installed, you can use natural language to manage infrastructure — e.g., "Create a server on ConoHa" or "Set up a k8s cluster."
+ConoHa CLI includes infrastructure automation skills for Claude Code. Once installed, you can use natural language to manage infrastructure.
+
+### Installation
 
 ```bash
 # Install the skill
@@ -125,12 +127,25 @@ conoha skill update
 conoha skill remove
 ```
 
-Included recipes:
-- Docker Compose app deployment
-- Custom script deployment
-- Kubernetes cluster (k3s)
-- OpenStack platform setup
-- Slurm HPC cluster setup
+### Usage
+
+Simply give instructions in Claude Code, and the skill will be triggered automatically:
+
+```
+> Create a server on ConoHa
+> Set up a k8s cluster
+> Deploy an app
+```
+
+### Recipe List
+
+| Recipe | Description |
+|--------|-------------|
+| Docker Compose App Deploy | Deploy containerized apps via `conoha app deploy` |
+| Custom Script Deploy | Server provisioning with startup scripts |
+| Kubernetes Cluster | k3s cluster setup (coming soon) |
+| OpenStack Platform | DevStack platform setup (coming soon) |
+| Slurm HPC Cluster | Slurm HPC cluster setup (coming soon) |
 
 See [conoha-cli-skill](https://github.com/crowdy/conoha-cli-skill) for details.
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -112,7 +112,9 @@ conoha server rename <server-id-or-name> new-name
 
 ## Claude Code 스킬
 
-ConoHa CLI에는 Claude Code용 인프라 구축 스킬이 포함되어 있습니다. 설치하면 Claude Code에서 "ConoHa에 서버 만들어줘", "k8s 클러스터 구축해줘" 등 자연어로 인프라 구축을 지시할 수 있습니다.
+ConoHa CLI에는 Claude Code용 인프라 구축 스킬이 포함되어 있습니다. 설치하면 Claude Code에서 자연어로 인프라 구축을 지시할 수 있습니다.
+
+### 설치
 
 ```bash
 # 스킬 설치
@@ -125,12 +127,25 @@ conoha skill update
 conoha skill remove
 ```
 
-포함된 레시피:
-- Docker Compose 앱 배포
-- 커스텀 스크립트 배포
-- Kubernetes 클러스터 (k3s) 구축
-- OpenStack 플랫폼 구축
-- Slurm HPC 클러스터 구축
+### 사용법
+
+Claude Code에서 다음과 같이 지시하면 스킬이 자동으로 트리거됩니다:
+
+```
+> ConoHa에 서버 만들어줘
+> k8s 클러스터 구축해줘
+> 앱을 배포해줘
+```
+
+### 레시피 목록
+
+| 레시피 | 설명 |
+|--------|------|
+| Docker Compose 앱 배포 | `conoha app deploy`를 통한 컨테이너 앱 배포 |
+| 커스텀 스크립트 배포 | 스타트업 스크립트를 이용한 서버 구성 |
+| Kubernetes 클러스터 | k3s를 이용한 클러스터 구축 (coming soon) |
+| OpenStack 플랫폼 | DevStack을 이용한 플랫폼 구축 (coming soon) |
+| Slurm HPC 클러스터 | Slurm을 이용한 HPC 클러스터 구축 (coming soon) |
 
 자세한 내용은 [conoha-cli-skill](https://github.com/crowdy/conoha-cli-skill)을 참조하세요.
 

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -18,4 +18,5 @@ func init() {
 	Cmd.AddCommand(envCmd)
 	Cmd.AddCommand(destroyCmd)
 	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(resetCmd)
 }

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -26,55 +26,58 @@ var deployCmd = &cobra.Command{
 			return err
 		}
 		defer func() { _ = ctx.Client.Close() }()
-
-		// Pre-flight: check compose file exists locally
-		if !hasComposeFile(".") {
-			return fmt.Errorf("no docker-compose.yml/yaml or compose.yml/yaml found in current directory")
-		}
-
-		// Load .dockerignore
-		patterns, err := loadIgnorePatterns(".")
-		if err != nil {
-			return err
-		}
-
-		// Create tar.gz
-		fmt.Fprintf(os.Stderr, "Archiving current directory...\n")
-		var buf bytes.Buffer
-		if err := createTarGz(".", patterns, &buf); err != nil {
-			return fmt.Errorf("create archive: %w", err)
-		}
-		fmt.Fprintf(os.Stderr, "Uploading to %s (%s)...\n", ctx.Server.Name, ctx.IP)
-
-		// Transfer tar (clean deploy: remove old files first)
-		workDir := "/opt/conoha/" + ctx.AppName
-		tarCmd := fmt.Sprintf("rm -rf %s && mkdir -p %s && tar xzf - -C %s", workDir, workDir, workDir)
-		exitCode, err := internalssh.RunWithStdin(ctx.Client, tarCmd, &buf, os.Stdout, os.Stderr)
-		if err != nil {
-			return fmt.Errorf("upload failed: %w", err)
-		}
-		if exitCode != 0 {
-			return fmt.Errorf("upload exited with code %d", exitCode)
-		}
-
-		// Docker compose up (copy .env.server if exists)
-		fmt.Fprintf(os.Stderr, "Building and starting containers...\n")
-		composeCmd := fmt.Sprintf(
-			"ENV_FILE=/opt/conoha/%s.env.server; "+
-				"if [ -f \"$ENV_FILE\" ]; then cp \"$ENV_FILE\" %s/.env; fi && "+
-				"cd %s && docker compose up -d --build --remove-orphans && docker compose ps",
-			ctx.AppName, workDir, workDir)
-		exitCode, err = internalssh.RunCommand(ctx.Client, composeCmd, os.Stdout, os.Stderr)
-		if err != nil {
-			return fmt.Errorf("deploy failed: %w", err)
-		}
-		if exitCode != 0 {
-			return fmt.Errorf("deploy exited with code %d", exitCode)
-		}
-
-		fmt.Fprintf(os.Stderr, "Deploy complete.\n")
-		return nil
+		return deployApp(ctx)
 	},
+}
+
+func deployApp(ctx *appContext) error {
+	// Pre-flight: check compose file exists locally
+	if !hasComposeFile(".") {
+		return fmt.Errorf("no docker-compose.yml/yaml or compose.yml/yaml found in current directory")
+	}
+
+	// Load .dockerignore
+	patterns, err := loadIgnorePatterns(".")
+	if err != nil {
+		return err
+	}
+
+	// Create tar.gz
+	fmt.Fprintf(os.Stderr, "Archiving current directory...\n")
+	var buf bytes.Buffer
+	if err := createTarGz(".", patterns, &buf); err != nil {
+		return fmt.Errorf("create archive: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Uploading to %s (%s)...\n", ctx.Server.Name, ctx.IP)
+
+	// Transfer tar (clean deploy: remove old files first)
+	workDir := "/opt/conoha/" + ctx.AppName
+	tarCmd := fmt.Sprintf("rm -rf %s && mkdir -p %s && tar xzf - -C %s", workDir, workDir, workDir)
+	exitCode, err := internalssh.RunWithStdin(ctx.Client, tarCmd, &buf, os.Stdout, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("upload failed: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("upload exited with code %d", exitCode)
+	}
+
+	// Docker compose up (copy .env.server if exists)
+	fmt.Fprintf(os.Stderr, "Building and starting containers...\n")
+	composeCmd := fmt.Sprintf(
+		"ENV_FILE=/opt/conoha/%s.env.server; "+
+			"if [ -f \"$ENV_FILE\" ]; then cp \"$ENV_FILE\" %s/.env; fi && "+
+			"cd %s && docker compose up -d --build --remove-orphans && docker compose ps",
+		ctx.AppName, workDir, workDir)
+	exitCode, err = internalssh.RunCommand(ctx.Client, composeCmd, os.Stdout, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("deploy failed: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("deploy exited with code %d", exitCode)
+	}
+
+	fmt.Fprintf(os.Stderr, "Deploy complete.\n")
+	return nil
 }
 
 // hasComposeFile checks if a docker compose file exists in dir.

--- a/cmd/app/destroy.go
+++ b/cmd/app/destroy.go
@@ -12,6 +12,7 @@ import (
 
 func init() {
 	addAppFlags(destroyCmd)
+	destroyCmd.Flags().Bool("yes", false, "skip confirmation prompt")
 }
 
 var destroyCmd = &cobra.Command{
@@ -26,13 +27,16 @@ var destroyCmd = &cobra.Command{
 		}
 		defer func() { _ = ctx.Client.Close() }()
 
-		ok, err := prompt.Confirm(fmt.Sprintf("Destroy app %q on %s? All data will be deleted.", ctx.AppName, ctx.Server.Name))
-		if err != nil {
-			return err
-		}
-		if !ok {
-			fmt.Fprintln(os.Stderr, "Cancelled.")
-			return nil
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes {
+			ok, err := prompt.Confirm(fmt.Sprintf("Destroy app %q on %s? All data will be deleted.", ctx.AppName, ctx.Server.Name))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintln(os.Stderr, "Cancelled.")
+				return nil
+			}
 		}
 
 		script := generateDestroyScript(ctx.AppName)

--- a/cmd/app/destroy_test.go
+++ b/cmd/app/destroy_test.go
@@ -1,0 +1,15 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestDestroyCmd_HasYesFlag(t *testing.T) {
+	f := destroyCmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("destroy command should have --yes flag")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--yes default should be false, got %s", f.DefValue)
+	}
+}

--- a/cmd/app/reset.go
+++ b/cmd/app/reset.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/crowdy/conoha-cli/internal/prompt"
+	internalssh "github.com/crowdy/conoha-cli/internal/ssh"
+)
+
+func init() {
+	addAppFlags(resetCmd)
+	resetCmd.Flags().Bool("yes", false, "skip confirmation prompt")
+}
+
+var resetCmd = &cobra.Command{
+	Use:   "reset <id|name>",
+	Short: "Destroy and redeploy an app from scratch",
+	Long:  "Equivalent to running destroy + init + deploy in sequence. Stops containers, removes all app data, re-initializes the environment, and deploys the current directory.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, err := connectToApp(cmd, args)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = ctx.Client.Close() }()
+
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes {
+			ok, err := prompt.Confirm(fmt.Sprintf("Reset app %q on %s? This will destroy all data and redeploy.", ctx.AppName, ctx.Server.Name))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintln(os.Stderr, "Cancelled.")
+				return nil
+			}
+		}
+
+		// Step 1: Destroy
+		fmt.Fprintln(os.Stderr, "==> Destroying app...")
+		script := generateDestroyScript(ctx.AppName)
+		exitCode, err := internalssh.RunScript(ctx.Client, script, nil, os.Stdout, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("destroy failed: %w", err)
+		}
+		if exitCode != 0 {
+			return fmt.Errorf("destroy exited with code %d", exitCode)
+		}
+
+		// Step 2: Init
+		fmt.Fprintln(os.Stderr, "==> Re-initializing app...")
+		script = generateInitScript(ctx.AppName)
+		exitCode, err = internalssh.RunScript(ctx.Client, script, nil, os.Stdout, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("init failed: %w", err)
+		}
+		if exitCode != 0 {
+			return fmt.Errorf("init exited with code %d", exitCode)
+		}
+
+		// Step 3: Deploy
+		fmt.Fprintln(os.Stderr, "==> Deploying app...")
+		if err := deployApp(ctx); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(os.Stderr, "App %q reset complete.\n", ctx.AppName)
+		return nil
+	},
+}

--- a/cmd/app/reset.go
+++ b/cmd/app/reset.go
@@ -18,7 +18,7 @@ func init() {
 var resetCmd = &cobra.Command{
 	Use:   "reset <id|name>",
 	Short: "Destroy and redeploy an app from scratch",
-	Long:  "Equivalent to running destroy + init + deploy in sequence. Stops containers, removes all app data, re-initializes the environment, and deploys the current directory.",
+	Long:  "Equivalent to running destroy + init + deploy in sequence. Stops containers, removes all app data, re-initializes the environment, and deploys the current directory.\n\nNote: server-side environment variables (set via 'app env set') will be lost.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, err := connectToApp(cmd, args)

--- a/cmd/app/reset_test.go
+++ b/cmd/app/reset_test.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestResetCmd_HasYesFlag(t *testing.T) {
+	f := resetCmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("reset command should have --yes flag")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--yes default should be false, got %s", f.DefValue)
+	}
+}
+
+func TestResetCmd_HasAppFlags(t *testing.T) {
+	for _, name := range []string{"app-name", "user", "port", "identity"} {
+		if resetCmd.Flags().Lookup(name) == nil {
+			t.Errorf("reset command should have --%s flag", name)
+		}
+	}
+}
+
+func TestResetCmd_RequiresExactlyOneArg(t *testing.T) {
+	if resetCmd.Args == nil {
+		t.Fatal("reset command should have Args validation")
+	}
+}

--- a/cmd/app/reset_test.go
+++ b/cmd/app/reset_test.go
@@ -23,7 +23,13 @@ func TestResetCmd_HasAppFlags(t *testing.T) {
 }
 
 func TestResetCmd_RequiresExactlyOneArg(t *testing.T) {
-	if resetCmd.Args == nil {
-		t.Fatal("reset command should have Args validation")
+	if err := resetCmd.Args(resetCmd, []string{}); err == nil {
+		t.Error("should reject zero args")
+	}
+	if err := resetCmd.Args(resetCmd, []string{"server1"}); err != nil {
+		t.Errorf("should accept one arg: %v", err)
+	}
+	if err := resetCmd.Args(resetCmd, []string{"server1", "server2"}); err == nil {
+		t.Error("should reject two args")
 	}
 }

--- a/cmd/volume/volume_test.go
+++ b/cmd/volume/volume_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,6 +13,26 @@ import (
 
 	"github.com/crowdy/conoha-cli/internal/api"
 )
+
+// setupTestConfig creates a temporary config directory with a minimal config.yaml
+// so that cmdutil.NewClient() can find a profile in tests.
+func setupTestConfig(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := []byte("version: 1\nactive_profile: default\nprofiles:\n  default:\n    tenant_id: test-tenant\n    region: c3j1\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), cfg, 0600); err != nil {
+		t.Fatal(err)
+	}
+	creds := []byte("version: 1\ncredentials:\n  default:\n    username: test\n    password: test\n")
+	if err := os.WriteFile(filepath.Join(dir, "credentials.yaml"), creds, 0600); err != nil {
+		t.Fatal(err)
+	}
+	tokens := []byte("version: 1\ntokens:\n  default:\n    token: test-token\n    expires: \"2099-01-01T00:00:00Z\"\n")
+	if err := os.WriteFile(filepath.Join(dir, "tokens.yaml"), tokens, 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CONOHA_CONFIG_DIR", dir)
+}
 
 func newTestVolumeAPI(ts *httptest.Server) *api.VolumeAPI {
 	client := &api.Client{HTTP: ts.Client(), Token: "test-token", TenantID: "test-tenant"}
@@ -115,6 +137,7 @@ func TestFindVolume_NotFound(t *testing.T) {
 }
 
 func TestRenameCmd_Success(t *testing.T) {
+	setupTestConfig(t)
 	var updateBody map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/volumes/detail") && r.Method == http.MethodGet {
@@ -171,6 +194,7 @@ func TestRenameCmd_NoFlags(t *testing.T) {
 }
 
 func TestCreateCmd_DuplicateNameWarning(t *testing.T) {
+	setupTestConfig(t)
 	createCalled := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/volumes/detail") && r.Method == http.MethodGet {
@@ -211,6 +235,7 @@ func TestCreateCmd_DuplicateNameWarning(t *testing.T) {
 }
 
 func TestCreateCmd_NoDuplicate(t *testing.T) {
+	setupTestConfig(t)
 	createCalled := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/volumes/detail") && r.Method == http.MethodGet {
@@ -317,6 +342,7 @@ func TestResolveImageID_NotFound(t *testing.T) {
 }
 
 func TestCreateCmd_WithImage(t *testing.T) {
+	setupTestConfig(t)
 	var createBody map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/volumes/detail") && r.Method == http.MethodGet {

--- a/docs/articles/2026-04-05-note-conoha-cli.md
+++ b/docs/articles/2026-04-05-note-conoha-cli.md
@@ -1,0 +1,290 @@
+# CLIひとつでVPSデプロイ完了 — conoha-cliとClaude Code Skillで変わるインフラ構築
+
+## はじめに
+
+VPSでアプリケーションを動かそうとすると、意外とやることが多い。まず管理画面にログインしてサーバーを作り、SSHキーを設定し、ターミナルからサーバーに入って、OSのアップデートをかけ、Dockerをインストールし、Composeも入れて、ソースコードを転送して、ようやくビルドとデプロイ。ここまでたどり着くまでに何度もブラウザとターミナルを行き来することになる。
+
+もちろん、TerraformやAnsibleのようなIaCツールを使えばこの手順を自動化できる。しかし、個人開発や小規模なプロジェクトでは、これらのツールを導入するコスト自体がオーバーヘッドになりがちだ。HCLやYAMLのPlaybookを書き、ステートファイルを管理し、ディレクトリ構成を整え…。やりたいことは「自分のアプリをサーバーで動かす」だけなのに、そこに至るまでの道のりが長い。
+
+この記事では、そんな「ちょうどいいインフラ管理」を実現するCLIツール **conoha-cli** を紹介する。ConoHa VPS3のAPIに対応したGo製のコマンドラインツールで、サーバーの作成からアプリのデプロイ、運用管理までをターミナルから一貫して操作できる。さらに、Claude Codeの **skill** を導入すれば、自然言語でインフラ構築を指示することも可能だ。
+
+前半ではconoha-cliの概要とインストール方法を紹介し、後半では実際に筆者がサーバーを立ててアプリをデプロイした体験と、同じことをClaude Code Skillで自然言語から実行した体験を書いていく。CLIに慣れている人も、これからVPSを触ってみたい人も、AIツールに興味がある人も、それぞれの視点で楽しめる内容になっていると思う。
+
+## conoha-cliとは
+
+conoha-cliは、ConoHa VPS3のAPIをターミナルから操作するためのCLIツールだ。Goで書かれたシングルバイナリとして配布されているため、インストールはファイルをひとつ置くだけで完了する。macOS、Linux、Windowsに対応しており、環境を選ばない。
+
+認証まわりは、GitHub CLIの`gh auth`に似た設計になっている。`conoha auth login`を実行するとテナントID・ユーザー名・パスワードを聞かれるので、ConoHaの管理画面で発行した認証情報を入力すればよい。認証トークンはローカルに保存され、有効期限が切れる5分前に自動的に再認証が走るため、使っている途中でトークン切れに悩まされることがない。複数のConoHaアカウントを使っている場合は、`conoha auth switch`でプロファイルを切り替えられるので、検証環境と本番環境を分けて管理するのも簡単だ。
+
+出力フォーマットはデフォルトのテーブル表示のほか、JSON、YAML、CSVを選べる。たとえば`conoha server list --format json`とすればJSON形式で結果が返ってくるので、`jq`と組み合わせてスクリプトに組み込むことも容易だ。`--no-input`フラグをつければ対話プロンプトをすべて抑制でき、CIパイプラインやAIエージェントからの自動実行にも対応する。
+
+インストール方法はいくつか用意されている。macOSやLinuxならHomebrewが最も手軽だ。
+
+```bash
+brew install crowdy/tap/conoha
+```
+
+WindowsならScoopに対応している。
+
+```powershell
+scoop bucket add crowdy https://github.com/crowdy/crowdy-bucket
+scoop install conoha
+```
+
+Goの開発環境がある場合は、`go install`でもインストールできる。
+
+```bash
+go install github.com/crowdy/conoha-cli@latest
+```
+
+GitHub Releasesページからバイナリを直接ダウンロードする方法もある。いずれの方法でも、インストール後に`conoha auth login`で認証を通せば準備完了だ。
+
+```bash
+conoha auth login
+# テナントID、ユーザー名、パスワードを入力
+```
+
+ここまででセットアップは終わり。あとはターミナルからConoHaのリソースを自由に操作できる。
+
+## 体験記: CLIでサーバーを立ててアプリをデプロイしてみた
+
+ここからは、実際に筆者がconoha-cliを使ってゼロからアプリをデプロイした体験を書いていく。
+
+### サーバーを作る
+
+まず、どのスペックのサーバーを作るか決めるために、フレーバー（プラン）の一覧を確認してみた。
+
+```bash
+conoha flavor list
+```
+
+テーブル形式で利用可能なプランがずらっと表示される。vCPU数やメモリ、月額料金が一覧できるので、管理画面を開かなくてもプラン選びができる。今回は検証用なので、最小構成の`g2l-t-c2m1`（2vCPU / 1GB RAM）を選ぶことにした。
+
+次にOSイメージを確認する。
+
+```bash
+conoha image list
+```
+
+Ubuntu、AlmaLinux、その他さまざまなOSイメージが並んでいる。ここではUbuntu 24.04を使うことにした。
+
+SSHキーペアも必要だ。まだ登録していなかったので、ここで作成しておく。
+
+```bash
+conoha keypair create --name my-key
+```
+
+秘密鍵が標準出力に表示されるので、ファイルに保存しておく。これでサーバー作成の材料が揃った。
+
+```bash
+conoha server create --name my-app \
+  --flavor g2l-t-c2m1 \
+  --image <ubuntu-image-id> \
+  --key-name my-key \
+  --wait
+```
+
+`--wait`フラグをつけると、サーバーがACTIVE状態になるまでコマンドが待機してくれる。ターミナルでプログレスが表示され、1〜2分ほどでサーバーが立ち上がった。これは地味にありがたい。`--wait`なしだと即座にコマンドが返ってきて、`conoha server list`で自分でステータスを確認しに行く必要があるが、`--wait`をつければ「コマンドが返ってきた＝サーバーが使える」という状態になる。
+
+サーバーが立ち上がったら、SSHで接続してみる。
+
+```bash
+conoha server ssh my-app
+```
+
+ここで便利だと感じたのが、サーバーIDではなく名前で指定できること、そしてSSHキーの自動解決だ。キーペアの名前からローカルの秘密鍵パスを推測してくれるので、`-i`オプションでいちいちパスを指定する必要がない。普通にサーバーに入れた。
+
+### アプリをデプロイする
+
+SSHで入れることは確認できたが、ここからDockerを入れてアプリを動かすまでが本来は面倒なところだ。ところが、conoha-cliにはそれを一発で片付ける`app`コマンドが用意されている。
+
+まず、サーバーをアプリデプロイ用に初期化する。
+
+```bash
+conoha app init my-app --app-name myapp
+```
+
+このコマンドひとつで、サーバー上にDockerとDocker Composeがインストールされ、`/opt/conoha/myapp/`にワーキングディレクトリと、`/opt/conoha/myapp.git/`にbareリポジトリが作られる。gitのpost-receiveフックも自動設定されるので、gitプッシュによるデプロイ環境まで整う。手動でやったら15分はかかりそうな作業がワンコマンドだ。
+
+次に、デプロイするアプリを用意する。今回はシンプルなExpress.jsアプリを使った。まず`Dockerfile`を書く。
+
+```dockerfile
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --production
+COPY . .
+EXPOSE 3000
+CMD ["node", "index.js"]
+```
+
+そして`docker-compose.yml`はこうなる。
+
+```yaml
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+```
+
+ローカルにこの2つのファイルとアプリのソースコードがある状態で、デプロイコマンドを実行する。
+
+```bash
+conoha app deploy my-app --app-name myapp
+```
+
+実行すると、ローカルのカレントディレクトリがtarアーカイブとしてパッケージングされ、SSH経由でサーバーに転送される。`.dockerignore`に書いたパターンと`.git/`ディレクトリは自動的に除外してくれる。サーバー側では`docker compose up -d --build`が走り、コンテナのビルドと起動が行われる。
+
+デプロイが完了したら、状態を確認してみる。
+
+```bash
+conoha app status my-app --app-name myapp
+```
+
+コンテナがRunning状態になっているのが見える。ログも確認してみよう。
+
+```bash
+conoha app logs my-app --app-name myapp --follow
+```
+
+`--follow`をつけるとリアルタイムにログがストリーミングされてくる。Expressのアクセスログが流れてきて、ちゃんと動いているのがわかる。ブラウザからサーバーのIPアドレスの3000番ポートにアクセスすると、アプリが表示された。
+
+ここまでの手順を振り返ると、`server create` → `app init` → `app deploy`の3コマンドで、サーバーの作成からアプリの稼働まで到達している。管理画面とターミナルを行き来する必要もなく、Dockerのインストール手順を調べる必要もなかった。
+
+### 運用もCLIで
+
+デプロイした後の運用もコマンドで完結する。たとえばデータベースの接続先を環境変数として設定したくなったら、こうする。
+
+```bash
+conoha app env set my-app --app-name myapp DATABASE_URL=postgres://user:pass@db:5432/mydb
+```
+
+環境変数はサーバー上の`.env.server`ファイルに永続化される。次に`app deploy`を実行した際に自動的に`.env`としてコピーされるので、再デプロイ時にも設定が引き継がれる仕組みだ。設定を変更したら再起動する。
+
+```bash
+conoha app restart my-app --app-name myapp
+```
+
+サーバー上に複数のアプリをデプロイしている場合は、`app list`で一覧を確認できる。
+
+```bash
+conoha app list my-app
+```
+
+アプリ名と状態（running / stopped）が表示される。不要になったアプリは`app destroy`で後片付けまでやってくれる。
+
+```bash
+conoha app destroy my-app --app-name myapp
+```
+
+コンテナの停止、ワーキングディレクトリの削除、gitリポジトリの削除、環境変数ファイルの削除まで一括で行われる。確認プロンプトが出るので、うっかり消してしまう心配もない。
+
+## 体験記: Skillを入れて自然言語でやり直してみた
+
+前のセクションで手動で行ったサーバー作成からアプリデプロイまでの流れを、今度はClaude Codeに頼んでやってみることにした。
+
+### Skillをインストールする
+
+conoha-cliにはClaude Code用の **skill** が用意されている。skillとは、Claude Codeに特定のドメイン知識を教えるためのプラグインのようなものだ。通常のClaude Codeはプログラミング全般の知識は持っているが、「ConoHa VPSでサーバーを作るにはどのAPIを叩けばよいか」「Dockerをインストールするためにどのコマンドを実行するか」といったインフラ構築の具体的な手順までは知らない。skillをインストールすることで、Claude Codeがこうしたドメイン固有の知識を持てるようになる。
+
+インストールは一行で終わる。
+
+```bash
+conoha skill install
+```
+
+これだけで、`~/.claude/skills/conoha-cli-skill/`にskillファイルがダウンロードされる。skillの中身はMarkdownで書かれたレシピ集で、Docker Composeアプリのデプロイ手順、カスタムスクリプトでのサーバー構築、Kubernetesクラスターのセットアップ、OpenStack環境の構築、Slurm HPCクラスターの構築など、さまざまなインフラ構築パターンが収録されている。
+
+更新も簡単で、`conoha skill update`で最新版に同期される。不要になったら`conoha skill remove`で削除できる。
+
+### 自然言語でデプロイしてみる
+
+skillをインストールした状態でClaude Codeを起動し、こう指示してみた。
+
+```
+> ConoHaにUbuntuサーバーを作って、Expressアプリをデプロイして
+```
+
+するとClaude Codeが応答し、まずフレーバーの確認から始まった。
+
+```
+Claude: ConoHaにサーバーを作成してアプリをデプロイしますね。
+        まず利用可能なフレーバーを確認します。
+        （conoha flavor list を実行）
+        いくつかのプランがあります。g2l-t-c2m1（2vCPU / 1GB）で
+        よろしいですか？
+```
+
+「はい」と答えると、次にイメージの選択に進んだ。Ubuntu 24.04を選び、キーペアも指定すると、Claude Codeがサーバー作成コマンドを組み立てて実行した。
+
+```
+Claude: サーバーを作成しています...
+        （conoha server create --name express-app --flavor g2l-t-c2m1
+         --image <id> --key-name my-key --wait を実行）
+        サーバーが起動しました。Docker環境を初期化します。
+        （conoha app init express-app --app-name myapp を実行）
+        初期化が完了しました。コードをデプロイします。
+        （conoha app deploy express-app --app-name myapp を実行）
+        デプロイが完了しました！
+        http://xxx.xxx.xxx.xxx:3000 でアクセスできます。
+```
+
+前のセクションで筆者が手動で行った手順——フレーバーの確認、サーバー作成、app init、app deploy——が、数回の対話のやりとりで完了してしまった。コマンドのフラグや引数を覚える必要もなく、「やりたいこと」を伝えるだけでClaude Codeがskillのレシピに沿って適切なコマンドを組み立ててくれる。
+
+重要なのは、skillの裏側で実行されているのはconoha-cliのコマンドそのものだということだ。ブラックボックスではない。Claude Codeが何を実行しているかはターミナルにすべて表示されるし、途中で「ちょっと待って、フレーバーはもう少し大きいのにして」と言えば柔軟に対応してくれる。CLIの操作を理解している人にとっては、自分の代わりにコマンドを叩いてくれるアシスタントのようなものだ。
+
+### 別のレシピも試してみる
+
+skillにはDocker Composeアプリ以外のレシピも含まれている。試しにKubernetesクラスターの構築を頼んでみた。
+
+```
+> ConoHaでk3sのKubernetesクラスターを作って
+```
+
+すると今度は別のレシピが読み込まれ、マスターノードとワーカーノードの台数を聞かれた。レシピが変わるとアプローチ自体も変わり、サーバーを複数台作成して、k3sのインストールスクリプトを順番に実行していく流れになった。先ほどのDocker Composeデプロイとはまったく異なる手順だが、同じように対話形式で進んでいく。
+
+用意されているレシピは現在5種類ある。
+
+- **Docker Composeアプリ** — 先ほどのデモで使ったパターン。docker-compose.ymlがあるプロジェクトを手軽にデプロイする
+- **カスタムスクリプト** — 任意のシェルスクリプトでサーバーをプロビジョニングする
+- **Kubernetes (k3s)** — 軽量Kubernetesクラスターを構築する
+- **OpenStack (DevStack)** — 開発用のOpenStack環境を立ち上げる
+- **Slurm HPC** — 高性能計算用のジョブスケジューラ環境を構築する
+
+skillはGitHubリポジトリとして公開されているので、既存のレシピを参考にして自分のユースケースに合わせたレシピを追加することもできる。Markdownで手順を書くだけなので、プログラミングの知識は必要ない。
+
+### 手動でやる意味、skillでやる意味
+
+ここまで体験してみて感じたのは、手動操作とskillはどちらかが上位互換というわけではなく、使い分けるものだということだ。
+
+CLIで手動操作するのは、細かい制御が必要なときや、コマンドの動作を理解したいときに適している。セキュリティグループの設定をひとつずつ確認しながら追加したいとか、デプロイのプロセスを理解しておきたいとか、そういう場面では手動のほうがいい。
+
+skillを使うのは、定型的な構築作業を素早く済ませたいときだ。「検証用にさっとサーバーを立ててアプリを動かしたい」という場面では、フレーバーのIDを調べたりフラグの名前を思い出したりする手間を省いて、やりたいことだけ伝えればよい。
+
+そして、この2つは矛盾しない。手動でCLIを使い込んで操作を理解している人ほど、skillが裏で何をしているかがわかるので安心して使える。逆にskillから入った人も、Claude Codeが実行するコマンドを見ることで、CLIの使い方を自然に学んでいける。
+
+## まとめ
+
+この記事では、conoha-cliを使ったVPSの管理とアプリのデプロイを紹介した。
+
+ターミナルからサーバーの作成、Docker環境の構築、アプリのデプロイ、ログの確認、環境変数の管理まで一貫して操作でき、管理画面とターミナルを行き来する必要がなくなる。`docker-compose.yml`があるプロジェクトなら、`app init` → `app deploy`の2コマンドでサーバー上にアプリが立ち上がる。
+
+さらにClaude Code Skillを導入すれば、同じ操作を自然言語で指示できるようになる。skillはconoha-cliのコマンドを内部で使っているため、何が実行されているかは常に透明だ。ブラックボックスにインフラを任せる不安感はなく、CLIの知識がそのまま活きる。
+
+conoha-cliの設計には、AIエージェントとの親和性が随所に組み込まれている。`--no-input`フラグによる非対話実行、`--format json`による構造化出力、明確に定義された終了コード。これらはCIパイプラインやスクリプトからの利用だけでなく、Claude CodeのようなAIエージェントが確実にコマンドの結果を解釈するための基盤でもある。
+
+conoha-cliはオープンソースとして開発されており、コントリビューションを歓迎している。興味があればぜひ試してみてほしい。
+
+**インストール:**
+
+```bash
+brew install crowdy/tap/conoha
+```
+
+**リポジトリ:**
+
+- conoha-cli: https://github.com/crowdy/conoha-cli
+- conoha-cli-skill: https://github.com/crowdy/conoha-cli-skill
+- ドキュメントサイト: https://crowdy.github.io/conoha-cli-pages/

--- a/docs/superpowers/plans/2026-03-31-app-samples-tier3-impl.md
+++ b/docs/superpowers/plans/2026-03-31-app-samples-tier3-impl.md
@@ -1,0 +1,15 @@
+# App Samples Tier 3 Additions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 5 Tier 3 samples (nginx-reverse-proxy, ghost-blog, gitea, minio-n8n, ollama-webui) to the existing `conoha-cli-app-samples` repo and update the root README.
+
+**Architecture:** Each sample is a flat top-level directory. Most use official Docker images with compose-only setups (no custom Dockerfile). Japanese READMEs, English code comments/output.
+
+**Tech Stack:** nginx, Ghost, Gitea, MinIO, n8n, Open WebUI, Ollama
+
+**Repo:** `/home/tkim/dev/crowdy/conoha-cli-app-samples`
+
+---
+
+Tier 3 samples are "実務特化" (practical/operational) — they demonstrate real infrastructure patterns rather than framework samples.

--- a/docs/superpowers/plans/2026-04-01-skill-commands-impl.md
+++ b/docs/superpowers/plans/2026-04-01-skill-commands-impl.md
@@ -1,0 +1,443 @@
+# Skill Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `conoha skill install|update|remove` commands to manage the conoha-cli-skill for Claude Code.
+
+**Architecture:** Single file `cmd/skill/skill.go` with parent command + 3 subcommands. Uses `os/exec` for git operations, `os` for filesystem checks, `prompt.Confirm` for destructive remove. Registered in `cmd/root.go`.
+
+**Tech Stack:** Go, cobra, os/exec, internal/errors, internal/prompt
+
+---
+
+### Task 1: Create `cmd/skill/skill.go` with install command + test
+
+**Files:**
+- Create: `cmd/skill/skill.go`
+- Create: `cmd/skill/skill_test.go`
+
+- [ ] **Step 1: Write the test file with install tests**
+
+Create `cmd/skill/skill_test.go`:
+
+```go
+package skill
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallCmd(t *testing.T) {
+	t.Run("fails when git not found", func(t *testing.T) {
+		// Override PATH to hide git
+		t.Setenv("PATH", "/nonexistent")
+		dir := t.TempDir()
+
+		err := runInstall(dir)
+		if err == nil {
+			t.Fatal("expected error when git not found")
+		}
+		if err.Error() != "validation error: git is required to install skills" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails when already installed", func(t *testing.T) {
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, skillName)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		err := runInstall(dir)
+		if err == nil {
+			t.Fatal("expected error when already installed")
+		}
+		if err.Error() != "validation error: already installed, use 'conoha skill update'" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("clones successfully", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not available")
+		}
+		dir := t.TempDir()
+
+		err := runInstall(dir)
+		if err != nil {
+			t.Fatalf("install failed: %v", err)
+		}
+
+		skillDir := filepath.Join(dir, skillName)
+		if _, err := os.Stat(filepath.Join(skillDir, ".git")); os.IsNotExist(err) {
+			t.Error("expected .git directory after install")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (skill.go doesn't exist yet)**
+
+Run: `go test ./cmd/skill/ -v -run TestInstallCmd 2>&1`
+Expected: compilation error — package does not exist
+
+- [ ] **Step 3: Create `cmd/skill/skill.go` with install command**
+
+Create `cmd/skill/skill.go`:
+
+```go
+package skill
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
+	"github.com/crowdy/conoha-cli/internal/prompt"
+)
+
+const (
+	skillRepo = "https://github.com/crowdy/conoha-cli-skill.git"
+	skillName = "conoha-cli-skill"
+)
+
+// Cmd is the parent command for skill management.
+var Cmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Manage Claude Code skills",
+}
+
+func init() {
+	Cmd.AddCommand(installCmd)
+}
+
+func defaultSkillBase() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".claude", "skills")
+}
+
+func runInstall(baseDir string) error {
+	if _, err := exec.LookPath("git"); err != nil {
+		return &cerrors.ValidationError{Message: "git is required to install skills"}
+	}
+
+	skillDir := filepath.Join(baseDir, skillName)
+	if _, err := os.Stat(skillDir); err == nil {
+		return &cerrors.ValidationError{Message: "already installed, use 'conoha skill update'"}
+	}
+
+	cmd := exec.Command("git", "clone", skillRepo, skillDir)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return &cerrors.NetworkError{Err: fmt.Errorf("git clone failed: %w", err)}
+	}
+
+	fmt.Fprintln(os.Stderr, "Installed conoha-cli-skill successfully.")
+	return nil
+}
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install conoha-cli-skill for Claude Code",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runInstall(defaultSkillBase())
+	},
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/skill/ -v -run TestInstallCmd 2>&1`
+Expected: all 3 subtests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/skill/skill.go cmd/skill/skill_test.go
+git commit -m "Add skill install command with tests (#47)"
+```
+
+---
+
+### Task 2: Add update command + test
+
+**Files:**
+- Modify: `cmd/skill/skill.go`
+- Modify: `cmd/skill/skill_test.go`
+
+- [ ] **Step 1: Add update tests to `cmd/skill/skill_test.go`**
+
+Append to `cmd/skill/skill_test.go`:
+
+```go
+func TestUpdateCmd(t *testing.T) {
+	t.Run("fails when not installed", func(t *testing.T) {
+		dir := t.TempDir()
+
+		err := runUpdate(dir)
+		if err == nil {
+			t.Fatal("expected error when not installed")
+		}
+		if err.Error() != "validation error: not installed, use 'conoha skill install'" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fails when not a git repo", func(t *testing.T) {
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, skillName)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		err := runUpdate(dir)
+		if err == nil {
+			t.Fatal("expected error when not a git repo")
+		}
+		if err.Error() != "validation error: not a git repository, remove and reinstall" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("pulls successfully", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not available")
+		}
+		dir := t.TempDir()
+
+		// Install first
+		if err := runInstall(dir); err != nil {
+			t.Fatalf("install failed: %v", err)
+		}
+
+		err := runUpdate(dir)
+		if err != nil {
+			t.Fatalf("update failed: %v", err)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/skill/ -v -run TestUpdateCmd 2>&1`
+Expected: compilation error — `runUpdate` not defined
+
+- [ ] **Step 3: Add update command to `cmd/skill/skill.go`**
+
+Add to `init()`:
+
+```go
+Cmd.AddCommand(updateCmd)
+```
+
+Add functions:
+
+```go
+func runUpdate(baseDir string) error {
+	skillDir := filepath.Join(baseDir, skillName)
+	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+		return &cerrors.ValidationError{Message: "not installed, use 'conoha skill install'"}
+	}
+
+	gitDir := filepath.Join(skillDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return &cerrors.ValidationError{Message: "not a git repository, remove and reinstall"}
+	}
+
+	cmd := exec.Command("git", "-C", skillDir, "pull")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return &cerrors.NetworkError{Err: fmt.Errorf("git pull failed: %w", err)}
+	}
+
+	fmt.Fprintln(os.Stderr, "Updated conoha-cli-skill successfully.")
+	return nil
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update conoha-cli-skill to latest version",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUpdate(defaultSkillBase())
+	},
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/skill/ -v -run TestUpdateCmd 2>&1`
+Expected: all 3 subtests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/skill/skill.go cmd/skill/skill_test.go
+git commit -m "Add skill update command with tests (#47)"
+```
+
+---
+
+### Task 3: Add remove command + test
+
+**Files:**
+- Modify: `cmd/skill/skill.go`
+- Modify: `cmd/skill/skill_test.go`
+
+- [ ] **Step 1: Add remove tests to `cmd/skill/skill_test.go`**
+
+Append to `cmd/skill/skill_test.go`:
+
+```go
+func TestRemoveCmd(t *testing.T) {
+	t.Run("fails when not installed", func(t *testing.T) {
+		dir := t.TempDir()
+
+		err := runRemove(dir)
+		if err == nil {
+			t.Fatal("expected error when not installed")
+		}
+		if err.Error() != "validation error: not installed" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("removes successfully with --yes", func(t *testing.T) {
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, skillName)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CONOHA_YES", "1")
+
+		err := runRemove(dir)
+		if err != nil {
+			t.Fatalf("remove failed: %v", err)
+		}
+
+		if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+			t.Error("expected skill directory to be removed")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/skill/ -v -run TestRemoveCmd 2>&1`
+Expected: compilation error — `runRemove` not defined
+
+- [ ] **Step 3: Add remove command to `cmd/skill/skill.go`**
+
+Add to `init()`:
+
+```go
+Cmd.AddCommand(removeCmd)
+```
+
+Add functions:
+
+```go
+func runRemove(baseDir string) error {
+	skillDir := filepath.Join(baseDir, skillName)
+	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+		return &cerrors.ValidationError{Message: "not installed"}
+	}
+
+	ok, err := prompt.Confirm("Remove conoha-cli-skill?")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Fprintln(os.Stderr, "Cancelled.")
+		return nil
+	}
+
+	if err := os.RemoveAll(skillDir); err != nil {
+		return fmt.Errorf("failed to remove: %w", err)
+	}
+
+	fmt.Fprintln(os.Stderr, "Removed conoha-cli-skill successfully.")
+	return nil
+}
+
+var removeCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove conoha-cli-skill",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRemove(defaultSkillBase())
+	},
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/skill/ -v -run TestRemoveCmd 2>&1`
+Expected: all 2 subtests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/skill/skill.go cmd/skill/skill_test.go
+git commit -m "Add skill remove command with tests (#47)"
+```
+
+---
+
+### Task 4: Register in root.go + full test + lint
+
+**Files:**
+- Modify: `cmd/root.go`
+
+- [ ] **Step 1: Add skill import and registration to `cmd/root.go`**
+
+Add import:
+
+```go
+"github.com/crowdy/conoha-cli/cmd/skill"
+```
+
+Add after `rootCmd.AddCommand(app.Cmd)` (line 89):
+
+```go
+rootCmd.AddCommand(skill.Cmd)
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `go test ./... -v 2>&1`
+Expected: all tests PASS
+
+- [ ] **Step 3: Run linter**
+
+Run: `golangci-lint run ./... 2>&1`
+Expected: 0 issues
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/root.go
+git commit -m "Register skill command group in root (#47)"
+```
+
+---
+
+### Task 5: Create PR
+
+- [ ] **Step 1: Create branch, push, and open PR**
+
+```bash
+git checkout -b feature/skill-commands
+git push -u origin feature/skill-commands
+gh pr create --title "Add skill install/update/remove commands" --body "Closes #47"
+```

--- a/docs/superpowers/plans/2026-04-07-app-reset.md
+++ b/docs/superpowers/plans/2026-04-07-app-reset.md
@@ -1,0 +1,306 @@
+# App Reset Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `conoha app reset` command that combines destroy + init + deploy in one step.
+
+**Architecture:** Extract deploy logic into a reusable helper, then create `reset.go` that orchestrates destroy script → init script → deploy helper using a single SSH connection.
+
+**Tech Stack:** Go, cobra, SSH
+
+---
+
+### Task 1: Extract deploy helper from deploy.go
+
+**Files:**
+- Modify: `cmd/app/deploy.go:23-78`
+
+- [ ] **Step 1: Extract deployApp helper function**
+
+Move the body of `deployCmd.RunE` (after `connectToApp`) into a new function. The RunE calls this helper:
+
+```go
+func deployApp(ctx *appContext) error {
+	// Pre-flight: check compose file exists locally
+	if !hasComposeFile(".") {
+		return fmt.Errorf("no docker-compose.yml/yaml or compose.yml/yaml found in current directory")
+	}
+
+	// Load .dockerignore
+	patterns, err := loadIgnorePatterns(".")
+	if err != nil {
+		return err
+	}
+
+	// Create tar.gz
+	fmt.Fprintf(os.Stderr, "Archiving current directory...\n")
+	var buf bytes.Buffer
+	if err := createTarGz(".", patterns, &buf); err != nil {
+		return fmt.Errorf("create archive: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Uploading to %s (%s)...\n", ctx.Server.Name, ctx.IP)
+
+	// Transfer tar (clean deploy: remove old files first)
+	workDir := "/opt/conoha/" + ctx.AppName
+	tarCmd := fmt.Sprintf("rm -rf %s && mkdir -p %s && tar xzf - -C %s", workDir, workDir, workDir)
+	exitCode, err := internalssh.RunWithStdin(ctx.Client, tarCmd, &buf, os.Stdout, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("upload failed: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("upload exited with code %d", exitCode)
+	}
+
+	// Docker compose up (copy .env.server if exists)
+	fmt.Fprintf(os.Stderr, "Building and starting containers...\n")
+	composeCmd := fmt.Sprintf(
+		"ENV_FILE=/opt/conoha/%s.env.server; "+
+			"if [ -f \"$ENV_FILE\" ]; then cp \"$ENV_FILE\" %s/.env; fi && "+
+			"cd %s && docker compose up -d --build --remove-orphans && docker compose ps",
+		ctx.AppName, workDir, workDir)
+	exitCode, err = internalssh.RunCommand(ctx.Client, composeCmd, os.Stdout, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("deploy failed: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("deploy exited with code %d", exitCode)
+	}
+
+	fmt.Fprintf(os.Stderr, "Deploy complete.\n")
+	return nil
+}
+```
+
+Update `deployCmd.RunE` to use the helper:
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    ctx, err := connectToApp(cmd, args)
+    if err != nil {
+        return err
+    }
+    defer func() { _ = ctx.Client.Close() }()
+
+    return deployApp(ctx)
+},
+```
+
+- [ ] **Step 2: Run tests to verify no regression**
+
+Run: `go test ./cmd/app/ -v -run TestDeploy`
+Then: `go build ./...`
+Expected: all pass, no behavior change
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/app/deploy.go
+git commit -m "refactor: extract deployApp helper from deploy command"
+```
+
+---
+
+### Task 2: Create app reset command
+
+**Files:**
+- Create: `cmd/app/reset.go`
+
+- [ ] **Step 1: Create reset.go**
+
+```go
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/crowdy/conoha-cli/internal/prompt"
+	internalssh "github.com/crowdy/conoha-cli/internal/ssh"
+)
+
+func init() {
+	addAppFlags(resetCmd)
+	resetCmd.Flags().Bool("yes", false, "skip confirmation prompt")
+}
+
+var resetCmd = &cobra.Command{
+	Use:   "reset <id|name>",
+	Short: "Destroy and redeploy an app from scratch",
+	Long:  "Equivalent to running destroy + init + deploy in sequence. Stops containers, removes all app data, re-initializes the environment, and deploys the current directory.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, err := connectToApp(cmd, args)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = ctx.Client.Close() }()
+
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes {
+			ok, err := prompt.Confirm(fmt.Sprintf("Reset app %q on %s? This will destroy all data and redeploy.", ctx.AppName, ctx.Server.Name))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintln(os.Stderr, "Cancelled.")
+				return nil
+			}
+		}
+
+		// Step 1: Destroy
+		fmt.Fprintln(os.Stderr, "==> Destroying app...")
+		script := generateDestroyScript(ctx.AppName)
+		exitCode, err := internalssh.RunScript(ctx.Client, script, nil, os.Stdout, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("destroy failed: %w", err)
+		}
+		if exitCode != 0 {
+			return fmt.Errorf("destroy exited with code %d", exitCode)
+		}
+
+		// Step 2: Init
+		fmt.Fprintln(os.Stderr, "==> Re-initializing app...")
+		script = generateInitScript(ctx.AppName)
+		exitCode, err = internalssh.RunScript(ctx.Client, script, nil, os.Stdout, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("init failed: %w", err)
+		}
+		if exitCode != 0 {
+			return fmt.Errorf("init exited with code %d", exitCode)
+		}
+
+		// Step 3: Deploy
+		fmt.Fprintln(os.Stderr, "==> Deploying app...")
+		if err := deployApp(ctx); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(os.Stderr, "App %q reset complete.\n", ctx.AppName)
+		return nil
+	},
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `go build ./...`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/app/reset.go
+git commit -m "feat: add app reset command (destroy + init + deploy)"
+```
+
+---
+
+### Task 3: Register reset command
+
+**Files:**
+- Modify: `cmd/app/app.go:19`
+
+- [ ] **Step 1: Add resetCmd to app.go**
+
+Add `Cmd.AddCommand(resetCmd)` in the `init()` function:
+
+```go
+func init() {
+	Cmd.AddCommand(initCmd)
+	Cmd.AddCommand(deployCmd)
+	Cmd.AddCommand(logsCmd)
+	Cmd.AddCommand(statusCmd)
+	Cmd.AddCommand(stopCmd)
+	Cmd.AddCommand(restartCmd)
+	Cmd.AddCommand(envCmd)
+	Cmd.AddCommand(destroyCmd)
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(resetCmd)
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `go build ./... && ./conoha app reset --help`
+Expected: shows reset command help with `--yes`, `--app-name`, SSH flags
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/app/app.go
+git commit -m "feat: register app reset subcommand"
+```
+
+---
+
+### Task 4: Add tests
+
+**Files:**
+- Create: `cmd/app/reset_test.go`
+
+- [ ] **Step 1: Write reset command structure tests**
+
+```go
+package app
+
+import (
+	"testing"
+)
+
+func TestResetCmd_HasYesFlag(t *testing.T) {
+	f := resetCmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("reset command should have --yes flag")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--yes default should be false, got %s", f.DefValue)
+	}
+}
+
+func TestResetCmd_HasAppFlags(t *testing.T) {
+	for _, name := range []string{"app-name", "user", "port", "identity"} {
+		if resetCmd.Flags().Lookup(name) == nil {
+			t.Errorf("reset command should have --%s flag", name)
+		}
+	}
+}
+
+func TestResetCmd_RequiresExactlyOneArg(t *testing.T) {
+	if resetCmd.Args == nil {
+		t.Fatal("reset command should have Args validation")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./cmd/app/ -v -run TestReset`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/app/reset_test.go
+git commit -m "test: add app reset command tests"
+```
+
+---
+
+### Task 5: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+Expected: all pass
+
+- [ ] **Step 2: Run linter**
+
+Run: `make lint`
+Expected: no issues
+
+- [ ] **Step 3: Verify help output**
+
+Run: `go run . app reset --help`
+Expected: shows correct usage, flags, and description

--- a/docs/superpowers/specs/2026-04-01-skill-commands-design.md
+++ b/docs/superpowers/specs/2026-04-01-skill-commands-design.md
@@ -1,0 +1,70 @@
+# Design: `conoha skill` Commands
+
+**Issue:** #47
+**Date:** 2026-04-01
+
+## Summary
+
+Add `conoha skill install|update|remove` commands to manage the `conoha-cli-skill` — a Claude Code skill that teaches Claude how to use ConoHa CLI via natural language.
+
+## Commands
+
+### `conoha skill install`
+
+1. `exec.LookPath("git")` — not found → `ValidationError("git is required")`
+2. Check `~/.claude/skills/conoha-cli-skill/` doesn't exist — exists → `ValidationError("already installed, use 'conoha skill update'")`
+3. `git clone https://github.com/crowdy/conoha-cli-skill.git ~/.claude/skills/conoha-cli-skill/`
+4. Print success to stderr
+
+### `conoha skill update`
+
+1. Check `~/.claude/skills/conoha-cli-skill/` exists — not found → `ValidationError("not installed, use 'conoha skill install'")`
+2. Check `.git/` exists inside — not found → `ValidationError("not a git repository, remove and reinstall")`
+3. `git -C <dir> pull`
+4. Print success to stderr
+
+### `conoha skill remove`
+
+1. Check `~/.claude/skills/conoha-cli-skill/` exists — not found → `ValidationError("not installed")`
+2. `prompt.Confirm("Remove conoha-cli-skill?")` — cancelled → print "Cancelled." and return nil
+3. `os.RemoveAll(dir)`
+4. Print success to stderr
+
+## Structure
+
+Single file: `cmd/skill/skill.go`
+
+- Parent `Cmd` (Use: "skill", Short: "Manage Claude Code skills")
+- Three subcommands registered in `init()`
+- Constants: `skillRepo`, `skillName`
+- `skillDir()` function using `os.UserHomeDir()`
+
+## Registration
+
+Add `skill.Cmd` to `cmd/root.go`.
+
+## Error Handling
+
+| Condition | Error Type | Exit Code |
+|-----------|-----------|-----------|
+| git not found | ValidationError | 4 |
+| Already/not installed | ValidationError | 4 |
+| git clone/pull fails | NetworkError | 6 |
+| User cancels remove | no error | 0 |
+
+## Design Decisions
+
+- **No tarball fallback** — git is required; users of a CLI tool will have git installed.
+- **Single file** — each subcommand is 20-30 lines; splitting would be over-engineering.
+- **No API client needed** — these commands don't call ConoHa API, only local git/filesystem.
+- **Fixed skill path** — `~/.claude/skills/conoha-cli-skill/` (Claude Code convention).
+
+## Testing
+
+Tests use real tmpdir + `git init` for filesystem operations. Mock the skill directory path via a helper function that accepts a base directory parameter.
+
+## Out of Scope
+
+- SKILL.md content authoring
+- Multiple skill support
+- Tarball/HTTP fallback

--- a/docs/superpowers/specs/2026-04-05-note-article-design.md
+++ b/docs/superpowers/specs/2026-04-05-note-article-design.md
@@ -2,82 +2,73 @@
 
 ## 概要
 
-note.com に投稿する conoha-cli 紹介記事の設計。日本語 6000 字以上、技術ブログ風のハンズオン形式。CLI の手動操作と Claude Code Skill による自然言語操作の対比を軸に構成する。
+note.com に投稿する conoha-cli 紹介記事の設計。日本語 6000 字以上。前半は客観的な紹介、後半は体験記スタイルで CLI 手動操作 → Claude Code Skill 自然言語操作の対比を軸に構成する。
 
 ## ターゲット読者
 
-- Claude Code を使っている開発者（AI ツール活用層）
-- ConoHa VPS 既存ユーザー
-- VPS / インフラ構築に興味がある CLI 初心者
+Claude Code を使っている開発者、ConoHa VPS 既存ユーザー、VPS やインフラ構築に興味がある初心者。エンジニアでない読者にも読みやすいよう配慮する。
 
 ## 記事の形式
 
 - テキスト + コード例のみ（画像なし）
 - Markdown で原稿作成、note.com への投稿は手動
-- 技術ブログ風: コード例多め、ハンズオン形式
+- コード例は残すが、前後を会話調の文章でつなぐ
+- 機能の列挙は箇条書きではなく、体験の流れの中で自然に登場させる
 
-## 構成: 「CLI → Skill 進化ストーリー」型
+## 文体ガイドライン
 
-前半で CLI の基本操作とアプリデプロイを手動で見せ、後半で skill による自然言語操作を紹介する対比構成。
+箇条書きによる機能列挙を避け、段落で流れるように書く。コード例の前後は「まず○○してみた。すると△△が返ってきた。」のような体験調の文章でつなぐ。非エンジニアの読者にも状況が伝わるよう、操作の意味や感想を丁寧に補足する。
 
-### セクション 1: 導入（〜600字）
+## 構成: 「客観紹介 → 体験記」型
 
-- タイトル案: 「CLIひとつでVPSデプロイ完了 — conoha-cliとClaude Code Skillで変わるインフラ構築」
-- VPS でアプリを動かすまでの手順の多さを共感ポイントとして提示
-- conoha-cli + skill で解決できるという全体像
-- 対象読者の明示
+前半2セクションで客観的な紹介（信頼感）、後半2セクションで一人称体験記（親近感）。
 
-### セクション 2: conoha-cli とは（〜800字）
+### セクション 1: 導入（〜900字）— 客観紹介
 
-- Go 製 CLI、シングルバイナリ、macOS/Linux/Windows 対応
-- 主な特徴: 複数プロファイル、構造化出力、自動トークンリフレッシュ、`--no-input`
-- インストール手順（`brew install crowdy/tap/conoha` + `conoha auth login`）
-- 「シングルバイナリひとつで VPS のライフサイクル全体を管理」という価値の訴求
+タイトル案: 「CLIひとつでVPSデプロイ完了 — conoha-cliとClaude Code Skillで変わるインフラ構築」
 
-### セクション 3: 基本操作 — サーバー作成から SSH まで（〜1000字）
+VPS でアプリを動かすまでの手順の多さを共感ポイントとして提示する。管理画面でサーバーを作り、SSH で入って環境構築し、Docker を入れて、コードを転送して…という「あるある」を具体的に描写する。Terraform や Ansible のような IaC ツールは大規模向けで、個人〜小規模には重い。conoha-cli はその中間に位置する「ちょうどいい」ツールであり、さらに Claude Code の skill を使えば自然言語でインフラ構築まで可能、という全体像を提示する。対象読者の明示も行う。
 
-- `conoha flavor list` / `conoha image list` でプラン・OS 確認
-- `conoha server create` でサーバー作成（フラグ付きのコード例）
-- `conoha server list` で状態確認
-- `conoha server ssh` で接続
-- 管理画面不要でターミナルから数コマンドで完結する手軽さを強調
+### セクション 2: conoha-cli とは（〜1200字）— 客観紹介
 
-### セクション 4: アプリデプロイ — docker-compose.yml があれば OK（〜1200字）
+段落形式で conoha-cli の特徴を紹介する。Go 製シングルバイナリで macOS/Linux/Windows に対応していること、複数プロファイルの切り替え、JSON/YAML 出力と jq の組み合わせ、自動トークンリフレッシュなどを、機能カタログではなく「こういう場面でこう便利」という文脈で伝える。
 
-- `conoha app` コマンド群の紹介
-- Express.js アプリを例にデプロイ全フロー:
-  1. `conoha app init` — Docker 環境構築 + git リポジトリ作成
-  2. `conoha app deploy` — tar アップロード → `docker compose up`
-  3. `conoha app status` / `conoha app logs --follow`
-- 運用系コマンド: `app env set`, `app restart`, `app destroy`
-- `.dockerignore` 尊重、`.env.server` 永続化などの実用ディテール
+インストール方法は Homebrew、`go install`、GitHub Releases の3通りを紹介。認証フロー（`conoha auth login` の対話）も簡潔に触れ、「ここまでで準備完了」という区切りを作る。
 
-### セクション 5: Claude Code Skill — 自然言語でインフラ構築（〜1500字）
+### セクション 3: 体験記 — CLI でサーバーを立ててアプリをデプロイしてみた（〜2500字）
 
-- 記事のクライマックス
-- `conoha skill install` で skill をインストール
-- skill の概念説明（Claude Code のドメイン知識プラグイン）
-- Claude Code との対話形式デモ:
-  - 「ConoHa にサーバーを作って Express アプリをデプロイして」
-  - skill が自動ロード → レシピに沿ってステップバイステップ実行
-- 用意されているレシピ一覧:
-  - Docker Compose アプリ / カスタムスクリプト / k3s / OpenStack / Slurm
-- 手動操作との対比: 自然言語で同じ結果が得られるインパクト
-- CLI 知識がなくても使える敷居の低さ + CLI を理解していれば動作が透明で安心
+一人称の体験記として、ゼロからアプリデプロイまでの全フローを時系列で書く。
 
-### セクション 6: まとめ（〜500字）
+まずサーバーを作るところから。`conoha flavor list` でプランを眺め、どれを選ぶか迷う過程。キーペアを作り、`conoha server create --wait` でサーバーが立ち上がるのを待つ。`--wait` をつけると起動完了まで待ってくれるのが地味に嬉しい、といった感想を交える。
 
-- CLI + skill の2段構えの振り返り
-- 設計思想: シングルバイナリ、AI 親和性、docker-compose.yml ベース
-- リンク集:
-  - `brew install crowdy/tap/conoha`
-  - `github.com/crowdy/conoha-cli`
-  - `github.com/crowdy/conoha-cli-skill`
+次に `conoha app init` を実行すると、Docker と Docker Compose のインストール、git リポジトリの作成まで一発で終わる。裏で何が起きているかの解説も軽く入れる。
+
+Express.js の簡単なアプリを用意し、`docker-compose.yml` と `Dockerfile` のサンプルコードを掲載。`conoha app deploy` でデプロイし、`app status` でコンテナが動いていることを確認、`app logs --follow` でリアルタイムログを見る。この一連の流れを、操作 → 結果 → 感想 というリズムで書く。
+
+環境変数の設定（`app env set`）、再起動（`app restart`）、複数アプリの管理（`app list`）にも体験の中で触れる。`.dockerignore` が尊重されること、`.env.server` で環境変数が永続化されることなど、使ってみて初めてわかる実用ディテールも自然に織り込む。
+
+### セクション 4: 体験記 — Skill を入れて自然言語でやり直してみた（〜2200字）
+
+記事のクライマックス。セクション3で手動でやったことを、今度は Claude Code に頼んでみる、という導入。
+
+`conoha skill install` で skill をインストール。skill とは何かを、「Claude Code にインフラ構築の知識を教えるプラグインのようなもの」と非エンジニアにも伝わる言葉で説明する。
+
+Claude Code に「ConoHa にサーバーを作って Express アプリをデプロイして」と投げてみる。対話のやりとりをリアルに再現し、フレーバーを確認される → 答える → サーバーが作られる → Docker 環境が初期化される → デプロイされる、という流れを会話形式で書く。「さっき手動で30分かけたことが、数分の対話で終わった」という感想。
+
+2つ目のデモとして「Kubernetes クラスターを作って」という別のレシピも短く紹介。レシピによってアプローチが変わることを見せる。
+
+skill の中身は CLI コマンドの組み合わせであり、ブラックボックスではないという安心感を伝える。自分で skill をカスタマイズ・拡張できる可能性にも触れる。
+
+### セクション 5: まとめ（〜800字）— 客観 + 体験の振り返り
+
+体験を通じて感じた CLI と Skill の使い分けを文章で語る。手動で理解して skill で加速する、というワークフロー。AI エージェントとの親和性（終了コード、`--no-input`、JSON 出力）がなぜ重要かを、体験を踏まえて実感として伝える。
+
+OSS としてのコントリビューション歓迎、GitHub リポジトリと skill リポジトリへのリンク、インストールコマンドを添えて締めくくる。
 
 ## 想定文字数
 
-合計約 5600 字（骨格）。コード例・解説の充実で 6000 字以上に到達。
+合計約 7600 字。コード例と体験描写の充実で 8000 字前後に到達する見込み。
 
 ## 成果物
 
-- `docs/articles/2026-04-05-note-conoha-cli.md` に Markdown 原稿を作成
+`docs/articles/2026-04-05-note-conoha-cli.md` に Markdown 原稿を作成。

--- a/docs/superpowers/specs/2026-04-05-note-article-design.md
+++ b/docs/superpowers/specs/2026-04-05-note-article-design.md
@@ -1,0 +1,83 @@
+# note.com 記事デザイン: conoha-cli 紹介
+
+## 概要
+
+note.com に投稿する conoha-cli 紹介記事の設計。日本語 6000 字以上、技術ブログ風のハンズオン形式。CLI の手動操作と Claude Code Skill による自然言語操作の対比を軸に構成する。
+
+## ターゲット読者
+
+- Claude Code を使っている開発者（AI ツール活用層）
+- ConoHa VPS 既存ユーザー
+- VPS / インフラ構築に興味がある CLI 初心者
+
+## 記事の形式
+
+- テキスト + コード例のみ（画像なし）
+- Markdown で原稿作成、note.com への投稿は手動
+- 技術ブログ風: コード例多め、ハンズオン形式
+
+## 構成: 「CLI → Skill 進化ストーリー」型
+
+前半で CLI の基本操作とアプリデプロイを手動で見せ、後半で skill による自然言語操作を紹介する対比構成。
+
+### セクション 1: 導入（〜600字）
+
+- タイトル案: 「CLIひとつでVPSデプロイ完了 — conoha-cliとClaude Code Skillで変わるインフラ構築」
+- VPS でアプリを動かすまでの手順の多さを共感ポイントとして提示
+- conoha-cli + skill で解決できるという全体像
+- 対象読者の明示
+
+### セクション 2: conoha-cli とは（〜800字）
+
+- Go 製 CLI、シングルバイナリ、macOS/Linux/Windows 対応
+- 主な特徴: 複数プロファイル、構造化出力、自動トークンリフレッシュ、`--no-input`
+- インストール手順（`brew install crowdy/tap/conoha` + `conoha auth login`）
+- 「シングルバイナリひとつで VPS のライフサイクル全体を管理」という価値の訴求
+
+### セクション 3: 基本操作 — サーバー作成から SSH まで（〜1000字）
+
+- `conoha flavor list` / `conoha image list` でプラン・OS 確認
+- `conoha server create` でサーバー作成（フラグ付きのコード例）
+- `conoha server list` で状態確認
+- `conoha server ssh` で接続
+- 管理画面不要でターミナルから数コマンドで完結する手軽さを強調
+
+### セクション 4: アプリデプロイ — docker-compose.yml があれば OK（〜1200字）
+
+- `conoha app` コマンド群の紹介
+- Express.js アプリを例にデプロイ全フロー:
+  1. `conoha app init` — Docker 環境構築 + git リポジトリ作成
+  2. `conoha app deploy` — tar アップロード → `docker compose up`
+  3. `conoha app status` / `conoha app logs --follow`
+- 運用系コマンド: `app env set`, `app restart`, `app destroy`
+- `.dockerignore` 尊重、`.env.server` 永続化などの実用ディテール
+
+### セクション 5: Claude Code Skill — 自然言語でインフラ構築（〜1500字）
+
+- 記事のクライマックス
+- `conoha skill install` で skill をインストール
+- skill の概念説明（Claude Code のドメイン知識プラグイン）
+- Claude Code との対話形式デモ:
+  - 「ConoHa にサーバーを作って Express アプリをデプロイして」
+  - skill が自動ロード → レシピに沿ってステップバイステップ実行
+- 用意されているレシピ一覧:
+  - Docker Compose アプリ / カスタムスクリプト / k3s / OpenStack / Slurm
+- 手動操作との対比: 自然言語で同じ結果が得られるインパクト
+- CLI 知識がなくても使える敷居の低さ + CLI を理解していれば動作が透明で安心
+
+### セクション 6: まとめ（〜500字）
+
+- CLI + skill の2段構えの振り返り
+- 設計思想: シングルバイナリ、AI 親和性、docker-compose.yml ベース
+- リンク集:
+  - `brew install crowdy/tap/conoha`
+  - `github.com/crowdy/conoha-cli`
+  - `github.com/crowdy/conoha-cli-skill`
+
+## 想定文字数
+
+合計約 5600 字（骨格）。コード例・解説の充実で 6000 字以上に到達。
+
+## 成果物
+
+- `docs/articles/2026-04-05-note-conoha-cli.md` に Markdown 原稿を作成

--- a/docs/superpowers/specs/2026-04-07-app-reset-design.md
+++ b/docs/superpowers/specs/2026-04-07-app-reset-design.md
@@ -1,0 +1,51 @@
+# App Reset Command Design Spec
+
+## Problem
+
+Redeploying an app from scratch requires three separate commands (`app destroy`, `app init`, `app deploy`). This is tedious for iterative development and error-prone in automated/agent workflows.
+
+## Solution
+
+Add `conoha app reset <server> --app-name <app>` that combines destroy + init + deploy in a single command with a single SSH connection.
+
+## Command
+
+```
+conoha app reset <id|name> --app-name <app> [--yes] [--user root] [--port 22] [--identity <key>]
+```
+
+- `--yes` skips the confirmation prompt
+- Inherits all standard app flags via `addAppFlags()`
+
+## Execution Flow
+
+1. `connectToApp()` — resolve server, SSH connect (1 connection, reused)
+2. Confirmation prompt (skipped with `--yes`)
+3. Run `generateDestroyScript()` via SSH — stop containers, remove work dir/git repo/env file
+4. Run `generateInitScript()` via SSH — install Docker/git, create bare repo + post-receive hook
+5. Run deploy logic — check local compose file, create tar.gz, upload, docker compose up
+
+## Implementation
+
+### Extract deploy helper
+
+Refactor `deploy.go`: extract the RunE body into `deployApp(ctx *appContext) error`. The `deployCmd.RunE` calls this helper.
+
+### New file: `reset.go`
+
+- `resetCmd` cobra command with `--yes` flag
+- Calls `connectToApp()`, then sequentially: destroy script, init script, `deployApp()`
+- Each step prints progress to stderr
+
+### Registration
+
+Add `resetCmd` to `app.go` via `Cmd.AddCommand(resetCmd)`.
+
+## Error Handling
+
+Each step (destroy, init, deploy) fails fast. If init fails after destroy, the app is in a partially destroyed state — user can manually run `app init` + `app deploy` to recover.
+
+## Testing
+
+- `reset_test.go`: verify command structure, `--yes` flag registration
+- Deploy helper extraction is covered by existing deploy behavior (no behavior change)


### PR DESCRIPTION
## Summary

- Extract `deployApp()` helper from `deploy.go` for reuse
- Add `app reset` command that combines destroy + init + deploy in a single step
- Single SSH connection reused across all three phases
- `--yes` flag to skip confirmation for non-interactive/agent workflows

Closes #73

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [x] `conoha app reset --help` shows correct flags
- [x] Manual test: `conoha app reset <server> --app-name <app> --yes`