### PR TITLE
fix: use debug.BuildInfo fallback for go install version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 
@@ -62,6 +63,11 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	if version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+			version = info.Main.Version
+		}
+	}
 	rootCmd.Version = version
 	rootCmd.SetVersionTemplate("conoha version {{.Version}}\n")
 	rootCmd.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "verbose output")


### PR DESCRIPTION
Closes #77

## Summary
- When installed via `go install`, ldflags are not applied so version stays as `"dev"`
- Added `runtime/debug.ReadBuildInfo()` fallback in `init()` to read the module version
- Now `go install github.com/crowdy/conoha-cli@v0.5.0` correctly sends `crowdy/conoha-cli/v0.5.0` as User-Agent and reports the right version with `--version`

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes (0 issues)