### PR TITLE
feat: support conoha-docker-compose.yml and --compose-file flag

### DIFF
--- a/cmd/app/connect.go
+++ b/cmd/app/connect.go
@@ -53,7 +53,10 @@ func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
 	user, _ := cmd.Flags().GetString("user")
 	port, _ := cmd.Flags().GetString("port")
 	identity, _ := cmd.Flags().GetString("identity")
-	composeFile, _ := cmd.Flags().GetString("compose-file")
+	var composeFile string
+	if f := cmd.Flags().Lookup("compose-file"); f != nil {
+		composeFile = f.Value.String()
+	}
 
 	if identity == "" {
 		identity = internalssh.ResolveKeyPath(s.KeyName)

--- a/cmd/app/connect.go
+++ b/cmd/app/connect.go
@@ -14,11 +14,12 @@ import (
 )
 
 type appContext struct {
-	Client  *ssh.Client
-	AppName string
-	Server  *model.Server
-	IP      string
-	User    string
+	Client      *ssh.Client
+	AppName     string
+	Server      *model.Server
+	IP          string
+	User        string
+	ComposeFile string
 }
 
 func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
@@ -52,6 +53,7 @@ func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
 	user, _ := cmd.Flags().GetString("user")
 	port, _ := cmd.Flags().GetString("port")
 	identity, _ := cmd.Flags().GetString("identity")
+	composeFile, _ := cmd.Flags().GetString("compose-file")
 
 	if identity == "" {
 		identity = internalssh.ResolveKeyPath(s.KeyName)
@@ -71,11 +73,12 @@ func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
 	}
 
 	return &appContext{
-		Client:  sshClient,
-		AppName: appName,
-		Server:  s,
-		IP:      ip,
-		User:    user,
+		Client:      sshClient,
+		AppName:     appName,
+		Server:      s,
+		IP:          ip,
+		User:        user,
+		ComposeFile: composeFile,
 	}, nil
 }
 

--- a/cmd/app/connect_test.go
+++ b/cmd/app/connect_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -68,6 +69,31 @@ func TestDetectComposeFile(t *testing.T) {
 		if got != name {
 			t.Errorf("expected %q, got %q", name, got)
 		}
+	}
+}
+
+func TestResolveComposeFile(t *testing.T) {
+	// Explicit file that exists
+	dir := t.TempDir()
+	f := filepath.Join(dir, "custom-compose.yml")
+	if err := os.WriteFile(f, []byte("version: '3'"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveComposeFile(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != f {
+		t.Errorf("expected %q, got %q", f, got)
+	}
+
+	// Explicit file that does not exist
+	_, err = resolveComposeFile("/nonexistent/compose.yml")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+	if err != nil && !strings.Contains(err.Error(), "compose file not found") {
+		t.Errorf("expected error to contain %q, got %q", "compose file not found", err.Error())
 	}
 }
 

--- a/cmd/app/connect_test.go
+++ b/cmd/app/connect_test.go
@@ -29,22 +29,61 @@ func TestAddAppFlags(t *testing.T) {
 	}
 }
 
-func TestHasComposeFile(t *testing.T) {
+func TestDeployCmdHasComposeFileFlag(t *testing.T) {
+	f := deployCmd.Flags().Lookup("compose-file")
+	if f == nil {
+		t.Fatal("expected compose-file flag to be registered on deployCmd")
+	}
+	if f.Shorthand != "f" {
+		t.Errorf("compose-file shorthand: got %q, want %q", f.Shorthand, "f")
+	}
+}
+
+func TestDetectComposeFile(t *testing.T) {
 	// Empty dir — no compose file
 	dir := t.TempDir()
-	if hasComposeFile(dir) {
-		t.Error("expected false for empty dir")
+	_, err := detectComposeFile(dir)
+	if err == nil {
+		t.Error("expected error for empty dir")
 	}
 
 	// Each valid compose file name
-	names := []string{"docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"}
+	names := []string{
+		"conoha-docker-compose.yml",
+		"conoha-docker-compose.yaml",
+		"docker-compose.yml",
+		"docker-compose.yaml",
+		"compose.yml",
+		"compose.yaml",
+	}
 	for _, name := range names {
 		d := t.TempDir()
 		if err := os.WriteFile(filepath.Join(d, name), []byte("version: '3'"), 0644); err != nil {
 			t.Fatal(err)
 		}
-		if !hasComposeFile(d) {
-			t.Errorf("expected true for %s", name)
+		got, err := detectComposeFile(d)
+		if err != nil {
+			t.Errorf("expected no error for %s, got %v", name, err)
 		}
+		if got != name {
+			t.Errorf("expected %q, got %q", name, got)
+		}
+	}
+}
+
+func TestDetectComposeFilePriority(t *testing.T) {
+	// conoha-docker-compose.yml takes priority over docker-compose.yml
+	dir := t.TempDir()
+	for _, name := range []string{"conoha-docker-compose.yml", "docker-compose.yml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("version: '3'"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := detectComposeFile(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "conoha-docker-compose.yml" {
+		t.Errorf("expected conoha-docker-compose.yml to take priority, got %q", got)
 	}
 }

--- a/cmd/app/connect_test.go
+++ b/cmd/app/connect_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	clerrors "github.com/crowdy/conoha-cli/internal/errors"
 )
 
 func TestAddAppFlags(t *testing.T) {
@@ -94,6 +96,44 @@ func TestResolveComposeFile(t *testing.T) {
 	}
 	if err != nil && !strings.Contains(err.Error(), "compose file not found") {
 		t.Errorf("expected error to contain %q, got %q", "compose file not found", err.Error())
+	}
+	// Should be a ValidationError (exit code 4)
+	if _, ok := err.(*clerrors.ValidationError); !ok {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestValidateComposeFilePath(t *testing.T) {
+	valid := []string{
+		"docker-compose.yml",
+		"conoha-docker-compose.yaml",
+		"compose.yml",
+		"path/to/compose.yml",
+		"my_app-compose.yml",
+	}
+	for _, p := range valid {
+		if err := validateComposeFilePath(p); err != nil {
+			t.Errorf("expected %q to be valid, got error: %v", p, err)
+		}
+	}
+
+	invalid := []string{
+		"it's-compose.yml",
+		"compose;rm -rf.yml",
+		"$(whoami).yml",
+		"file`cmd`.yml",
+		"a b.yml",
+		"compose|pipe.yml",
+		"compose&bg.yml",
+	}
+	for _, p := range invalid {
+		err := validateComposeFilePath(p)
+		if err == nil {
+			t.Errorf("expected %q to be invalid", p)
+		}
+		if _, ok := err.(*clerrors.ValidationError); !ok {
+			t.Errorf("expected ValidationError for %q, got %T", p, err)
+		}
 	}
 }
 

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -13,6 +13,7 @@ import (
 
 func init() {
 	addAppFlags(deployCmd)
+	deployCmd.Flags().StringP("compose-file", "f", "", "compose file path (auto-detected if not specified)")
 }
 
 var deployCmd = &cobra.Command{
@@ -32,8 +33,8 @@ var deployCmd = &cobra.Command{
 
 func deployApp(ctx *appContext) error {
 	// Pre-flight: check compose file exists locally
-	if !hasComposeFile(".") {
-		return fmt.Errorf("no docker-compose.yml/yaml or compose.yml/yaml found in current directory")
+	if _, err := detectComposeFile("."); err != nil {
+		return err
 	}
 
 	// Load .dockerignore
@@ -80,12 +81,22 @@ func deployApp(ctx *appContext) error {
 	return nil
 }
 
-// hasComposeFile checks if a docker compose file exists in dir.
-func hasComposeFile(dir string) bool {
-	for _, name := range []string{"docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"} {
+// composeFileNames lists compose files in detection priority order.
+var composeFileNames = []string{
+	"conoha-docker-compose.yml",
+	"conoha-docker-compose.yaml",
+	"docker-compose.yml",
+	"docker-compose.yaml",
+	"compose.yml",
+	"compose.yaml",
+}
+
+// detectComposeFile returns the first compose file found in dir.
+func detectComposeFile(dir string) (string, error) {
+	for _, name := range composeFileNames {
 		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
-			return true
+			return name, nil
 		}
 	}
-	return false
+	return "", fmt.Errorf("no compose file found in current directory (checked conoha-docker-compose.yml/yaml, docker-compose.yml/yaml, compose.yml/yaml)")
 }

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -82,7 +82,7 @@ func deployApp(ctx *appContext) error {
 	composeCmd := fmt.Sprintf(
 		"ENV_FILE=/opt/conoha/%s.env.server; "+
 			"if [ -f \"$ENV_FILE\" ]; then cp \"$ENV_FILE\" %s/.env; fi && "+
-			"cd %s && docker compose -f %s up -d --build --remove-orphans && docker compose -f %s ps",
+			"cd %s && docker compose -f '%s' up -d --build --remove-orphans && docker compose -f '%s' ps",
 		ctx.AppName, workDir, workDir, composeFile, composeFile)
 	exitCode, err = internalssh.RunCommand(ctx.Client, composeCmd, os.Stdout, os.Stderr)
 	if err != nil {

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -31,11 +31,26 @@ var deployCmd = &cobra.Command{
 	},
 }
 
+// resolveComposeFile returns the compose file to use.
+// If explicit is non-empty, it validates that the file exists.
+// Otherwise it auto-detects using the priority order.
+func resolveComposeFile(explicit string) (string, error) {
+	if explicit != "" {
+		if _, err := os.Stat(explicit); err != nil {
+			return "", fmt.Errorf("compose file not found: %s", explicit)
+		}
+		return explicit, nil
+	}
+	return detectComposeFile(".")
+}
+
 func deployApp(ctx *appContext) error {
-	// Pre-flight: check compose file exists locally
-	if _, err := detectComposeFile("."); err != nil {
+	// Resolve compose file
+	composeFile, err := resolveComposeFile(ctx.ComposeFile)
+	if err != nil {
 		return err
 	}
+	fmt.Fprintf(os.Stderr, "Using compose file: %s\n", composeFile)
 
 	// Load .dockerignore
 	patterns, err := loadIgnorePatterns(".")
@@ -67,8 +82,8 @@ func deployApp(ctx *appContext) error {
 	composeCmd := fmt.Sprintf(
 		"ENV_FILE=/opt/conoha/%s.env.server; "+
 			"if [ -f \"$ENV_FILE\" ]; then cp \"$ENV_FILE\" %s/.env; fi && "+
-			"cd %s && docker compose up -d --build --remove-orphans && docker compose ps",
-		ctx.AppName, workDir, workDir)
+			"cd %s && docker compose -f %s up -d --build --remove-orphans && docker compose -f %s ps",
+		ctx.AppName, workDir, workDir, composeFile, composeFile)
 	exitCode, err = internalssh.RunCommand(ctx.Client, composeCmd, os.Stdout, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("deploy failed: %w", err)

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/spf13/cobra"
 
+	clerrors "github.com/crowdy/conoha-cli/internal/errors"
 	internalssh "github.com/crowdy/conoha-cli/internal/ssh"
 )
 
@@ -31,13 +33,33 @@ var deployCmd = &cobra.Command{
 	},
 }
 
+// composeFileRegex allows alphanumeric, hyphens, dots, underscores, and path separators.
+var composeFileRegex = regexp.MustCompile(`^[a-zA-Z0-9/][a-zA-Z0-9._/-]*$`)
+
+// validateComposeFilePath checks that the path contains only safe characters.
+func validateComposeFilePath(path string) error {
+	if !composeFileRegex.MatchString(path) {
+		return &clerrors.ValidationError{
+			Field:   "compose-file",
+			Message: fmt.Sprintf("invalid compose file path %q: must contain only alphanumeric, hyphens, dots, underscores, and slashes", path),
+		}
+	}
+	return nil
+}
+
 // resolveComposeFile returns the compose file to use.
 // If explicit is non-empty, it validates that the file exists.
 // Otherwise it auto-detects using the priority order.
 func resolveComposeFile(explicit string) (string, error) {
 	if explicit != "" {
+		if err := validateComposeFilePath(explicit); err != nil {
+			return "", err
+		}
 		if _, err := os.Stat(explicit); err != nil {
-			return "", fmt.Errorf("compose file not found: %s", explicit)
+			return "", &clerrors.ValidationError{
+				Field:   "compose-file",
+				Message: fmt.Sprintf("compose file not found: %s", explicit),
+			}
 		}
 		return explicit, nil
 	}
@@ -113,5 +135,8 @@ func detectComposeFile(dir string) (string, error) {
 			return name, nil
 		}
 	}
-	return "", fmt.Errorf("no compose file found in current directory (checked conoha-docker-compose.yml/yaml, docker-compose.yml/yaml, compose.yml/yaml)")
+	return "", &clerrors.ValidationError{
+		Field:   "compose-file",
+		Message: "no compose file found in current directory (checked conoha-docker-compose.yml/yaml, docker-compose.yml/yaml, compose.yml/yaml)",
+	}
 }

--- a/cmd/app/init.go
+++ b/cmd/app/init.go
@@ -100,11 +100,26 @@ while read -r oldrev newrev refname; do
 
     cd "$WORK_DIR"
 
-    if [ -f docker-compose.yml ] || [ -f docker-compose.yaml ] || [ -f compose.yml ] || [ -f compose.yaml ]; then
-        echo "==> Building and starting containers..."
-        docker compose up -d --build --remove-orphans
+    COMPOSE_FILE=""
+    if [ -f conoha-docker-compose.yml ]; then
+        COMPOSE_FILE=conoha-docker-compose.yml
+    elif [ -f conoha-docker-compose.yaml ]; then
+        COMPOSE_FILE=conoha-docker-compose.yaml
+    elif [ -f docker-compose.yml ]; then
+        COMPOSE_FILE=docker-compose.yml
+    elif [ -f docker-compose.yaml ]; then
+        COMPOSE_FILE=docker-compose.yaml
+    elif [ -f compose.yml ]; then
+        COMPOSE_FILE=compose.yml
+    elif [ -f compose.yaml ]; then
+        COMPOSE_FILE=compose.yaml
+    fi
+
+    if [ -n "$COMPOSE_FILE" ]; then
+        echo "==> Building and starting containers with $COMPOSE_FILE..."
+        docker compose -f "$COMPOSE_FILE" up -d --build --remove-orphans
         echo "==> Deploy complete!"
-        docker compose ps
+        docker compose -f "$COMPOSE_FILE" ps
     else
         echo "Warning: No compose file found in $WORK_DIR"
         echo "Push a docker-compose.yml to enable auto-deploy."

--- a/cmd/app/init_test.go
+++ b/cmd/app/init_test.go
@@ -21,7 +21,7 @@ func TestGenerateInitScript(t *testing.T) {
 		{"work dir", "/opt/conoha/${APP_NAME}"},
 		{"bare repo init", "git init --bare"},
 		{"post-receive hook", "hooks/post-receive"},
-		{"docker compose up", "docker compose up -d --build"},
+		{"docker compose up", `docker compose -f "$COMPOSE_FILE" up -d --build`},
 		{"deploy branch", `DEPLOY_BRANCH="main"`},
 		{"branch check", `read -r oldrev newrev refname`},
 		{"chmod", "chmod +x"},
@@ -33,6 +33,34 @@ func TestGenerateInitScript(t *testing.T) {
 				t.Errorf("script missing %q", c.want)
 			}
 		})
+	}
+}
+
+func TestGenerateInitScriptComposeDetection(t *testing.T) {
+	script := string(generateInitScript("myapp"))
+
+	// Verify conoha-docker-compose.yml is checked first
+	checks := []string{
+		"conoha-docker-compose.yml",
+		"conoha-docker-compose.yaml",
+		"docker-compose.yml",
+		"docker-compose.yaml",
+		"compose.yml",
+		"compose.yaml",
+		"COMPOSE_FILE=",
+		`docker compose -f "$COMPOSE_FILE"`,
+	}
+	for _, want := range checks {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %q", want)
+		}
+	}
+
+	// Verify priority order: conoha-docker-compose.yml appears before docker-compose.yml
+	conohaIdx := strings.Index(script, "conoha-docker-compose.yml")
+	dockerIdx := strings.Index(script, "docker-compose.yml")
+	if conohaIdx > dockerIdx {
+		t.Error("conoha-docker-compose.yml should be checked before docker-compose.yml")
 	}
 }
 

--- a/docs/superpowers/plans/2026-04-09-compose-file-support.md
+++ b/docs/superpowers/plans/2026-04-09-compose-file-support.md
@@ -1,0 +1,423 @@
+# Compose File Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Support `conoha-docker-compose.yml` auto-detection and `--compose-file` flag for `app deploy` (#75).
+
+**Architecture:** Refactor `hasComposeFile()` to `detectComposeFile()` returning the detected filename. Add `--compose-file` / `-f` flag to `addAppFlags()`. Pass `-f <file>` to remote `docker compose` commands. Update post-receive hook in `init.go` to match new detection order.
+
+**Tech Stack:** Go, cobra, `os.Stat`, shell scripting for post-receive hook
+
+---
+
+### File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `cmd/app/deploy.go` | Modify | Replace `hasComposeFile()` with `detectComposeFile()`, update `deployApp()` |
+| `cmd/app/connect.go` | Modify | Add `--compose-file` / `-f` flag to `addAppFlags()` |
+| `cmd/app/init.go` | Modify | Update post-receive hook template |
+| `cmd/app/connect_test.go` | Modify | Replace `TestHasComposeFile` with `TestDetectComposeFile`, add flag test |
+| `cmd/app/init_test.go` | Modify | Add assertions for new hook detection order |
+
+---
+
+### Task 1: Add `--compose-file` flag and update `detectComposeFile()`
+
+**Files:**
+- Modify: `cmd/app/connect.go:82-87`
+- Modify: `cmd/app/deploy.go:83-91`
+- Modify: `cmd/app/connect_test.go:32-50`
+
+- [ ] **Step 1: Write tests for `detectComposeFile()` and the new flag**
+
+Replace `TestHasComposeFile` and add `TestDetectComposeFilePriority` in `cmd/app/connect_test.go`. Replace the entire file content with:
+
+```go
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAddAppFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	addAppFlags(cmd)
+
+	flags := []string{"app-name", "user", "port", "identity", "compose-file"}
+	for _, name := range flags {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected flag %q to be registered", name)
+		}
+	}
+
+	// Check shorthand
+	shorthands := map[string]string{"user": "l", "port": "p", "identity": "i", "compose-file": "f"}
+	for name, short := range shorthands {
+		f := cmd.Flags().Lookup(name)
+		if f.Shorthand != short {
+			t.Errorf("flag %q shorthand: got %q, want %q", name, f.Shorthand, short)
+		}
+	}
+}
+
+func TestDetectComposeFile(t *testing.T) {
+	// Empty dir — no compose file
+	dir := t.TempDir()
+	_, err := detectComposeFile(dir)
+	if err == nil {
+		t.Error("expected error for empty dir")
+	}
+
+	// Each valid compose file name
+	names := []string{
+		"conoha-docker-compose.yml",
+		"conoha-docker-compose.yaml",
+		"docker-compose.yml",
+		"docker-compose.yaml",
+		"compose.yml",
+		"compose.yaml",
+	}
+	for _, name := range names {
+		d := t.TempDir()
+		if err := os.WriteFile(filepath.Join(d, name), []byte("version: '3'"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := detectComposeFile(d)
+		if err != nil {
+			t.Errorf("expected no error for %s, got %v", name, err)
+		}
+		if got != name {
+			t.Errorf("expected %q, got %q", name, got)
+		}
+	}
+}
+
+func TestDetectComposeFilePriority(t *testing.T) {
+	// conoha-docker-compose.yml takes priority over docker-compose.yml
+	dir := t.TempDir()
+	for _, name := range []string{"conoha-docker-compose.yml", "docker-compose.yml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("version: '3'"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := detectComposeFile(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "conoha-docker-compose.yml" {
+		t.Errorf("expected conoha-docker-compose.yml to take priority, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/app/ -run "TestDetectComposeFile|TestAddAppFlags" -v`
+Expected: FAIL — `detectComposeFile` undefined, `compose-file` flag not found
+
+- [ ] **Step 3: Add `--compose-file` flag to `addAppFlags()`**
+
+In `cmd/app/connect.go`, add one line at the end of `addAppFlags()`:
+
+```go
+func addAppFlags(cmd *cobra.Command) {
+	cmd.Flags().String("app-name", "", "application name")
+	cmd.Flags().StringP("user", "l", "root", "SSH user")
+	cmd.Flags().StringP("port", "p", "22", "SSH port")
+	cmd.Flags().StringP("identity", "i", "", "SSH private key path")
+	cmd.Flags().StringP("compose-file", "f", "", "compose file path (auto-detected if not specified)")
+}
+```
+
+- [ ] **Step 4: Replace `hasComposeFile()` with `detectComposeFile()` in `deploy.go`**
+
+Replace the `hasComposeFile` function (lines 83-91) with:
+
+```go
+// composeFileNames lists compose files in detection priority order.
+var composeFileNames = []string{
+	"conoha-docker-compose.yml",
+	"conoha-docker-compose.yaml",
+	"docker-compose.yml",
+	"docker-compose.yaml",
+	"compose.yml",
+	"compose.yaml",
+}
+
+// detectComposeFile returns the first compose file found in dir.
+func detectComposeFile(dir string) (string, error) {
+	for _, name := range composeFileNames {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no compose file found in current directory (checked conoha-docker-compose.yml/yaml, docker-compose.yml/yaml, compose.yml/yaml)")
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./cmd/app/ -run "TestDetectComposeFile|TestAddAppFlags" -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/app/deploy.go cmd/app/connect.go cmd/app/connect_test.go
+git commit -m "feat: add detectComposeFile and --compose-file flag (#75)"
+```
+
+---
+
+### Task 2: Update `deployApp()` to use compose file selection
+
+**Files:**
+- Modify: `cmd/app/deploy.go:33-81`
+
+- [ ] **Step 1: Update `deployApp()` to resolve and use compose file**
+
+Replace the `deployApp` function in `cmd/app/deploy.go` with:
+
+```go
+func deployApp(ctx *appContext) error {
+	// Resolve compose file
+	composeFile, err := resolveComposeFile(ctx.ComposeFile)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Using compose file: %s\n", composeFile)
+
+	// Load .dockerignore
+	patterns, err := loadIgnorePatterns(".")
+	if err != nil {
+		return err
+	}
+
+	// Create tar.gz
+	fmt.Fprintf(os.Stderr, "Archiving current directory...\n")
+	var buf bytes.Buffer
+	if err := createTarGz(".", patterns, &buf); err != nil {
+		return fmt.Errorf("create archive: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Uploading to %s (%s)...\n", ctx.Server.Name, ctx.IP)
+
+	// Transfer tar (clean deploy: remove old files first)
+	workDir := "/opt/conoha/" + ctx.AppName
+	tarCmd := fmt.Sprintf("rm -rf %s && mkdir -p %s && tar xzf - -C %s", workDir, workDir, workDir)
+	exitCode, err := internalssh.RunWithStdin(ctx.Client, tarCmd, &buf, os.Stdout, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("upload failed: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("upload exited with code %d", exitCode)
+	}
+
+	// Docker compose up (copy .env.server if exists)
+	fmt.Fprintf(os.Stderr, "Building and starting containers...\n")
+	composeCmd := fmt.Sprintf(
+		"ENV_FILE=/opt/conoha/%s.env.server; "+
+			"if [ -f \"$ENV_FILE\" ]; then cp \"$ENV_FILE\" %s/.env; fi && "+
+			"cd %s && docker compose -f %s up -d --build --remove-orphans && docker compose -f %s ps",
+		ctx.AppName, workDir, workDir, composeFile, composeFile)
+	exitCode, err = internalssh.RunCommand(ctx.Client, composeCmd, os.Stdout, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("deploy failed: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("deploy exited with code %d", exitCode)
+	}
+
+	fmt.Fprintf(os.Stderr, "Deploy complete.\n")
+	return nil
+}
+
+// resolveComposeFile returns the compose file to use.
+// If explicit is non-empty, it validates that the file exists.
+// Otherwise it auto-detects using the priority order.
+func resolveComposeFile(explicit string) (string, error) {
+	if explicit != "" {
+		if _, err := os.Stat(explicit); err != nil {
+			return "", fmt.Errorf("compose file not found: %s", explicit)
+		}
+		return explicit, nil
+	}
+	return detectComposeFile(".")
+}
+```
+
+- [ ] **Step 2: Add `ComposeFile` field to `appContext` and wire the flag**
+
+In `cmd/app/connect.go`, add the field to `appContext`:
+
+```go
+type appContext struct {
+	Client      *ssh.Client
+	AppName     string
+	Server      *model.Server
+	IP          string
+	User        string
+	ComposeFile string
+}
+```
+
+In `connectToApp()`, read the flag and set the field. Add after the `identity` resolution block (after line 58):
+
+```go
+	composeFile, _ := cmd.Flags().GetString("compose-file")
+```
+
+And set it in the return struct:
+
+```go
+	return &appContext{
+		Client:      sshClient,
+		AppName:     appName,
+		Server:      s,
+		IP:          ip,
+		User:        user,
+		ComposeFile: composeFile,
+	}, nil
+```
+
+- [ ] **Step 3: Run all app tests**
+
+Run: `go test ./cmd/app/ -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/app/deploy.go cmd/app/connect.go
+git commit -m "feat: use compose file selection in deploy flow (#75)"
+```
+
+---
+
+### Task 3: Update post-receive hook in `init.go`
+
+**Files:**
+- Modify: `cmd/app/init.go:103-112`
+- Modify: `cmd/app/init_test.go`
+
+- [ ] **Step 1: Add test assertions for new hook detection order**
+
+Add a new test in `cmd/app/init_test.go`:
+
+```go
+func TestGenerateInitScriptComposeDetection(t *testing.T) {
+	script := string(generateInitScript("myapp"))
+
+	// Verify conoha-docker-compose.yml is checked first
+	checks := []string{
+		"conoha-docker-compose.yml",
+		"conoha-docker-compose.yaml",
+		"docker-compose.yml",
+		"docker-compose.yaml",
+		"compose.yml",
+		"compose.yaml",
+		"COMPOSE_FILE=",
+		`docker compose -f "$COMPOSE_FILE"`,
+	}
+	for _, want := range checks {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %q", want)
+		}
+	}
+
+	// Verify priority order: conoha-docker-compose.yml appears before docker-compose.yml
+	conohaIdx := strings.Index(script, "conoha-docker-compose.yml")
+	dockerIdx := strings.Index(script, "docker-compose.yml")
+	if conohaIdx > dockerIdx {
+		t.Error("conoha-docker-compose.yml should be checked before docker-compose.yml")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/app/ -run TestGenerateInitScriptComposeDetection -v`
+Expected: FAIL — missing `conoha-docker-compose.yml` and `COMPOSE_FILE=` in script
+
+- [ ] **Step 3: Update the post-receive hook template in `init.go`**
+
+Replace lines 103-111 in `generateInitScript()` (the compose detection block inside the HOOK heredoc) with:
+
+```go
+    COMPOSE_FILE=""
+    if [ -f conoha-docker-compose.yml ]; then
+        COMPOSE_FILE=conoha-docker-compose.yml
+    elif [ -f conoha-docker-compose.yaml ]; then
+        COMPOSE_FILE=conoha-docker-compose.yaml
+    elif [ -f docker-compose.yml ]; then
+        COMPOSE_FILE=docker-compose.yml
+    elif [ -f docker-compose.yaml ]; then
+        COMPOSE_FILE=docker-compose.yaml
+    elif [ -f compose.yml ]; then
+        COMPOSE_FILE=compose.yml
+    elif [ -f compose.yaml ]; then
+        COMPOSE_FILE=compose.yaml
+    fi
+
+    if [ -n "$COMPOSE_FILE" ]; then
+        echo "==> Building and starting containers with $COMPOSE_FILE..."
+        docker compose -f "$COMPOSE_FILE" up -d --build --remove-orphans
+        echo "==> Deploy complete!"
+        docker compose -f "$COMPOSE_FILE" ps
+    else
+        echo "Warning: No compose file found in $WORK_DIR"
+        echo "Push a docker-compose.yml to enable auto-deploy."
+    fi
+```
+
+- [ ] **Step 4: Update existing init test assertion**
+
+In `cmd/app/init_test.go`, update the `TestGenerateInitScript` check for `"docker compose up"`. The existing check `{"docker compose up", "docker compose up -d --build"}` should be updated to:
+
+```go
+{"docker compose up", `docker compose -f "$COMPOSE_FILE" up -d --build`},
+```
+
+- [ ] **Step 5: Run all tests to verify they pass**
+
+Run: `go test ./cmd/app/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/app/init.go cmd/app/init_test.go
+git commit -m "feat: update post-receive hook with compose file priority (#75)"
+```
+
+---
+
+### Task 4: Lint and final verification
+
+**Files:** All modified files
+
+- [ ] **Step 1: Run linter**
+
+Run: `make lint`
+Expected: No issues
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `make test`
+Expected: All tests pass
+
+- [ ] **Step 3: Build**
+
+Run: `make build`
+Expected: Clean build
+
+- [ ] **Step 4: Final commit if any lint fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: lint issues from compose file support"
+```

--- a/docs/superpowers/specs/2026-04-09-compose-file-support-design.md
+++ b/docs/superpowers/specs/2026-04-09-compose-file-support-design.md
@@ -1,0 +1,95 @@
+# Compose File Support for app deploy
+
+**Issue:** [#75](https://github.com/crowdy/conoha-cli/issues/75)
+**Date:** 2026-04-09
+
+## Problem
+
+`conoha app deploy` always uses whichever compose file `docker compose` auto-detects in the current directory. Projects that use `docker-compose.yml` for local dev or other cloud providers must manually swap files before deploying to ConoHa.
+
+## Solution
+
+### 1. Auto-detect `conoha-docker-compose.yml`
+
+Refactor `hasComposeFile()` in `deploy.go` to `detectComposeFile(dir string) (string, error)` that returns the first matching filename in priority order:
+
+1. `conoha-docker-compose.yml`
+2. `conoha-docker-compose.yaml`
+3. `docker-compose.yml`
+4. `docker-compose.yaml`
+5. `compose.yml`
+6. `compose.yaml`
+
+Returns an error if none found.
+
+### 2. `--compose-file` flag
+
+Add `--compose-file` / `-f` (string, optional) to `addAppFlags()` in `connect.go` so all app subcommands receive it. Only `deploy` reads it initially.
+
+When specified:
+- Validate the file exists locally before deploying
+- Use that filename for the remote `docker compose -f <file>` command
+
+When not specified:
+- Auto-detect using the 6-file priority order
+
+In both cases, the remote command becomes:
+
+```bash
+docker compose -f <file> up -d --build --remove-orphans
+docker compose -f <file> ps
+```
+
+### 3. Post-receive hook update
+
+Update the hook template in `init.go` to match the new 6-file priority order using shell if/elif chain:
+
+```bash
+if [ -f conoha-docker-compose.yml ]; then
+    COMPOSE_FILE=conoha-docker-compose.yml
+elif [ -f conoha-docker-compose.yaml ]; then
+    COMPOSE_FILE=conoha-docker-compose.yaml
+elif [ -f docker-compose.yml ]; then
+    COMPOSE_FILE=docker-compose.yml
+elif [ -f docker-compose.yaml ]; then
+    COMPOSE_FILE=docker-compose.yaml
+elif [ -f compose.yml ]; then
+    COMPOSE_FILE=compose.yml
+elif [ -f compose.yaml ]; then
+    COMPOSE_FILE=compose.yaml
+fi
+
+if [ -n "$COMPOSE_FILE" ]; then
+    echo "==> Building and starting containers with $COMPOSE_FILE..."
+    docker compose -f "$COMPOSE_FILE" up -d --build --remove-orphans
+    docker compose -f "$COMPOSE_FILE" ps
+fi
+```
+
+### 4. Error handling
+
+- `--compose-file` points to non-existent file: error `compose file not found: <path>` (exit code 4)
+- No compose file detected and no flag: error `no compose file found in current directory (checked conoha-docker-compose.yml/yaml, docker-compose.yml/yaml, compose.yml/yaml)` (exit code 4)
+
+### 5. Testing
+
+- **`deploy_test.go`**: Test `detectComposeFile()` with various file combinations (conoha priority, fallback, no file)
+- **Existing deploy tests**: Update remote command assertions to include `-f <file>`
+- **Flag tests**: Verify `--compose-file` flag is registered on all app subcommands
+- **`init_test.go`**: Update post-receive hook assertions to match new template
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `cmd/app/deploy.go` | Refactor `hasComposeFile()` to `detectComposeFile()`, update `deployApp()` to use detected/specified file, pass `-f` to remote commands |
+| `cmd/app/connect.go` | Add `--compose-file` / `-f` flag to `addAppFlags()` |
+| `cmd/app/init.go` | Update post-receive hook template with new detection order |
+| `cmd/app/deploy_test.go` | Add `detectComposeFile()` tests, update deploy flow tests |
+| `cmd/app/init_test.go` | Update hook template assertions |
+
+## Out of scope
+
+- Config persistence (saving compose file choice in app config)
+- Archive filtering (excluding non-selected compose files from tar)
+- `--compose-file` support baked into post-receive hook


### PR DESCRIPTION
## Summary
- Add `conoha-docker-compose.yml/yaml` auto-detection with priority over `docker-compose.yml/yaml` and `compose.yml/yaml`
- Add `--compose-file` / `-f` flag to `app deploy` for explicit compose file selection
- Update post-receive hook in `app init` to use the same 6-file priority detection order
- Shell-safe quoting for compose file names in remote commands

Closes #75

## Test Plan
- [x] `TestDetectComposeFile` — all 6 compose file names detected, empty dir returns error
- [x] `TestDetectComposeFilePriority` — conoha-docker-compose.yml takes priority
- [x] `TestResolveComposeFile` — explicit file validation and auto-detect fallback
- [x] `TestDeployCmdHasComposeFileFlag` — flag registered with `-f` shorthand
- [x] `TestGenerateInitScriptComposeDetection` — hook template has correct detection order
- [x] All existing tests pass, lint clean, build succeeds