### PR TITLE
fix(proxy/sshexec): default remote stderr to os.Stderr so failures surface

### DIFF
--- a/internal/proxy/sshexec.go
+++ b/internal/proxy/sshexec.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"io"
+	"os"
 
 	"golang.org/x/crypto/ssh"
 
@@ -13,14 +14,17 @@ import (
 // HTTP request body (--data-binary @-).
 type SSHExecutor struct {
 	Client *ssh.Client
-	Stderr io.Writer // where SSH stderr gets routed (can be nil → discarded)
+	// Stderr is where remote stderr is routed. nil defaults to os.Stderr so
+	// curl/socket failures (e.g. "curl: (7) Failed to connect") reach the
+	// operator. Pass io.Discard explicitly to suppress.
+	Stderr io.Writer
 }
 
 // Run implements proxy.Executor.
 func (e *SSHExecutor) Run(cmd string, stdin io.Reader, stdout io.Writer) error {
 	stderr := e.Stderr
 	if stderr == nil {
-		stderr = io.Discard
+		stderr = os.Stderr
 	}
 	if stdin != nil {
 		_, err := internalssh.RunWithStdin(e.Client, cmd, stdin, stdout, stderr)


### PR DESCRIPTION
## Summary

Every \`SSHExecutor\` call site in \`cmd/app/\` (\`init.go:76\`, \`deploy.go:175\`, \`status.go:61\`, \`rollback.go:66\`, \`destroy.go:81\`) and \`cmd/proxy/\` constructs \`SSHExecutor{Client: sshClient}\` without setting \`Stderr\`. The prior default routed remote stderr to \`io.Discard\`, which silently dropped curl's connection errors.

Concrete symptom: a user running \`conoha app init\` without first running \`conoha proxy boot\` sees only the opaque error

\`\`\`
missing HTTPSTATUS tag in curl output: ""
\`\`\`

coming from \`internal/proxy/admin.go:136\`. curl's own \`(7) Failed to connect to admin socket\` message was discarded before reaching the terminal.

## Change

\`internal/proxy/sshexec.go\` default for nil \`Stderr\` is now \`os.Stderr\` instead of \`io.Discard\`. This aligns with the existing pattern in \`internalssh.RunCommand\` (used elsewhere in \`cmd/app/\`) which already passes \`os.Stderr\` directly. Callers that want suppression can still pass \`io.Discard\` explicitly.

+6 / -2 lines. No behavior change for callers who already set \`Stderr\` explicitly (e.g. test harnesses).

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./internal/proxy/... ./cmd/app/...\` — green; no existing test mocks the stderr destination
- No new test: the change is a 1-line default-value swap. Verifying "stderr goes to os.Stderr when not set" via unit test requires a live ssh.Client or reflection; not worth the weight for this change.

## Context

Surfaced during the post-merge review of #118 (see #120 for related README wording that this unblocks for future tightening). With this change, users who skip \`proxy boot\` will see curl's actual "(7) Failed to connect" diagnostic on stderr in addition to the existing wrapped error — making the "Admin API socket" wording in the README correspond to what they observe.