### PR TITLE
fix(app,proxy): bound CURRENT_SLOT err + quote curlVia paths (closes #107, #100)

### DIFF
--- a/cmd/app/mode.go
+++ b/cmd/app/mode.go
@@ -118,9 +118,20 @@ func ReadCurrentSlot(cli *ssh.Client, app string) (string, error) {
 		return "", nil
 	}
 	if err := ValidateSlotID(slot); err != nil {
-		return "", fmt.Errorf("CURRENT_SLOT: %w", err)
+		return "", fmt.Errorf("CURRENT_SLOT contains invalid slot ID %s: must match %s", truncateForError(slot, 16), slotIDRe)
 	}
 	return slot, nil
+}
+
+// truncateForError returns a %q-quoted rendering of s, truncated to max
+// runes with a trailing ellipsis when needed. Used to bound log output
+// when server-side state files are corrupted with arbitrary content.
+func truncateForError(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return fmt.Sprintf("%q", s)
+	}
+	return fmt.Sprintf("%q (truncated, %d bytes)", string(runes[:max])+"…", len(s))
 }
 
 // flagMode reads --proxy / --no-proxy flags and returns the intended mode, or

--- a/cmd/app/mode_test.go
+++ b/cmd/app/mode_test.go
@@ -81,6 +81,28 @@ func TestBuildReadCurrentSlotCmd(t *testing.T) {
 	}
 }
 
+func TestTruncateForError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"short fits", "abc123", 16, `"abc123"`},
+		{"exact fit", "abcdefghijklmnop", 16, `"abcdefghijklmnop"`},
+		{"over max", "abcdefghijklmnopqrstuvwxyz", 16, `"abcdefghijklmnop…" (truncated, 26 bytes)`},
+		{"megabyte of nonsense bounded", strings.Repeat("x", 4096), 16, `"xxxxxxxxxxxxxxxx…" (truncated, 4096 bytes)`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateForError(tt.in, tt.max)
+			if got != tt.want {
+				t.Errorf("truncateForError(%d chars, %d) = %q, want %q", len(tt.in), tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveModeLogic(t *testing.T) {
 	sentinelReadErr := errors.New("ssh broken")
 

--- a/cmd/proxy/observability.go
+++ b/cmd/proxy/observability.go
@@ -106,7 +106,7 @@ var servicesCmd = &cobra.Command{
 // curlVia is a tiny helper for non-/v1/ endpoints (/version, /readyz)
 // that don't return the proxy error envelope.
 func curlVia(exec proxypkg.Executor, dataDir, path string) ([]byte, error) {
-	cmd := fmt.Sprintf("curl -sS --unix-socket %s/admin.sock http://admin%s", dataDir, path)
+	cmd := fmt.Sprintf("curl -sS --unix-socket '%s/admin.sock' 'http://admin%s'", dataDir, path)
 	var buf []byte
 	w := byteWriter{&buf}
 	if err := exec.Run(cmd, nil, &w); err != nil {


### PR DESCRIPTION
## Summary
- \`cmd/app/mode.go\` — \`ReadCurrentSlot\` no longer leaks the full \`CURRENT_SLOT\` file content into stderr when the file is corrupted. New \`truncateForError\` helper caps display at 16 runes + ellipsis + byte count. Closes #107.
- \`cmd/proxy/observability.go\` — \`curlVia\` now quotes the \`--data-dir\`-derived socket path + URL, matching \`internal/proxy/admin.go\`. Safe against whitespace in the flag value. Closes #100.

## Test plan
- [x] New \`TestTruncateForError\` in \`cmd/app/mode_test.go\` covers short/exact/over-max/4K cases.
- [x] \`go test ./...\` full suite passes.
- [x] \`go build ./...\` clean.