### PR TITLE
refactor(app): unify error phrasing + collapse inline marker check (closes #106, #109)

### DIFF
--- a/cmd/app/connect.go
+++ b/cmd/app/connect.go
@@ -16,6 +16,7 @@ import (
 type appContext struct {
 	Client      *ssh.Client
 	AppName     string
+	ServerID    string // the raw id-or-name value the user passed on the CLI
 	Server      *model.Server
 	IP          string
 	User        string
@@ -78,6 +79,7 @@ func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
 	return &appContext{
 		Client:      sshClient,
 		AppName:     appName,
+		ServerID:    args[0],
 		Server:      s,
 		IP:          ip,
 		User:        user,

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -54,15 +54,15 @@ func runDeployDispatch(cmd *cobra.Command, serverID string) error {
 			return err
 		}
 		defer func() { _ = sshClient.Close() }()
-		got, err := ReadMarker(sshClient, appName)
+		mode, err := ResolveMode(cmd, sshClient, appName, serverID)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
-				return fmt.Errorf("app %q not initialized on this server — run 'conoha app init --no-proxy --app-name %s %s' first", appName, appName, serverID)
+				return notInitializedError(appName, serverID, ModeNoProxy)
 			}
 			return err
 		}
-		if got != ModeNoProxy {
-			return formatModeConflictError(appName, got, ModeNoProxy)
+		if mode != ModeNoProxy {
+			return formatModeConflictError(appName, serverID, mode, ModeNoProxy)
 		}
 		return runNoProxyDeploy(cmd, sshClient, s, ip, appName)
 	}
@@ -163,12 +163,12 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 
 	// Mode dispatch parity: reject if this app was initialized in no-proxy mode.
 	// Absent marker falls through to the existing "service not found on proxy" path.
-	got, markerErr := ReadMarker(sshClient, pf.Name)
-	if markerErr != nil && !errors.Is(markerErr, ErrNoMarker) {
-		return markerErr
+	mode, err := ResolveMode(cmd, sshClient, pf.Name, serverID)
+	if err != nil && !errors.Is(err, ErrNoMarker) {
+		return err
 	}
-	if markerErr == nil && got == ModeNoProxy {
-		return formatModeConflictError(pf.Name, got, ModeProxy)
+	if mode == ModeNoProxy {
+		return formatModeConflictError(pf.Name, serverID, mode, ModeProxy)
 	}
 
 	dataDir, _ := cmd.Flags().GetString("data-dir")
@@ -176,7 +176,7 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 
 	// Service must exist — init registers it. Missing = user skipped init.
 	if _, err := admin.Get(pf.Name); err != nil {
-		return fmt.Errorf("app %q not initialized on this server — run 'conoha app init %s' first: %w", pf.Name, serverID, err)
+		return fmt.Errorf("%w: %v", notInitializedError(pf.Name, serverID, ModeProxy), err)
 	}
 
 	slotOverride, _ := cmd.Flags().GetString("slot")

--- a/cmd/app/destroy.go
+++ b/cmd/app/destroy.go
@@ -36,7 +36,7 @@ var destroyCmd = &cobra.Command{
 		// Resolve mode BEFORE the prompt so a flag/marker conflict aborts
 		// before the user commits, and BEFORE the destroy script runs
 		// because the script removes the .conoha-mode marker as part of rm -rf.
-		mode, modeErr := ResolveMode(cmd, ctx.Client, ctx.AppName)
+		mode, modeErr := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
 		if modeErr != nil && !errors.Is(modeErr, ErrNoMarker) {
 			return modeErr
 		}

--- a/cmd/app/init.go
+++ b/cmd/app/init.go
@@ -67,7 +67,7 @@ func runInitProxy(cmd *cobra.Command, serverID string) error {
 
 	// Reject implicit mode switch — user must `app destroy` first.
 	if existing, err := ReadMarker(sshClient, pf.Name); err == nil && existing != ModeProxy {
-		return formatModeConflictError(pf.Name, existing, ModeProxy)
+		return formatModeConflictError(pf.Name, serverID, existing, ModeProxy)
 	} else if err != nil && !errors.Is(err, ErrNoMarker) {
 		return err
 	}
@@ -112,7 +112,7 @@ func runInitNoProxy(cmd *cobra.Command, serverID string) error {
 
 	// Reject implicit mode switch — user must `app destroy` first.
 	if existing, err := ReadMarker(sshClient, appName); err == nil && existing != ModeNoProxy {
-		return formatModeConflictError(appName, existing, ModeNoProxy)
+		return formatModeConflictError(appName, serverID, existing, ModeNoProxy)
 	} else if err != nil && !errors.Is(err, ErrNoMarker) {
 		return err
 	}

--- a/cmd/app/logs.go
+++ b/cmd/app/logs.go
@@ -39,10 +39,10 @@ var logsCmd = &cobra.Command{
 			}
 		}
 
-		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName)
+		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
-				return fmt.Errorf("app %q has not been initialized on this server", ctx.AppName)
+				return notInitializedError(ctx.AppName, ctx.ServerID, "")
 			}
 			return err
 		}
@@ -54,7 +54,7 @@ var logsCmd = &cobra.Command{
 				return err
 			}
 			if slot == "" {
-				return fmt.Errorf("app %q has not been deployed on this server", ctx.AppName)
+				return notDeployedError(ctx.AppName, ctx.ServerID)
 			}
 			composeCmd = buildLogsCmdForProxy(ctx.AppName, slot, tail, follow, service)
 		} else {

--- a/cmd/app/mode.go
+++ b/cmd/app/mode.go
@@ -64,18 +64,54 @@ func buildReadCurrentSlotCmd(app string) string {
 }
 
 // formatModeConflictError returns a user-facing error wrapping ErrModeConflict.
-func formatModeConflictError(app string, got, want Mode) error {
+// serverID is substituted into the recovery command hint so users can copy-run.
+// When serverID is empty the literal "<server>" placeholder is kept (used when
+// the caller doesn't know the server ID at error-construction time).
+func formatModeConflictError(app, serverID string, got, want Mode) error {
 	oppositeInit := "conoha app init"
 	if want == ModeNoProxy {
 		oppositeInit = "conoha app init --no-proxy"
 	}
+	server := serverID
+	if server == "" {
+		server = "<server>"
+	}
 	return fmt.Errorf(
 		`app %q is initialized in %s mode on this server, but --%s was requested.
 To switch modes:
-    conoha app destroy <server>               # removes the existing deployment
-    %s <server>       # re-initialize in %s mode
+    conoha app destroy %s               # removes the existing deployment
+    %s %s       # re-initialize in %s mode
 %w`,
-		app, string(got), string(want), oppositeInit, string(want), ErrModeConflict)
+		app, string(got), string(want), server, oppositeInit, server, string(want), ErrModeConflict)
+}
+
+// notInitializedError is the canonical error for a command that needs the
+// app's mode marker but finds it missing. The recovery hint includes the right
+// init subcommand based on mode when known; when mode is unset it suggests
+// the bare 'conoha app init' form.
+func notInitializedError(app, serverID string, mode Mode) error {
+	server := serverID
+	if server == "" {
+		server = "<server>"
+	}
+	switch mode {
+	case ModeNoProxy:
+		return fmt.Errorf("app %q not initialized on this server — run 'conoha app init --no-proxy --app-name %s %s' first", app, app, server)
+	case ModeProxy:
+		return fmt.Errorf("app %q not initialized on this server — run 'conoha app init %s' first", app, server)
+	default:
+		return fmt.Errorf("app %q not initialized on this server — run 'conoha app init %s' first", app, server)
+	}
+}
+
+// notDeployedError is the canonical error for "marker present but CURRENT_SLOT
+// absent" — the app was initialized but never deployed.
+func notDeployedError(app, serverID string) error {
+	server := serverID
+	if server == "" {
+		server = "<server>"
+	}
+	return fmt.Errorf("app %q has not been deployed on this server — run 'conoha app deploy %s' first", app, server)
 }
 
 // ReadMarker returns the mode recorded on the server for app, or ErrNoMarker
@@ -142,16 +178,18 @@ func flagMode(cmd *cobra.Command) Mode {
 
 // ResolveMode interprets flags against the marker.
 // Precedence: flag override compared to marker (error on mismatch) > marker > ErrNoMarker.
-func ResolveMode(cmd *cobra.Command, cli *ssh.Client, app string) (Mode, error) {
+// serverID is embedded into ErrModeConflict's recovery hint; pass "" if the
+// caller does not have it.
+func ResolveMode(cmd *cobra.Command, cli *ssh.Client, app, serverID string) (Mode, error) {
 	want := flagMode(cmd)
 	got, readErr := ReadMarker(cli, app)
-	return resolveModeLogic(app, want, got, readErr)
+	return resolveModeLogic(app, serverID, want, got, readErr)
 }
 
 // resolveModeLogic is the pure precedence layer extracted for unit testing.
 // want is the flag-requested mode ("" if none). got/readErr come from ReadMarker.
 // Non-ErrNoMarker read errors are propagated unchanged.
-func resolveModeLogic(app string, want, got Mode, readErr error) (Mode, error) {
+func resolveModeLogic(app, serverID string, want, got Mode, readErr error) (Mode, error) {
 	if readErr != nil && !errors.Is(readErr, ErrNoMarker) {
 		return "", readErr
 	}
@@ -163,7 +201,7 @@ func resolveModeLogic(app string, want, got Mode, readErr error) (Mode, error) {
 	case errors.Is(readErr, ErrNoMarker):
 		return want, nil
 	case want != got:
-		return "", formatModeConflictError(app, got, want)
+		return "", formatModeConflictError(app, serverID, got, want)
 	default:
 		return got, nil
 	}

--- a/cmd/app/mode_test.go
+++ b/cmd/app/mode_test.go
@@ -112,7 +112,7 @@ func TestResolveModeLogic(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			mode, err := resolveModeLogic("myapp", c.want, c.got, c.readErr)
+			mode, err := resolveModeLogic("myapp", "my-server", c.want, c.got, c.readErr)
 			if mode != c.expMode {
 				t.Errorf("mode = %q, want %q", mode, c.expMode)
 			}
@@ -135,7 +135,7 @@ func TestResolveModeLogic(t *testing.T) {
 }
 
 func TestFormatModeConflictError(t *testing.T) {
-	err := formatModeConflictError("myapp", ModeProxy, ModeNoProxy)
+	err := formatModeConflictError("myapp", "my-server", ModeProxy, ModeNoProxy)
 	if !errors.Is(err, ErrModeConflict) {
 		t.Errorf("expected ErrModeConflict, got %v", err)
 	}
@@ -144,11 +144,50 @@ func TestFormatModeConflictError(t *testing.T) {
 		`"myapp"`,
 		"proxy mode",
 		"--no-proxy was requested",
-		"conoha app destroy",
-		"conoha app init --no-proxy",
+		"conoha app destroy my-server",
+		"conoha app init --no-proxy my-server",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("conflict error missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestFormatModeConflictError_missingServerID(t *testing.T) {
+	err := formatModeConflictError("myapp", "", ModeProxy, ModeNoProxy)
+	if !strings.Contains(err.Error(), "conoha app destroy <server>") {
+		t.Errorf("expected <server> placeholder when serverID is empty: %s", err.Error())
+	}
+}
+
+func TestNotInitializedError(t *testing.T) {
+	cases := []struct {
+		name    string
+		mode    Mode
+		wantSub string
+	}{
+		{"proxy mode", ModeProxy, "conoha app init my-server"},
+		{"no-proxy mode", ModeNoProxy, "conoha app init --no-proxy --app-name myapp my-server"},
+		{"mode unknown", "", "conoha app init my-server"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := notInitializedError("myapp", "my-server", c.mode).Error()
+			if !strings.Contains(got, c.wantSub) {
+				t.Errorf("want substring %q, got %q", c.wantSub, got)
+			}
+			if !strings.Contains(got, `app "myapp"`) {
+				t.Errorf("missing quoted app name: %s", got)
+			}
+		})
+	}
+}
+
+func TestNotDeployedError(t *testing.T) {
+	got := notDeployedError("myapp", "my-server").Error()
+	for _, want := range []string{`"myapp"`, "not been deployed", "conoha app deploy my-server"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %s", want, got)
 		}
 	}
 }

--- a/cmd/app/restart.go
+++ b/cmd/app/restart.go
@@ -26,10 +26,10 @@ var restartCmd = &cobra.Command{
 		}
 		defer func() { _ = ctx.Client.Close() }()
 
-		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName)
+		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
-				return fmt.Errorf("app %q has not been initialized on this server", ctx.AppName)
+				return notInitializedError(ctx.AppName, ctx.ServerID, "")
 			}
 			return err
 		}
@@ -41,7 +41,7 @@ var restartCmd = &cobra.Command{
 				return err
 			}
 			if slot == "" {
-				return fmt.Errorf("app %q has not been deployed on this server", ctx.AppName)
+				return notDeployedError(ctx.AppName, ctx.ServerID)
 			}
 			composeCmd = buildRestartCmdForProxy(ctx.AppName, slot)
 		} else {

--- a/cmd/app/rollback.go
+++ b/cmd/app/rollback.go
@@ -51,10 +51,10 @@ var rollbackCmd = &cobra.Command{
 		}
 		defer func() { _ = sshClient.Close() }()
 
-		mode, err := ResolveMode(cmd, sshClient, pf.Name)
+		mode, err := ResolveMode(cmd, sshClient, pf.Name, args[0])
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
-				return fmt.Errorf("app %q not initialized on this server — run 'conoha app init' first", pf.Name)
+				return notInitializedError(pf.Name, args[0], ModeProxy)
 			}
 			return err
 		}

--- a/cmd/app/status.go
+++ b/cmd/app/status.go
@@ -30,10 +30,10 @@ var statusCmd = &cobra.Command{
 		}
 		defer func() { _ = ctx.Client.Close() }()
 
-		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName)
+		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
-				return fmt.Errorf("app %q has not been initialized on this server", ctx.AppName)
+				return notInitializedError(ctx.AppName, ctx.ServerID, "")
 			}
 			return err
 		}

--- a/cmd/app/stop.go
+++ b/cmd/app/stop.go
@@ -29,10 +29,10 @@ var stopCmd = &cobra.Command{
 
 		// Resolve mode + slot before the prompt so flag/marker conflicts or
 		// "not deployed" errors abort without asking the user to confirm (I3).
-		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName)
+		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
-				return fmt.Errorf("app %q has not been initialized on this server", ctx.AppName)
+				return notInitializedError(ctx.AppName, ctx.ServerID, "")
 			}
 			return err
 		}
@@ -44,7 +44,7 @@ var stopCmd = &cobra.Command{
 				return err
 			}
 			if slot == "" {
-				return fmt.Errorf("app %q has not been deployed on this server", ctx.AppName)
+				return notDeployedError(ctx.AppName, ctx.ServerID)
 			}
 			composeCmd = buildStopCmdForProxy(ctx.AppName, slot)
 		} else {


### PR DESCRIPTION
## Summary
- **#106** — Nine app subcommands ship their own wording for \"no marker\" / \"no CURRENT_SLOT\" errors. Collapse to two helpers (\`notInitializedError\`, \`notDeployedError\`) in \`cmd/app/mode.go\`. Thread \`serverID\` through \`ResolveMode\` / \`formatModeConflictError\` so the recovery hint references the real server the user typed. Empty \`serverID\` still falls back to \`<server>\` (for callers that don't have one yet).
- **#109** — \`runProxyDeploy\` no longer open-codes its own marker read / no-proxy conflict branch. Uses \`ResolveMode\` like every other mode-aware site.

## Call sites updated
\`deploy.go\` (both proxy + no-proxy paths), \`logs.go\`, \`stop.go\`, \`restart.go\`, \`status.go\`, \`rollback.go\`, \`destroy.go\`, \`init.go\` (both modes).

## Tests
- \`TestFormatModeConflictError\` now asserts the real \`my-server\` substitution in both destroy + init commands.
- New \`TestFormatModeConflictError_missingServerID\` locks in the \`<server>\` fallback.
- New \`TestNotInitializedError\` covers proxy / no-proxy / unknown-mode branches.
- New \`TestNotDeployedError\` covers the deploy-recovery hint.
- \`go test ./...\` full suite passes.

## Behavior changes
- \`rollback\` on an unmarked app previously printed "run 'conoha app init' first" (no server id); now prints \`run 'conoha app init <server-id-or-name>' first\` with the real value.
- \`app deploy\` (both modes) no longer prints the legacy bare messages. They're replaced with the helper output. No new states / no new exits.