### PR TITLE
fix(app/destroy): use compose.project label instead of legacy {{.Name}} format (#114)

### DIFF
--- a/cmd/app/compose.go
+++ b/cmd/app/compose.go
@@ -1,0 +1,23 @@
+package app
+
+import "fmt"
+
+// composeProjectEnumPipeline returns a bash pipeline that prints the names of
+// all Compose projects whose name equals appName or starts with
+// "appName-" — this matches both no-proxy deployments (project = app) and
+// proxy slot deployments (project = app-blue / app-green).
+//
+// The enumeration uses the com.docker.compose.project container label via
+// `docker ps -a` rather than `docker compose ls --format '{{.Name}}'`.
+// Docker Compose v5 removed Go-template support for `compose ls --format`
+// (only table/json are accepted), so the template form silently fails on
+// recent hosts — see issue #114. Labels are stable across versions.
+//
+// appName is interpolated verbatim; callers must feed an already-validated
+// app name (cmd/app loaders enforce the [A-Za-z0-9_-] charset).
+func composeProjectEnumPipeline(appName string) string {
+	return fmt.Sprintf(
+		`docker ps -a --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null | awk 'NF' | sort -u | grep -E "^%s(-|$)" || true`,
+		appName,
+	)
+}

--- a/cmd/app/compose.go
+++ b/cmd/app/compose.go
@@ -13,8 +13,16 @@ import "fmt"
 // (only table/json are accepted), so the template form silently fails on
 // recent hosts — see issue #114. Labels are stable across versions.
 //
-// appName is interpolated verbatim; callers must feed an already-validated
-// app name (cmd/app loaders enforce the [A-Za-z0-9_-] charset).
+// appName is interpolated verbatim into the generated shell text.
+// Callers may pass either:
+//   - a Go string holding an already-validated app name — cmd/app loaders
+//     (see cmd/app/connect.go) enforce the [A-Za-z0-9_-] charset via
+//     internalssh.ValidateAppName before the context reaches this helper; or
+//   - a bash variable reference such as "${APP_NAME}" to defer expansion
+//     to the remote shell. In that form the caller is responsible for
+//     ensuring the variable holds a validated name at expansion time
+//     (destroy.go does this: APP_NAME is set from a Go-validated value
+//     one line above the pipeline).
 func composeProjectEnumPipeline(appName string) string {
 	return fmt.Sprintf(
 		`docker ps -a --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null | awk 'NF' | sort -u | grep -E "^%s(-|$)" || true`,

--- a/cmd/app/compose_test.go
+++ b/cmd/app/compose_test.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComposeProjectEnumPipeline_UsesLabelSource(t *testing.T) {
+	got := composeProjectEnumPipeline("myapp")
+	if !strings.Contains(got, `docker ps -a --format '{{.Label "com.docker.compose.project"}}'`) {
+		t.Errorf("pipeline should read the compose project label via docker ps; got: %s", got)
+	}
+	if strings.Contains(got, `docker compose ls`) {
+		t.Errorf("pipeline must not fall back to `docker compose ls` (unsupported --format on Compose v5, #114); got: %s", got)
+	}
+	if strings.Contains(got, "{{.Name}}") {
+		t.Errorf("pipeline must not use the legacy Go-template format; got: %s", got)
+	}
+}
+
+func TestComposeProjectEnumPipeline_FiltersByAppAndSlot(t *testing.T) {
+	got := composeProjectEnumPipeline("myapp")
+	if !strings.Contains(got, `grep -E "^myapp(-|$)"`) {
+		t.Errorf("pipeline should filter project names with the app-or-slot regex; got: %s", got)
+	}
+}
+
+func TestComposeProjectEnumPipeline_TerminatesWithOrTrue(t *testing.T) {
+	got := composeProjectEnumPipeline("myapp")
+	// `grep` exits 1 when no lines match; the pipeline must absorb that
+	// under `set -euo pipefail` so empty enumerations don't abort callers.
+	if !strings.HasSuffix(strings.TrimSpace(got), "|| true") {
+		t.Errorf("pipeline should end in `|| true` so no-match is a soft success; got: %s", got)
+	}
+}

--- a/cmd/app/destroy.go
+++ b/cmd/app/destroy.go
@@ -95,23 +95,19 @@ var destroyCmd = &cobra.Command{
 }
 
 func generateDestroyScript(appName string) []byte {
-	// Enumerate compose projects via container labels instead of
-	// 'docker compose ls --format "{{.Name}}"' — Docker Compose v5+ dropped
-	// Go-template format support for 'ls', so the template silently fails
-	// on recent hosts and the cleanup loop iterates over nothing (issue #114).
-	// The com.docker.compose.project label is stable across compose versions.
+	// Compose project enumeration comes from composeProjectEnumPipeline —
+	// a shared helper that avoids the 'docker compose ls --format
+	// "{{.Name}}"' pattern Docker Compose v5 no longer supports
+	// (issue #114). Shared with buildStatusCmdForProxy so both paths stay
+	// in sync on hosts with modern Compose.
 	return []byte(fmt.Sprintf(`#!/bin/bash
 set -euo pipefail
 
-APP_NAME="%s"
+APP_NAME="%[1]s"
 APP_DIR="/opt/conoha/${APP_NAME}"
 
 echo "==> Stopping all compose projects for ${APP_NAME}..."
-projects=$(docker ps -a --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null \
-    | awk 'NF' \
-    | sort -u \
-    | grep -E "^${APP_NAME}(-|$)" \
-    || true)
+projects=$(%[2]s)
 if [ -z "${projects}" ]; then
     echo "    (no compose projects found for ${APP_NAME})"
 else
@@ -130,5 +126,5 @@ rm -rf "/opt/conoha/${APP_NAME}.git" 2>/dev/null || true
 rm -f  "/opt/conoha/${APP_NAME}.env.server" 2>/dev/null || true
 
 echo "==> Done."
-`, appName))
+`, appName, composeProjectEnumPipeline("${APP_NAME}")))
 }

--- a/cmd/app/destroy.go
+++ b/cmd/app/destroy.go
@@ -95,6 +95,11 @@ var destroyCmd = &cobra.Command{
 }
 
 func generateDestroyScript(appName string) []byte {
+	// Enumerate compose projects via container labels instead of
+	// 'docker compose ls --format "{{.Name}}"' — Docker Compose v5+ dropped
+	// Go-template format support for 'ls', so the template silently fails
+	// on recent hosts and the cleanup loop iterates over nothing (issue #114).
+	// The com.docker.compose.project label is stable across compose versions.
 	return []byte(fmt.Sprintf(`#!/bin/bash
 set -euo pipefail
 
@@ -102,10 +107,20 @@ APP_NAME="%s"
 APP_DIR="/opt/conoha/${APP_NAME}"
 
 echo "==> Stopping all compose projects for ${APP_NAME}..."
-for project in $(docker compose ls -a --format '{{.Name}}' 2>/dev/null | grep -E "^${APP_NAME}(-|$)" || true); do
-    echo "    - ${project}"
-    docker compose -p "${project}" down --remove-orphans 2>/dev/null || true
-done
+projects=$(docker ps -a --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null \
+    | awk 'NF' \
+    | sort -u \
+    | grep -E "^${APP_NAME}(-|$)" \
+    || true)
+if [ -z "${projects}" ]; then
+    echo "    (no compose projects found for ${APP_NAME})"
+else
+    while IFS= read -r project; do
+        [ -z "${project}" ] && continue
+        echo "    - ${project}"
+        docker compose -p "${project}" down --remove-orphans 2>/dev/null || true
+    done <<< "${projects}"
+fi
 
 echo "==> Removing app directory..."
 rm -rf "${APP_DIR}"

--- a/cmd/app/destroy_test.go
+++ b/cmd/app/destroy_test.go
@@ -36,11 +36,16 @@ func TestGenerateDestroyScript_DoesNotUseLegacyGoTemplateFormat(t *testing.T) {
 }
 
 // The enumeration must survive across docker compose versions. Labels on
-// containers (com.docker.compose.project) are the stable source of truth.
+// containers (com.docker.compose.project) read via `docker ps -a` are the
+// stable source of truth; `docker inspect` or other approaches would not
+// satisfy the #114 fix (addresses review NP1).
 func TestGenerateDestroyScript_EnumeratesViaComposeProjectLabel(t *testing.T) {
 	script := string(generateDestroyScript("myapp"))
 	if !strings.Contains(script, "com.docker.compose.project") {
 		t.Errorf("destroy script should enumerate compose projects via the com.docker.compose.project label; script:\n%s", script)
+	}
+	if !strings.Contains(script, `docker ps -a --format '{{.Label "com.docker.compose.project"}}'`) {
+		t.Errorf("destroy script should read labels via `docker ps -a --format`; script:\n%s", script)
 	}
 }
 

--- a/cmd/app/destroy_test.go
+++ b/cmd/app/destroy_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -20,5 +21,44 @@ func TestDestroyCmd_HasModeFlags(t *testing.T) {
 	}
 	if destroyCmd.Flags().Lookup("no-proxy") == nil {
 		t.Error("destroy should have --no-proxy flag")
+	}
+}
+
+// Docker Compose v5 dropped Go-template --format support for `docker compose ls`
+// (only `table` and `json` are accepted). Emitting `--format '{{.Name}}'` silently
+// fails on v5 hosts so the enumeration loop iterates over nothing and containers
+// leak. Regression: issue #114.
+func TestGenerateDestroyScript_DoesNotUseLegacyGoTemplateFormat(t *testing.T) {
+	script := string(generateDestroyScript("myapp"))
+	if strings.Contains(script, "{{.Name}}") {
+		t.Errorf("destroy script must not use docker compose ls --format '{{.Name}}' (unsupported on Compose v5); script:\n%s", script)
+	}
+}
+
+// The enumeration must survive across docker compose versions. Labels on
+// containers (com.docker.compose.project) are the stable source of truth.
+func TestGenerateDestroyScript_EnumeratesViaComposeProjectLabel(t *testing.T) {
+	script := string(generateDestroyScript("myapp"))
+	if !strings.Contains(script, "com.docker.compose.project") {
+		t.Errorf("destroy script should enumerate compose projects via the com.docker.compose.project label; script:\n%s", script)
+	}
+}
+
+func TestGenerateDestroyScript_InterpolatesAppName(t *testing.T) {
+	script := string(generateDestroyScript("myapp"))
+	if !strings.Contains(script, `APP_NAME="myapp"`) {
+		t.Errorf(`destroy script should set APP_NAME="myapp"; script:\n%s`, script)
+	}
+	if !strings.Contains(script, `APP_DIR="/opt/conoha/${APP_NAME}"`) {
+		t.Errorf(`destroy script should derive APP_DIR from APP_NAME; script:\n%s`, script)
+	}
+}
+
+// The project-name match must cover exactly <app> (no-proxy) and <app>-<slot>
+// (proxy). It must not match <app>foo or other unrelated projects.
+func TestGenerateDestroyScript_MatchesAppAndSlotProjectsOnly(t *testing.T) {
+	script := string(generateDestroyScript("myapp"))
+	if !strings.Contains(script, `"^${APP_NAME}(-|$)"`) {
+		t.Errorf(`destroy script should filter projects with "^${APP_NAME}(-|$)"; script:\n%s`, script)
 	}
 }

--- a/cmd/app/status.go
+++ b/cmd/app/status.go
@@ -79,12 +79,15 @@ var statusCmd = &cobra.Command{
 }
 
 func buildStatusCmdForProxy(app string) string {
+	// Enumerate slot projects via container labels rather than
+	// 'docker compose ls --format "{{.Name}}"', which fails silently on
+	// Docker Compose v5 hosts and would produce an empty listing (#114).
 	return fmt.Sprintf(
-		`for p in $(docker compose ls -a --format '{{.Name}}' 2>/dev/null | grep -E "^%[1]s(-|$)" || true); do `+
+		`for p in $(%[1]s); do `+
 			`echo "--- compose project: ${p} ---"; `+
 			`docker compose -p "${p}" ps; `+
 			`done`,
-		app)
+		composeProjectEnumPipeline(app))
 }
 
 func buildStatusCmdForNoProxy(app string) string {

--- a/cmd/app/status_test.go
+++ b/cmd/app/status_test.go
@@ -17,7 +17,7 @@ func TestStatusCmd_HasModeFlags(t *testing.T) {
 func TestBuildStatusCmd_Proxy(t *testing.T) {
 	got := buildStatusCmdForProxy("myapp")
 	for _, want := range []string{
-		"docker compose ls",
+		`docker ps -a --format '{{.Label "com.docker.compose.project"}}'`,
 		`grep -E "^myapp(-|$)"`,
 		"docker compose -p",
 		"ps",
@@ -25,6 +25,11 @@ func TestBuildStatusCmd_Proxy(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in %s", want, got)
 		}
+	}
+	// Regression: the legacy 'docker compose ls --format "{{.Name}}"' pattern
+	// stops working on Docker Compose v5 (#114) — must not come back.
+	if strings.Contains(got, "{{.Name}}") {
+		t.Errorf("buildStatusCmdForProxy must not use the legacy Go-template format; got: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #114 — `conoha app destroy` silently no-oped on Docker Compose v5 because the enumeration loop used `docker compose ls --format '{{.Name}}'`, which v5 rejects (only `table` / `json` are accepted). The error was swallowed by `2>/dev/null` + `|| true`, so the for-loop iterated over nothing while `rm -rf ${APP_DIR}` still ran — `App "..." destroyed.` printed even though the containers stayed up with their ports bound, breaking subsequent sequential deploys on the same VPS with `port is already allocated`.

## Change

Enumerate compose projects from `docker ps -a --format '{{.Label "com.docker.compose.project"}}'` instead. The `com.docker.compose.project` label is stable across compose versions and does not rely on `docker compose ls` template support. Also explicitly log the empty-match case rather than silently falling through an empty loop.

The `^APP_NAME(-|$)` regex that distinguishes `<app>` (no-proxy) from `<app>-<slot>` (proxy) is preserved.

## Test plan

- [x] `go test ./...` — all green (new regression tests under `cmd/app/destroy_test.go`)
- [x] `bash -n` on the generated script — syntactically valid
- [x] Local simulation confirms `^smoke-foo(-|$)` matches `smoke-foo`, `smoke-foo-blue`, `smoke-foo-green` and excludes `smoke-foobar` / `smoke-other` (no behavioural regression vs. prior regex)
- [ ] End-to-end re-run of 5-sample `--no-proxy` smoke test on ConoHa VPS (`vmi-docker-29.2-ubuntu-24.04-amd64`, Compose v5.0.2) — scheduled after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)