### PR TITLE
docs(readme): correct 'invalid certs' wording for DNS-not-pointed case

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -160,7 +160,7 @@ conoha server rename <server-id-or-name> new-name
 
    Skipping this step and going straight to `app init` fails with an Admin API socket error — the proxy container is not yet running.
 
-3. Point the DNS A record at the VPS (Let's Encrypt HTTP-01 validation needs it). DNS must resolve by the time `app init` registers the host — if it doesn't, the `app`-layer deploy itself still succeeds but the hostname serves invalid certs until ACME eventually succeeds.
+3. Point the DNS A record at the VPS (Let's Encrypt HTTP-01 validation needs it). DNS must resolve by the time `app init` registers the host — if it doesn't, the `app`-layer deploy still succeeds but HTTPS to the hostname fails at the TLS handshake (no cert has been issued for that SNI, so the server can't present one — clients see a connection reset / handshake failure, not a browser cert-warning page) until ACME eventually succeeds.
 
 4. Register with the proxy and deploy:
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -160,7 +160,7 @@ conoha server rename <server-id-or-name> new-name
 
    이 단계를 건너뛰고 바로 `app init` 으로 넘어가면 Admin API 소켓에 닿지 못해 에러로 중단됩니다 (프록시 컨테이너가 아직 떠 있지 않음).
 
-3. DNS A 레코드를 VPS 로 향하게 하기 (Let's Encrypt HTTP-01 검증에 필요). DNS 는 `app init` 이 호스트를 등록하는 시점까지 해소 가능해야 합니다 — 설정 전에 진행해도 `app` 계층 배포 자체는 성공하지만, ACME 가 성공할 때까지는 호스트명에 유효하지 않은 인증서가 응답됩니다.
+3. DNS A 레코드를 VPS 로 향하게 하기 (Let's Encrypt HTTP-01 검증에 필요). DNS 는 `app init` 이 호스트를 등록하는 시점까지 해소 가능해야 합니다 — 설정 전에 진행해도 `app` 계층 배포 자체는 성공하지만, ACME 가 발급에 성공할 때까지 해당 호스트명으로의 HTTPS 는 TLS 핸드셰이크 단계에서 실패합니다 (해당 SNI 에 발급된 인증서가 없어 서버가 인증서를 제시하지 못함 — 브라우저 경고 페이지가 아니라 connection reset / handshake 실패로 보입니다).
 
 4. 프록시에 앱을 등록하고 배포:
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ conoha server create --name my-server --user-data-url https://example.com/setup.
 
    このステップを飛ばして `app init` に進むと、Admin API ソケットに到達できずエラーで停止します。
 
-3. DNS の A レコードを VPS に向ける（Let's Encrypt HTTP-01 検証に必要）。DNS は `app init` がホストを登録する時点で名前解決できる必要があります — 未設定のまま進めても `app` レイヤのデプロイ自体は成功しますが、ACME 発行失敗の間はホスト名で無効な証明書が返ります。
+3. DNS の A レコードを VPS に向ける（Let's Encrypt HTTP-01 検証に必要）。DNS は `app init` がホストを登録する時点で名前解決できる必要があります — 未設定のまま進めても `app` レイヤのデプロイ自体は成功しますが、ACME が発行に成功するまでは該当ホスト名への HTTPS が TLS ハンドシェイク段階で失敗します（発行できた証明書が無く、SNI に対してサーバが証明書を返せない状態。ブラウザ警告ページではなく接続リセット／ハンドシェイク失敗として見えます）。
 
 4. アプリを proxy に登録してデプロイ：
 


### PR DESCRIPTION
Closes #120.

## Summary

PR #118 added a walkthrough note claiming the hostname "serves invalid certs" when ACME is failing because DNS is not yet pointed. That wording is misleading.

Verified against crowdy/conoha-proxy HEAD:
- \`cmd/conoha-proxy/main.go:116-124\` wires certmagic with production Let's Encrypt as the sole issuer — **no \`OnDemand\`, no self-signed fallback** (\`grep OnDemand|self.signed\` returns only test-harness hits).
- \`internal/tls/certmanager.go:80-102\` \`ManageDomains\` calls \`ManageAsync\` when a host is added. If HTTP-01 cannot validate (DNS not pointed), **no cert is ever cached for that SNI**.
- \`internal/router/router.go:35-53\` only runs after a TLS handshake completes, so on a missing-cert SNI the router never sees the request.

Client-visible behavior is therefore a **TLS handshake failure / connection reset** (no cert to present), not a browser cert-warning page. Those are very different debugging signals — the old wording points operators at cert-chain / expiry / name-mismatch troubleshooting when the real symptom is the TLS layer being wholly unreachable for that hostname.

## Change

Rewrites step 3 of the proxy walkthrough in all three READMEs (JA / EN / KO) to describe the actual failure mode. One-liner per file.

## Test plan

- [x] Pure docs change, no code touched.
- [x] Verified claim against conoha-proxy source (referenced file:line above).