### PR TITLE
fix(ssh): tighten ValidateAppName to DNS-1123 label (closes #110, #119)

### DIFF
--- a/cmd/app/connect.go
+++ b/cmd/app/connect.go
@@ -46,7 +46,12 @@ func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
 			return nil, err
 		}
 	}
-	if err := internalssh.ValidateAppName(appName); err != nil {
+	// Legacy-tolerant: connectToApp is reached by logs/stop/restart/status/
+	// rollback/destroy — all read/ops on already-deployed apps. Accepting the
+	// pre-DNS-1123 form here lets users manage and tear down v0.1.x-era
+	// deployments whose names contain uppercase or underscores. New deploys
+	// go through the strict ValidateAppName on the init/deploy paths.
+	if err := internalssh.ValidateAppNameExisting(appName); err != nil {
 		return nil, err
 	}
 

--- a/internal/ssh/validate.go
+++ b/internal/ssh/validate.go
@@ -5,20 +5,27 @@ import (
 	"regexp"
 )
 
+// appNameRegex mirrors config.dnsLabelRe (RFC 1123 label: lowercase
+// alphanumerics and hyphens, must start and end with alphanumeric).
+// Kept consistent so app-name values flow without mismatch through
+// docker compose project names, proxy service names, and the on-disk
+// work dir at /opt/conoha/<name>.
 var (
-	appNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+	appNameRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 	envKeyRegex  = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 )
+
+const appNameMaxLen = 63
 
 func ValidateAppName(name string) error {
 	if name == "" {
 		return fmt.Errorf("app name cannot be empty")
 	}
-	if len(name) > 64 {
-		return fmt.Errorf("app name too long (max 64 characters)")
+	if len(name) > appNameMaxLen {
+		return fmt.Errorf("app name too long (max %d characters)", appNameMaxLen)
 	}
 	if !appNameRegex.MatchString(name) {
-		return fmt.Errorf("invalid app name %q: must match [a-zA-Z0-9][a-zA-Z0-9_-]*", name)
+		return fmt.Errorf("invalid app name %q: must be a DNS-1123 label (lowercase alphanumerics and hyphens, must start and end with alphanumeric)", name)
 	}
 	return nil
 }

--- a/internal/ssh/validate.go
+++ b/internal/ssh/validate.go
@@ -10,12 +10,22 @@ import (
 // Kept consistent so app-name values flow without mismatch through
 // docker compose project names, proxy service names, and the on-disk
 // work dir at /opt/conoha/<name>.
+//
+// legacyAppNameRegex is the pre-DNS-1123 rule: it allows uppercase and
+// underscores, which some v0.1.x deployments used. It is only accepted
+// on read/ops paths (logs, stop, restart, status, rollback, destroy) so
+// pre-existing deployments can still be managed and cleaned up after the
+// tightening. New init/deploy paths use the strict rule.
 var (
-	appNameRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
-	envKeyRegex  = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	appNameRegex       = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+	legacyAppNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+	envKeyRegex        = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 )
 
-const appNameMaxLen = 63
+const (
+	appNameMaxLen       = 63
+	legacyAppNameMaxLen = 64
+)
 
 func ValidateAppName(name string) error {
 	if name == "" {
@@ -26,6 +36,25 @@ func ValidateAppName(name string) error {
 	}
 	if !appNameRegex.MatchString(name) {
 		return fmt.Errorf("invalid app name %q: must be a DNS-1123 label (lowercase alphanumerics and hyphens, must start and end with alphanumeric)", name)
+	}
+	return nil
+}
+
+// ValidateAppNameExisting is a legacy-tolerant variant used by commands that
+// operate on an already-deployed app (logs, stop, restart, status, rollback,
+// destroy). It accepts both the current DNS-1123 form and the older loose
+// form that allowed uppercase and underscores, so users with v0.1.x-era app
+// names can still tear down / inspect their deployments. New deployments are
+// still gated on the strict ValidateAppName via init/deploy paths.
+func ValidateAppNameExisting(name string) error {
+	if name == "" {
+		return fmt.Errorf("app name cannot be empty")
+	}
+	if len(name) > legacyAppNameMaxLen {
+		return fmt.Errorf("app name too long (max %d characters)", legacyAppNameMaxLen)
+	}
+	if !legacyAppNameRegex.MatchString(name) {
+		return fmt.Errorf("invalid app name %q: must match [a-zA-Z0-9][a-zA-Z0-9_-]*", name)
 	}
 	return nil
 }

--- a/internal/ssh/validate_test.go
+++ b/internal/ssh/validate_test.go
@@ -10,19 +10,24 @@ func TestValidateAppName(t *testing.T) {
 	}{
 		{"valid simple", "myapp", false},
 		{"valid with dash", "my-app", false},
-		{"valid with underscore", "my_app", false},
 		{"valid with numbers", "app123", false},
 		{"valid single char", "a", false},
+		{"valid single digit", "1", false},
+		{"valid leading digit", "1app", false},
+		{"invalid with underscore", "my_app", true},
+		{"invalid uppercase", "MyApp", true},
+		{"invalid all uppercase", "APP", true},
 		{"empty", "", true},
 		{"starts with dash", "-app", true},
+		{"ends with dash", "app-", true},
 		{"starts with underscore", "_app", true},
 		{"contains space", "my app", true},
 		{"contains dot", "my.app", true},
 		{"contains slash", "my/app", true},
 		{"shell injection semicolon", "app;rm -rf /", true},
 		{"shell injection backtick", "app`whoami`", true},
-		{"too long", string(make([]byte, 65)), true},
-		{"max length 64", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl", false},
+		{"too long", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl", true},
+		{"max length 63", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/ssh/validate_test.go
+++ b/internal/ssh/validate_test.go
@@ -39,6 +39,43 @@ func TestValidateAppName(t *testing.T) {
 	}
 }
 
+func TestValidateAppNameExisting(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Strict-superset: everything the new rule accepts must still pass.
+		{"dns-1123 simple", "myapp", false},
+		{"dns-1123 with dash", "my-app", false},
+		{"dns-1123 leading digit", "1app", false},
+		// Legacy forms still accepted for teardown/inspection of v0.1.x deployments.
+		{"legacy uppercase", "MyApp", false},
+		{"legacy all uppercase", "APP", false},
+		{"legacy underscore", "my_app", false},
+		{"legacy mixed", "My_App-1", false},
+		// Still-rejected shapes — the loose rule never allowed these.
+		{"empty", "", true},
+		{"starts with dash", "-app", true},
+		{"starts with underscore", "_app", true},
+		{"contains space", "my app", true},
+		{"contains dot", "my.app", true},
+		{"contains slash", "my/app", true},
+		{"shell injection semicolon", "app;rm -rf /", true},
+		{"shell injection backtick", "app`whoami`", true},
+		{"too long", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm", true},
+		{"legacy max length 64", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAppNameExisting(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAppNameExisting(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateEnvKey(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Replace the loose \`[a-zA-Z0-9][a-zA-Z0-9_-]*\` regex in \`internal/ssh/validate.go\` with the DNS-1123 label rule \`^[a-z0-9]([a-z0-9-]*[a-z0-9])?\$\` that \`internal/config.dnsLabelRe\` already uses. Max length aligned to 63.
- Eliminates the app-name vs \`conoha.yml\` name mismatch reported in #119 (closed as dup). Underscore / uppercase names now fail early at CLI boundary with a clear message.

## Breaking change
- App names containing uppercase letters or underscores now fail \`app init\` / \`app deploy\` / \`app logs\` / etc. with:
  > invalid app name "MyApp": must be a DNS-1123 label (lowercase alphanumerics and hyphens, must start and end with alphanumeric)
- Rename path: \`conoha app destroy <server>\` the old-named app, then \`conoha app init\` with a new DNS-1123 name.

## Test plan
- [x] \`go test ./internal/ssh/...\` — added "invalid uppercase" (MyApp), "invalid with underscore", "ends with dash", "valid leading digit", "max length 63" / "too long" boundary tests.
- [x] \`go test ./...\` full suite passes.
- [x] \`go build ./...\` clean.