### PR TITLE
docs: document no-proxy redeploy tar-overlay behavior (closes #108)

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -199,6 +199,8 @@ conoha app destroy my-server --app-name myapp
 
 `rollback` is not available in no-proxy mode (there is no blue/green swap; invoking it prints a "rollback is not supported in no-proxy mode" error and exits). To revert, check out the previous commit and redeploy: `git checkout <sha> && conoha app deploy --no-proxy --app-name <app> <server>`.
 
+Redeploys only **overlay** new files on top of the work dir — paths removed from the repo stay on the server (this is intentional for `.env.server` and named-volume bind mounts that must survive redeploys). To clean up a specific stale file, run `ssh <server> rm /opt/conoha/<name>/<path>` yourself. A future `--clean` flag may be added ([#108](https://github.com/crowdy/conoha-cli/issues/108)).
+
 ### Switching modes
 
 Destroy, then re-init in the opposite mode:

--- a/README-ko.md
+++ b/README-ko.md
@@ -199,6 +199,8 @@ conoha app destroy my-server --app-name myapp
 
 no-proxy 모드에는 blue/green 스왑이 없으므로 `rollback` 은 사용할 수 없습니다 (실행 시 "rollback is not supported in no-proxy mode" 에러가 발생). 이전 커밋으로 되돌리려면 `git checkout <sha> && conoha app deploy --no-proxy --app-name <app> <server>` 로 재배포하세요.
 
+재배포 시 tar 는 **덮어쓰기만** 수행하며, 리포지토리에서 삭제된 파일은 서버에 계속 남습니다 (`.env.server` 나 named volume bind mount 가 재배포 후에도 살아남도록 의도된 동작). 특정 stale 파일을 정리하려면 `ssh <server> rm /opt/conoha/<name>/<path>` 로 직접 삭제하세요. 향후 `--clean` 플래그 추가 여지가 있습니다 ([#108](https://github.com/crowdy/conoha-cli/issues/108)).
+
 ### 모드 전환
 
 기존 앱의 모드를 바꾸려면 한 번 제거한 뒤 반대 모드로 재 init 합니다:

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ conoha app destroy my-server --app-name myapp
 
 no-proxy モードには blue/green swap が存在しないため、`rollback` は利用できません (実行すると "rollback is not supported in no-proxy mode" エラーが出ます)。履歴から戻したい場合は該当コミットを checkout して `deploy` し直してください。
 
+再デプロイ時は tar 展開が **上書きのみ**行い、リポジトリから消したファイルはサーバー上に残り続けます (`.env.server` や名前付きボリュームの bind mount を守るため意図的にそうしています)。古いファイルを掃除する場合は `ssh <server> rm /opt/conoha/<name>/<path>` で個別に削除してください。将来 `--clean` フラグを追加する可能性があります ([#108](https://github.com/crowdy/conoha-cli/issues/108))。
+
 ### モードの切り替え
 
 既存のアプリのモードを変更するには、一度破棄してから反対のモードで再 init します:

--- a/recipes/single-server-app-noproxy.md
+++ b/recipes/single-server-app-noproxy.md
@@ -44,6 +44,16 @@ conoha app deploy --no-proxy --app-name myapp myapp
 
 The CLI tars the current directory (respecting `.dockerignore`), uploads to `/opt/conoha/myapp/` on the VPS, and runs `docker compose -p myapp up -d --build`.
 
+### Redeploy behavior
+
+Tar extraction overlays new files on top of the existing work dir — it does **not** sweep files that have been removed from the repo. If you `rm old-config.json` locally, `old-config.json` stays on the VPS across redeploys until you remove it manually:
+
+```bash
+ssh <server> rm /opt/conoha/myapp/old-config.json
+```
+
+This mirrors v0.1.x behavior and is intentional for `.env.server` (lives at `/opt/conoha/myapp.env.server`, one level up) and named-volume bind mounts, which must survive redeploys. A future `--clean` flag may be added if the manual step proves too easy to forget (see #108).
+
 ## 5. Day-two operations
 
 ```bash


### PR DESCRIPTION
## Summary
Surface the intentional-but-surprising redeploy overlay behavior of no-proxy mode in the three README no-proxy sections and in the no-proxy recipe. No code changes.

## Why
Users removing a file from the repo expect the next deploy to remove it from the server. Tar-extract + no pre-sweep means the file persists. This is intentional for \`.env.server\` and bind-mount volumes that must survive redeploys, but it needs to be visible in docs. Option 2 (implement a sweep behind \`--clean\`) is tracked in #108 as a possible follow-up.

## Files touched
- \`recipes/single-server-app-noproxy.md\` — new "Redeploy behavior" subsection under §4.
- \`README.md\` / \`README-en.md\` / \`README-ko.md\` — one paragraph after the no-proxy rollback note.

## Test plan
- [x] Docs-only; no code changed.
- [ ] Reviewer: verify all three language variants read equivalently.