### PR TITLE
docs(readme): cover 3 operational edge cases in proxy deploy walkthrough

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -158,7 +158,9 @@ conoha server rename <server-id-or-name> new-name
    conoha proxy boot my-server --acme-email ops@example.com
    ```
 
-3. Point the DNS A record at the VPS (Let's Encrypt HTTP-01 validation needs it).
+   Skipping this step and going straight to `app init` fails with an Admin API socket error — the proxy container is not yet running.
+
+3. Point the DNS A record at the VPS (Let's Encrypt HTTP-01 validation needs it). DNS must resolve by the time `app init` registers the host — if it doesn't, the `app`-layer deploy itself still succeeds but the hostname serves invalid certs until ACME eventually succeeds.
 
 4. Register with the proxy and deploy:
 
@@ -173,7 +175,7 @@ conoha server rename <server-id-or-name> new-name
    conoha app rollback my-server
    ```
 
-`deploy --slot <id>` pins the slot ID (rule: `[a-z0-9][a-z0-9-]{0,63}`; default is git short SHA or timestamp). Reusing an existing slot ID purges its work dir before re-extracting.
+`deploy --slot <id>` pins the slot ID (rule: `[a-z0-9][a-z0-9-]{0,63}`; default is git short SHA or timestamp). Explicitly reusing an existing slot ID purges its work dir before re-extracting. When `--slot` is omitted and the default collides with an existing compose project (e.g. a still-draining previous slot), the CLI auto-suffixes with `-2`, `-3`, ... so a collision is never destructive.
 
 ### no-proxy mode: flat single-slot
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -158,7 +158,9 @@ conoha server rename <server-id-or-name> new-name
    conoha proxy boot my-server --acme-email ops@example.com
    ```
 
-3. DNS A 레코드를 VPS 로 향하게 하기 (Let's Encrypt HTTP-01 검증에 필요).
+   이 단계를 건너뛰고 바로 `app init` 으로 넘어가면 Admin API 소켓에 닿지 못해 에러로 중단됩니다 (프록시 컨테이너가 아직 떠 있지 않음).
+
+3. DNS A 레코드를 VPS 로 향하게 하기 (Let's Encrypt HTTP-01 검증에 필요). DNS 는 `app init` 이 호스트를 등록하는 시점까지 해소 가능해야 합니다 — 설정 전에 진행해도 `app` 계층 배포 자체는 성공하지만, ACME 가 성공할 때까지는 호스트명에 유효하지 않은 인증서가 응답됩니다.
 
 4. 프록시에 앱을 등록하고 배포:
 
@@ -173,7 +175,7 @@ conoha server rename <server-id-or-name> new-name
    conoha app rollback my-server
    ```
 
-`deploy --slot <id>` 로 슬롯 ID 를 고정할 수 있습니다 (규칙: `[a-z0-9][a-z0-9-]{0,63}`, 기본값은 git short SHA 또는 timestamp). 기존 슬롯명을 재사용하면 작업 디렉터리를 정리한 뒤 재전개합니다.
+`deploy --slot <id>` 로 슬롯 ID 를 고정할 수 있습니다 (규칙: `[a-z0-9][a-z0-9-]{0,63}`, 기본값은 git short SHA 또는 timestamp). 기존 슬롯명을 명시적으로 재사용하면 작업 디렉터리를 정리한 뒤 재전개합니다. `--slot` 을 생략했을 때 기본값이 기존 compose 프로젝트와 충돌하면 (예: drain 중인 이전 슬롯) CLI 가 자동으로 `-2` / `-3` 접미사를 붙여 충돌을 회피하므로, 충돌이 파괴적으로 작용하지 않습니다.
 
 ### no-proxy 모드: 평면 단일 슬롯
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ conoha server create --name my-server --user-data-url https://example.com/setup.
    conoha proxy boot my-server --acme-email ops@example.com
    ```
 
-3. DNS の A レコードを VPS に向ける（Let's Encrypt HTTP-01 検証に必要）。
+   このステップを飛ばして `app init` に進むと、Admin API ソケットに到達できずエラーで停止します。
+
+3. DNS の A レコードを VPS に向ける（Let's Encrypt HTTP-01 検証に必要）。DNS は `app init` がホストを登録する時点で名前解決できる必要があります — 未設定のまま進めても `app` レイヤのデプロイ自体は成功しますが、ACME 発行失敗の間はホスト名で無効な証明書が返ります。
 
 4. アプリを proxy に登録してデプロイ：
 
@@ -215,7 +217,7 @@ conoha server create --name my-server --user-data-url https://example.com/setup.
    conoha app rollback my-server
    ```
 
-`deploy --slot <id>` で slot ID を固定できます (規則: `[a-z0-9][a-z0-9-]{0,63}`、既定は git short SHA または timestamp)。同名 slot を再利用すると作業ディレクトリを削除してから再展開します。
+`deploy --slot <id>` で slot ID を固定できます (規則: `[a-z0-9][a-z0-9-]{0,63}`、既定は git short SHA または timestamp)。同名 slot を明示的に再利用すると作業ディレクトリを削除してから再展開します。`--slot` を省略した場合、既定値が既存の compose プロジェクトと衝突したら CLI が自動で `-2` / `-3` と suffix を付けて衝突を回避するので、drain 中のスロットを破壊的に上書きすることはありません。
 
 ### no-proxy モード: フラット単一スロット
 


### PR DESCRIPTION
## Summary

Closes #117. Three one-liner additions to the proxy blue/green walkthrough in all three READMEs:

- **N1** — `--slot` auto-suffix: previously the flag description only covered *explicit* slot reuse. Now also notes that when `--slot` is omitted and the default ID (git short SHA / timestamp) collides with an existing compose project, the CLI auto-suffixes with `-2`, `-3`, ... so a collision with a still-draining slot is never destructive.
- **N3a** — skipping `conoha proxy boot` and going straight to `app init` fails with an Admin API socket error. Previously only surfaced in `--help` long desc; now inline in the walkthrough under step 2.
- **N3b** — DNS must resolve by the time `app init` registers the host. If it doesn't, the `app`-layer deploy still succeeds but ACME keeps failing and the hostname serves invalid certs until validation eventually succeeds. Previously documented in the skill recipe's troubleshooting table; README now matches.

Applied symmetrically across `README.md` (JA), `README-en.md`, `README-ko.md`.

## Code references

- N1: \`cmd/app/slot.go:47-57\` (suffixIfTaken), \`cmd/app/deploy.go:188-194\` (probe via docker compose ls).
- N3a: \`cmd/app/init.go:35\` (long desc only — now promoted inline).
- N3b: ACME flow in conoha-proxy, previously only visible via troubleshooting table.

## Test plan

- [x] Pure docs change — no code, no tests.
- [x] JA/EN/KO structurally aligned: each gets the same 3 additions in the same walkthrough positions.