### PR TITLE
fix: --no-input implies --yes for confirmation prompts

### DIFF
--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -336,7 +336,7 @@ func selectFlavor(compute *api.ComputeAPI) (*model.Flavor, error) {
 		}
 		flavorMap[f.ID] = &usable[i]
 	}
-	id, err := prompt.Select("Select flavor", items)
+	id, err := prompt.Select("Select flavor", items, "use --flavor <id> to specify")
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +359,7 @@ func selectKeypair(compute *api.ComputeAPI) (string, error) {
 			Value: kp.Name,
 		}
 	}
-	return prompt.Select("Select keypair", items)
+	return prompt.Select("Select keypair", items, "use --key-name <name> to specify")
 }
 
 func selectImage(imageAPI *api.ImageAPI) (string, error) {
@@ -383,7 +383,7 @@ func selectImage(imageAPI *api.ImageAPI) (string, error) {
 			Value: img.ID,
 		}
 	}
-	return prompt.Select("Select image", items)
+	return prompt.Select("Select image", items, "use --image <id> to specify")
 }
 
 // maxBootVolumeGB returns the maximum boot volume size in GB for the given flavor.
@@ -608,7 +608,7 @@ func selectSecurityGroups(networkAPI *api.NetworkAPI) ([]string, error) {
 
 	var selected []string
 	for {
-		choice, err := prompt.Select("Select security group (or skip)", items)
+		choice, err := prompt.Select("Select security group (or skip)", items, "use --security-group <name> to specify (repeatable)")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/volume/volume_test.go
+++ b/cmd/volume/volume_test.go
@@ -226,11 +226,12 @@ func TestCreateCmd_DuplicateNameWarning(t *testing.T) {
 	cmd := Cmd
 	cmd.SetArgs([]string{"create", "--name", "my-volume", "--size", "50", "--image", ""})
 	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error in no-input mode when duplicate name exists")
+	// --no-input implies --yes: duplicate-name warning is auto-confirmed and volume is created
+	if err != nil {
+		t.Fatalf("expected no error in no-input mode (auto-confirm duplicate): %v", err)
 	}
-	if createCalled {
-		t.Error("CreateVolume should not have been called when duplicate detected in no-input mode")
+	if !createCalled {
+		t.Error("CreateVolume should have been called (--no-input auto-confirms duplicate warning)")
 	}
 }
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -75,12 +75,10 @@ func Password(label string) (string, error) {
 }
 
 // Confirm asks for yes/no confirmation.
+// In non-interactive mode (--no-input or --yes), it auto-confirms without prompting.
 func Confirm(label string) (bool, error) {
-	if config.IsYes() {
+	if config.IsYes() || config.IsNoInput() {
 		return true, nil
-	}
-	if config.IsNoInput() {
-		return false, fmt.Errorf("confirmation required but --no-input is set; use --yes to auto-confirm")
 	}
 	fmt.Fprintf(os.Stderr, "%s [y/N]: ", label)
 	reader := bufio.NewReader(os.Stdin)

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -30,17 +30,15 @@ func TestConfirm_Yes_Env(t *testing.T) {
 	}
 }
 
-func TestConfirm_NoInput_Without_Yes(t *testing.T) {
+func TestConfirm_NoInput_ImpliesYes(t *testing.T) {
+	// #83: --no-input should auto-confirm like --yes; requiring both is redundant
 	t.Setenv("CONOHA_NO_INPUT", "1")
 	ok, err := Confirm("Delete?")
-	if ok {
-		t.Fatal("expected false when --no-input without --yes")
+	if err != nil {
+		t.Fatalf("--no-input should auto-confirm without error (#83): %v", err)
 	}
-	if err == nil {
-		t.Fatal("expected error when --no-input without --yes")
-	}
-	if got := err.Error(); got != "confirmation required but --no-input is set; use --yes to auto-confirm" {
-		t.Fatalf("unexpected error message: %s", got)
+	if !ok {
+		t.Fatal("--no-input should return true (auto-confirm) (#83)")
 	}
 }
 

--- a/internal/prompt/select.go
+++ b/internal/prompt/select.go
@@ -18,12 +18,15 @@ type SelectItem struct {
 }
 
 // Select shows an interactive selection prompt and returns the selected Value.
-func Select(label string, items []SelectItem) (string, error) {
-	if config.IsNoInput() {
-		return "", fmt.Errorf("selection required but --no-input is set")
-	}
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return "", fmt.Errorf("interactive selection requires a TTY; use flags to specify values")
+// hint (optional) is shown in the error message when a TTY is unavailable,
+// so the user knows which flag to use instead (e.g. "use --security-group <name>").
+// Without a hint, the label is included to identify which selection failed.
+func Select(label string, items []SelectItem, hint ...string) (string, error) {
+	if config.IsNoInput() || !term.IsTerminal(int(os.Stdin.Fd())) {
+		if len(hint) > 0 && hint[0] != "" {
+			return "", fmt.Errorf("%s; interactive selection requires a TTY", hint[0])
+		}
+		return "", fmt.Errorf("interactive selection requires a TTY for %q; use flags to specify values", label)
 	}
 
 	searcher := func(input string, index int) bool {

--- a/internal/prompt/select_test.go
+++ b/internal/prompt/select_test.go
@@ -1,27 +1,43 @@
 package prompt
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"golang.org/x/term"
-	"os"
 
 	"github.com/crowdy/conoha-cli/internal/config"
 )
 
-func TestSelect_NoInput(t *testing.T) {
+func TestSelect_NoInput_WithoutHint_IncludesLabel(t *testing.T) {
+	// Without a hint, the error includes the selection label so the user knows
+	// which selection failed.
 	t.Setenv(config.EnvNoInput, "1")
 	items := []SelectItem{{Label: "test", Value: "v1"}}
-	_, err := Select("pick", items)
+	_, err := Select("Select flavor", items)
 	if err == nil {
 		t.Fatal("expected error when --no-input is set")
 	}
-	if got := err.Error(); got != "selection required but --no-input is set" {
-		t.Errorf("unexpected error: %s", got)
+	if !strings.Contains(err.Error(), "Select flavor") {
+		t.Errorf("error should include label, got: %q", err.Error())
 	}
 }
 
-func TestSelect_NonTTY(t *testing.T) {
+func TestSelect_NoInput_WithHint_ShowsFlag(t *testing.T) {
+	// With a hint, the error names the specific flag the user should provide.
+	t.Setenv(config.EnvNoInput, "1")
+	items := []SelectItem{{Label: "option A", Value: "a"}}
+	_, err := Select("Select security group", items, "use --security-group <name> to specify (repeatable)")
+	if err == nil {
+		t.Fatal("expected error under --no-input")
+	}
+	if !strings.Contains(err.Error(), "--security-group") {
+		t.Errorf("error should include flag hint, got: %q", err.Error())
+	}
+}
+
+func TestSelect_NonTTY_IncludesLabel(t *testing.T) {
 	t.Setenv(config.EnvNoInput, "")
 	if term.IsTerminal(int(os.Stdin.Fd())) {
 		t.Skip("stdin is a terminal, skipping non-TTY test")
@@ -31,8 +47,7 @@ func TestSelect_NonTTY(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when stdin is not a TTY")
 	}
-	expected := "interactive selection requires a TTY; use flags to specify values"
-	if got := err.Error(); got != expected {
-		t.Errorf("unexpected error: %q, want %q", got, expected)
+	if !strings.Contains(err.Error(), "pick") {
+		t.Errorf("error should include label, got: %q", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

- `--no-input` now auto-confirms like `--yes`; requiring both flags was redundant and confusing (#83)
- Boot volume orphan issue resolved: `server create --no-input --flavor ... --image ... --key-name ...` now proceeds through confirmation without leaving orphaned volumes
- `volume create` duplicate-name warning is also auto-confirmed in `--no-input` mode, consistent with the new semantics
- Interactive `Select` prompts now include specific flag hints in error messages (e.g. `use --flavor <id> to specify`) so users know exactly which flag to add (#83)

## Behavior change

| Mode | Before | After |
|------|--------|-------|
| `--yes` | auto-confirm | auto-confirm (unchanged) |
| `--no-input` (no `--yes`) | error: "use --yes to auto-confirm" | auto-confirm |
| `--no-input --yes` | auto-confirm | auto-confirm (unchanged) |
| `--no-input` + missing select flag | `interactive selection requires a TTY` | `use --flavor <id> to specify; interactive selection requires a TTY` |

## Test plan

- [x] `go test ./internal/prompt/` — `TestConfirm_NoInput_ImpliesYes`, `TestSelect_NoInput_WithHint_ShowsFlag`, `TestSelect_NoInput_WithoutHint_IncludesLabel` pass
- [x] `go test ./cmd/volume/` — `TestCreateCmd_DuplicateNameWarning` updated to expect auto-confirm
- [x] `go test ./...` — all tests pass

Closes #83