### PR TITLE
feat(server/create): accept flavor name in --flavor (closes #91)

### DIFF
--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -73,10 +73,12 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		// Resolve flavor (need full struct for volume decision)
+		// Resolve flavor (need full struct for volume decision). Accept either
+		// a UUID or a flavor name (e.g. g2l-t-c4m4) to match the UX of --image
+		// and server-id arguments.
 		var flavor *model.Flavor
 		if flavorID != "" {
-			flavor, err = compute.GetFlavor(flavorID)
+			flavor, err = compute.FindFlavor(flavorID)
 			if err != nil {
 				return fmt.Errorf("flavor %q not found: %w", flavorID, err)
 			}

--- a/internal/api/compute.go
+++ b/internal/api/compute.go
@@ -199,6 +199,32 @@ func (a *ComputeAPI) GetFlavor(id string) (*model.Flavor, error) {
 	return &resp.Flavor, nil
 }
 
+// FindFlavor returns a flavor by UUID or by exact Name match. UUID lookup is
+// attempted first when the input shape matches (36-char 8-4-4-4-12). Otherwise
+// ListFlavors is called and matched by Name.
+func (a *ComputeAPI) FindFlavor(idOrName string) (*model.Flavor, error) {
+	if looksLikeUUID(idOrName) {
+		return a.GetFlavor(idOrName)
+	}
+	flavors, err := a.ListFlavors()
+	if err != nil {
+		return nil, err
+	}
+	for i := range flavors {
+		if flavors[i].Name == idOrName {
+			return &flavors[i], nil
+		}
+	}
+	return nil, fmt.Errorf("flavor %q not found", idOrName)
+}
+
+// looksLikeUUID reports whether s matches the canonical 8-4-4-4-12 dash layout
+// without validating the hex characters. Sufficient for routing between ID and
+// name lookups.
+func looksLikeUUID(s string) bool {
+	return len(s) == 36 && s[8] == '-' && s[13] == '-' && s[18] == '-' && s[23] == '-'
+}
+
 // ListKeypairs returns all keypairs.
 func (a *ComputeAPI) ListKeypairs() ([]model.Keypair, error) {
 	url := fmt.Sprintf("%s/os-keypairs", a.baseURL())

--- a/internal/api/compute_test.go
+++ b/internal/api/compute_test.go
@@ -593,6 +593,58 @@ func TestGetFlavor(t *testing.T) {
 	}
 }
 
+func TestFindFlavor(t *testing.T) {
+	const uuid = "6f3c4747-8471-4a38-902b-4c57ad76d776"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/v2.1/flavors/"+uuid):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"flavor": map[string]any{"id": uuid, "name": "g2l-t-c4m4", "ram": 4096, "vcpus": 4, "disk": 0},
+			})
+		case strings.HasSuffix(r.URL.Path, "/v2.1/flavors/detail"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"flavors": []map[string]any{
+					{"id": uuid, "name": "g2l-t-c4m4", "ram": 4096, "vcpus": 4, "disk": 0},
+					{"id": "00000000-0000-0000-0000-000000000002", "name": "g2l-c2m4d100", "ram": 4096, "vcpus": 2, "disk": 100},
+				},
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	t.Setenv("CONOHA_ENDPOINT", ts.URL)
+	api := NewComputeAPI(newTestClient(ts))
+
+	t.Run("by UUID", func(t *testing.T) {
+		f, err := api.FindFlavor(uuid)
+		if err != nil {
+			t.Fatalf("FindFlavor(uuid) error: %v", err)
+		}
+		if f.ID != uuid || f.Name != "g2l-t-c4m4" {
+			t.Errorf("unexpected flavor: %+v", f)
+		}
+	})
+
+	t.Run("by name", func(t *testing.T) {
+		f, err := api.FindFlavor("g2l-t-c4m4")
+		if err != nil {
+			t.Fatalf("FindFlavor(name) error: %v", err)
+		}
+		if f.ID != uuid {
+			t.Errorf("expected id %q, got %q", uuid, f.ID)
+		}
+	})
+
+	t.Run("name not found", func(t *testing.T) {
+		if _, err := api.FindFlavor("nope"); err == nil {
+			t.Errorf("expected error for unknown flavor name")
+		}
+	})
+}
+
 func TestListKeypairs(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {


### PR DESCRIPTION
## Summary
- \`conoha server create --flavor g2l-t-c4m4\` now works alongside the existing UUID form.
- Adds \`internal/api.FindFlavor(idOrName)\` mirroring the UUID-first, name-fallback pattern already used by \`cmd/volume.resolveImageID\` and \`ComputeAPI.FindServer\`.

## Test plan
- [x] New \`TestFindFlavor\` with UUID, name, and not-found subtests.
- [x] \`go test ./...\` full suite passes.
- [x] \`go build ./...\` clean.

## Manual verification suggestion
\`\`\`
conoha server create --name hermes --flavor g2l-t-c4m4 --image vmi-docker-29.2-ubuntu-24.04-amd64 ...
# Before: fails "flavor \"g2l-t-c4m4\" not found"
# After:  resolves to the UUID and proceeds.
\`\`\`