### PR TITLE
fix: app deploy .env handling and subdirectory .dockerignore support

### DIFF
--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -88,10 +88,11 @@ func deployApp(ctx *appContext) error {
 	}
 	fmt.Fprintf(os.Stderr, "Uploading to %s (%s)...\n", ctx.Server.Name, ctx.IP)
 
-	// Transfer tar (clean deploy: remove old files first)
+	// Upload: backup existing .env, clean-extract archive, then restore .env from
+	// .env.server (if present in archive) or from the backup.
 	workDir := "/opt/conoha/" + ctx.AppName
-	tarCmd := fmt.Sprintf("rm -rf %s && mkdir -p %s && tar xzf - -C %s", workDir, workDir, workDir)
-	exitCode, err := internalssh.RunWithStdin(ctx.Client, tarCmd, &buf, os.Stdout, os.Stderr)
+	uploadCmd := buildUploadCmd(workDir)
+	exitCode, err := internalssh.RunWithStdin(ctx.Client, uploadCmd, &buf, os.Stdout, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("upload failed: %w", err)
 	}
@@ -99,13 +100,9 @@ func deployApp(ctx *appContext) error {
 		return fmt.Errorf("upload exited with code %d", exitCode)
 	}
 
-	// Docker compose up (copy .env.server if exists)
+	// Run docker compose (passes --env-file when .env exists for build-time vars)
 	fmt.Fprintf(os.Stderr, "Building and starting containers...\n")
-	composeCmd := fmt.Sprintf(
-		"ENV_FILE=/opt/conoha/%s.env.server; "+
-			"if [ -f \"$ENV_FILE\" ]; then cp \"$ENV_FILE\" %s/.env; fi && "+
-			"cd %s && docker compose -f '%s' up -d --build --remove-orphans && docker compose -f '%s' ps",
-		ctx.AppName, workDir, workDir, composeFile, composeFile)
+	composeCmd := buildComposeCmd(workDir, composeFile)
 	exitCode, err = internalssh.RunCommand(ctx.Client, composeCmd, os.Stdout, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("deploy failed: %w", err)
@@ -116,6 +113,37 @@ func deployApp(ctx *appContext) error {
 
 	fmt.Fprintf(os.Stderr, "Deploy complete.\n")
 	return nil
+}
+
+// buildUploadCmd generates the shell command that uploads the tar archive.
+// It preserves any pre-existing .env on the server:
+//   - If the new archive contains .env.server, it is copied to .env (fixes #81).
+//   - Otherwise the pre-existing .env is restored from a backup (fixes #85).
+func buildUploadCmd(workDir string) string {
+	return fmt.Sprintf(
+		"ENV_BACKUP=$([ -f '%[1]s/.env' ] && cat '%[1]s/.env' || true) && "+
+			"rm -rf '%[1]s' && mkdir -p '%[1]s' && tar xzf - -C '%[1]s' && "+
+			"{ if [ -f '%[1]s/.env.server' ]; then "+
+			"cp '%[1]s/.env.server' '%[1]s/.env'; "+
+			"elif [ -n \"$ENV_BACKUP\" ]; then "+
+			"printf '%%s' \"$ENV_BACKUP\" > '%[1]s/.env'; "+
+			"fi; }",
+		workDir)
+}
+
+// buildComposeCmd generates the shell command that runs docker compose.
+// When .env exists, --env-file is passed so variables are substituted in
+// compose.yml including build.args, making them available at Docker build time (#82).
+func buildComposeCmd(workDir, composeFile string) string {
+	return fmt.Sprintf(
+		"cd '%[1]s' && "+
+			"{ if [ -f .env ]; then "+
+			"docker compose --env-file .env -f '%[2]s' up -d --build --remove-orphans; "+
+			"else "+
+			"docker compose -f '%[2]s' up -d --build --remove-orphans; "+
+			"fi; } && "+
+			"docker compose -f '%[2]s' ps",
+		workDir, composeFile)
 }
 
 // composeFileNames lists compose files in detection priority order.

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -119,13 +119,17 @@ func deployApp(ctx *appContext) error {
 // It preserves any pre-existing .env on the server:
 //   - If the new archive contains .env.server, it is copied to .env (fixes #81).
 //   - Otherwise the pre-existing .env is restored from a backup (fixes #85).
+//
+// ENV_EXISTS is used as a boolean sentinel (not content check) so that an empty
+// .env file is still preserved after redeploy.
 func buildUploadCmd(workDir string) string {
 	return fmt.Sprintf(
-		"ENV_BACKUP=$([ -f '%[1]s/.env' ] && cat '%[1]s/.env' || true) && "+
+		"ENV_EXISTS=0; [ -f '%[1]s/.env' ] && ENV_EXISTS=1 || true; "+
+			"ENV_BACKUP=$([ -f '%[1]s/.env' ] && cat '%[1]s/.env' || true) && "+
 			"rm -rf '%[1]s' && mkdir -p '%[1]s' && tar xzf - -C '%[1]s' && "+
 			"{ if [ -f '%[1]s/.env.server' ]; then "+
 			"cp '%[1]s/.env.server' '%[1]s/.env'; "+
-			"elif [ -n \"$ENV_BACKUP\" ]; then "+
+			"elif [ \"$ENV_EXISTS\" = \"1\" ]; then "+
 			"printf '%%s' \"$ENV_BACKUP\" > '%[1]s/.env'; "+
 			"fi; }",
 		workDir)

--- a/cmd/app/deploy_test.go
+++ b/cmd/app/deploy_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildUploadCmd_EnvServerPathInsideWorkDir(t *testing.T) {
+	// Bug #81: ENV_FILE was "/opt/conoha/<name>.env.server" (sibling of workDir)
+	// Correct:  "/opt/conoha/<name>/.env.server" (inside workDir)
+	cmd := buildUploadCmd("/opt/conoha/myapp")
+	if strings.Contains(cmd, "/opt/conoha/myapp.env.server") {
+		t.Error("buildUploadCmd looks for .env.server as sibling of workDir (bug #81); must look inside workDir")
+	}
+	if !strings.Contains(cmd, "/opt/conoha/myapp/.env.server") {
+		t.Error("buildUploadCmd must look for .env.server inside workDir (#81)")
+	}
+}
+
+func TestBuildUploadCmd_BacksUpEnvBeforeRmRf(t *testing.T) {
+	// Bug #85: rm -rf deletes .env before extraction; existing .env must be preserved
+	cmd := buildUploadCmd("/opt/conoha/myapp")
+	if !strings.Contains(cmd, "ENV_BACKUP") {
+		t.Error("buildUploadCmd must backup existing .env before rm -rf (#85)")
+	}
+}
+
+func TestBuildComposeCmd_PassesEnvFileForBuildArgs(t *testing.T) {
+	// Issue #82: NEXT_PUBLIC_* vars need --env-file at docker compose build time
+	cmd := buildComposeCmd("/opt/conoha/myapp", "compose.yml")
+	if !strings.Contains(cmd, "--env-file") {
+		t.Error("buildComposeCmd must pass --env-file so Docker build args pick up .env vars (#82)")
+	}
+}

--- a/cmd/app/deploy_test.go
+++ b/cmd/app/deploy_test.go
@@ -17,11 +17,17 @@ func TestBuildUploadCmd_EnvServerPathInsideWorkDir(t *testing.T) {
 	}
 }
 
-func TestBuildUploadCmd_BacksUpEnvBeforeRmRf(t *testing.T) {
-	// Bug #85: rm -rf deletes .env before extraction; existing .env must be preserved
+func TestBuildUploadCmd_UsesExistenceSentinelNotContentCheck(t *testing.T) {
+	// Bug #85 edge case: an empty .env file must also be preserved after redeploy.
+	// Using [ -n "$ENV_BACKUP" ] (content check) would silently drop a zero-byte .env
+	// because command substitution strips trailing newlines and empty content is falsy.
+	// The fix uses a boolean ENV_EXISTS sentinel instead.
 	cmd := buildUploadCmd("/opt/conoha/myapp")
-	if !strings.Contains(cmd, "ENV_BACKUP") {
-		t.Error("buildUploadCmd must backup existing .env before rm -rf (#85)")
+	if !strings.Contains(cmd, "ENV_EXISTS") {
+		t.Error("buildUploadCmd must use ENV_EXISTS sentinel to detect pre-existing .env (#85)")
+	}
+	if strings.Contains(cmd, `[ -n "$ENV_BACKUP" ]`) {
+		t.Error("buildUploadCmd must not gate restore on content; empty .env would be silently lost")
 	}
 }
 

--- a/cmd/app/dockerignore.go
+++ b/cmd/app/dockerignore.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bufio"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,31 +10,56 @@ import (
 
 var defaultExcludes = []string{".git"}
 
+// loadIgnorePatterns reads .dockerignore files from dir and all subdirectories.
+// Patterns from subdirectory .dockerignore files are prefixed with the relative
+// directory path so they apply only within that subtree.
 func loadIgnorePatterns(dir string) ([]string, error) {
 	patterns := append([]string{}, defaultExcludes...)
 
-	f, err := os.Open(filepath.Join(dir, ".dockerignore"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return patterns, nil
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
+		if d.IsDir() || d.Name() != ".dockerignore" {
+			return nil
+		}
+
+		prefix, err := filepath.Rel(dir, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		sub, err := readIgnoreFile(path, prefix)
+		if err != nil {
+			return err
+		}
+		patterns = append(patterns, sub...)
+		return nil
+	})
+
+	return patterns, err
+}
+
+func readIgnoreFile(path, prefix string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
+	var result []string
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		if strings.HasPrefix(line, "!") {
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
 			continue
 		}
 		line = strings.TrimRight(line, "/")
-		patterns = append(patterns, line)
+		if prefix != "." {
+			line = prefix + "/" + line
+		}
+		result = append(result, line)
 	}
-	return patterns, scanner.Err()
+	return result, scanner.Err()
 }
 
 func shouldExclude(path string, patterns []string) bool {

--- a/cmd/app/dockerignore.go
+++ b/cmd/app/dockerignore.go
@@ -50,7 +50,12 @@ func readIgnoreFile(path, prefix string) ([]string, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Negation patterns ("!foo") are not supported: the simple glob-based
+		// walk cannot re-include files that were already skipped by SkipDir.
+		if strings.HasPrefix(line, "!") {
 			continue
 		}
 		line = strings.TrimRight(line, "/")

--- a/cmd/app/dockerignore_test.go
+++ b/cmd/app/dockerignore_test.go
@@ -40,6 +40,37 @@ func TestLoadIgnorePatterns_WithFile(t *testing.T) {
 	}
 }
 
+func TestLoadIgnorePatterns_SubdirDockerignore(t *testing.T) {
+	dir := t.TempDir()
+	// Root .dockerignore does NOT list node_modules
+	if err := os.WriteFile(filepath.Join(dir, ".dockerignore"), []byte("*.log\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// frontend subdirectory has its own .dockerignore
+	if err := os.MkdirAll(filepath.Join(dir, "frontend"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "frontend", ".dockerignore"), []byte("node_modules\n.next\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns, err := loadIgnorePatterns(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !shouldExclude("frontend/node_modules", patterns) {
+		t.Error("frontend/node_modules should be excluded by frontend/.dockerignore")
+	}
+	if !shouldExclude("frontend/.next", patterns) {
+		t.Error("frontend/.next should be excluded by frontend/.dockerignore")
+	}
+	// backend/node_modules must NOT be excluded (no pattern covers it)
+	if shouldExclude("backend/node_modules", patterns) {
+		t.Error("backend/node_modules should NOT be excluded")
+	}
+}
+
 func TestShouldExclude(t *testing.T) {
 	patterns := []string{".git", "node_modules", "*.log"}
 


### PR DESCRIPTION
## Summary

- **#81** `.env.server` → `.env` auto-copy used wrong path (`/opt/conoha/<name>.env.server` instead of `/opt/conoha/<name>/.env.server` inside workDir)
- **#85** `rm -rf` during upload deleted any pre-existing `.env`; deploy now backs up `.env` before extraction and restores it if no `.env.server` is present in the new archive
- **#82** `docker compose` was called without `--env-file`, so `NEXT_PUBLIC_*` and other build-time variables from `.env` were not substituted in `compose.yml` (including `build.args`); now passes `--env-file .env` when `.env` exists
- **#84** `loadIgnorePatterns` only read the root `.dockerignore`; it now walks all subdirectories and prefixes their patterns with the relative path, so `frontend/.dockerignore` with `node_modules` correctly excludes `frontend/node_modules` from the upload archive

## `.env` lifecycle on each deploy

| Situation | Result |
|-----------|--------|
| First deploy, `.env.server` in archive | `.env.server` → `.env` copied ✓ |
| Redeploy, `.env.server` in archive | `.env` updated from fresh `.env.server` ✓ |
| Redeploy, no `.env.server`, existing `.env` | `.env` preserved from backup ✓ |
| First deploy, no `.env.server` | No `.env` created (unchanged) ✓ |

## Test plan

- [ ] `go test ./cmd/app/` — `TestBuildUploadCmd_*` and `TestBuildComposeCmd_*` pass
- [ ] `TestLoadIgnorePatterns_SubdirDockerignore` passes
- [ ] `go test ./...` — all tests pass

Closes #81
Closes #82
Closes #84
Closes #85