### PR TITLE
refactor(app): cache ctx marker + return SSH errors in status (closes #104, #105)

### DIFF
--- a/cmd/app/connect.go
+++ b/cmd/app/connect.go
@@ -32,9 +32,13 @@ type appContext struct {
 	markerErr  error
 }
 
-// Marker returns the on-server mode marker, cached on first call. Safe to
-// call any number of times from any code path. Returns ErrNoMarker when the
-// .conoha-mode file is absent.
+// Marker returns the on-server mode marker. On first call it performs the
+// ReadMarker round-trip and caches **both** the value and the error; every
+// subsequent call within the same command invocation returns the same pair.
+// That means a transient SSH/parse failure on the first call is pinned for
+// the rest of the command — consistent with fail-fast semantics. Safe for
+// concurrent use. Returns ErrNoMarker when .conoha-mode is absent; other
+// errors (SSH transport, ParseMarker) propagate unchanged.
 func (c *appContext) Marker() (Mode, error) {
 	c.markerOnce.Do(func() {
 		c.markerMode, c.markerErr = ReadMarker(c.Client, c.AppName)

--- a/cmd/app/connect.go
+++ b/cmd/app/connect.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -21,6 +22,24 @@ type appContext struct {
 	IP          string
 	User        string
 	ComposeFile string
+
+	// markerOnce caches the ReadMarker round-trip across the lifetime of a
+	// single command invocation. Multiple call sites (maybeWarnProxyEnvMode,
+	// ResolveMode via ResolveModeFromCtx, destroy's marker check) would
+	// otherwise issue redundant SSH cats.
+	markerOnce sync.Once
+	markerMode Mode
+	markerErr  error
+}
+
+// Marker returns the on-server mode marker, cached on first call. Safe to
+// call any number of times from any code path. Returns ErrNoMarker when the
+// .conoha-mode file is absent.
+func (c *appContext) Marker() (Mode, error) {
+	c.markerOnce.Do(func() {
+		c.markerMode, c.markerErr = ReadMarker(c.Client, c.AppName)
+	})
+	return c.markerMode, c.markerErr
 }
 
 func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {

--- a/cmd/app/destroy.go
+++ b/cmd/app/destroy.go
@@ -36,7 +36,7 @@ var destroyCmd = &cobra.Command{
 		// Resolve mode BEFORE the prompt so a flag/marker conflict aborts
 		// before the user commits, and BEFORE the destroy script runs
 		// because the script removes the .conoha-mode marker as part of rm -rf.
-		mode, modeErr := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
+		mode, modeErr := ResolveModeFromCtx(cmd, ctx)
 		if modeErr != nil && !errors.Is(modeErr, ErrNoMarker) {
 			return modeErr
 		}

--- a/cmd/app/env.go
+++ b/cmd/app/env.go
@@ -19,8 +19,10 @@ func proxyEnvWarningMessage() string {
 
 // maybeWarnProxyEnvMode emits the proxy-mode warning to stderr once per env
 // subcommand invocation. Silent on no-proxy or when marker lookup fails.
+// Consumes the ctx-cached marker so read-only subcommands (get, list) don't
+// pay a second SSH round-trip alongside the env file read.
 func maybeWarnProxyEnvMode(ctx *appContext) {
-	m, err := ReadMarker(ctx.Client, ctx.AppName)
+	m, err := ctx.Marker()
 	if err == nil && m == ModeProxy {
 		fmt.Fprint(os.Stderr, proxyEnvWarningMessage())
 	}

--- a/cmd/app/logs.go
+++ b/cmd/app/logs.go
@@ -39,7 +39,7 @@ var logsCmd = &cobra.Command{
 			}
 		}
 
-		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
+		mode, err := ResolveModeFromCtx(cmd, ctx)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
 				return notInitializedError(ctx.AppName, ctx.ServerID, "")

--- a/cmd/app/mode.go
+++ b/cmd/app/mode.go
@@ -197,6 +197,15 @@ func ResolveMode(cmd *cobra.Command, cli *ssh.Client, app, serverID string) (Mod
 	return resolveModeLogic(app, serverID, want, got, readErr)
 }
 
+// ResolveModeFromCtx is ResolveMode but consumes the marker cached on the
+// appContext, avoiding a second SSH round-trip when the marker has already
+// been fetched for a sibling check in the same command invocation.
+func ResolveModeFromCtx(cmd *cobra.Command, ctx *appContext) (Mode, error) {
+	want := flagMode(cmd)
+	got, readErr := ctx.Marker()
+	return resolveModeLogic(ctx.AppName, ctx.ServerID, want, got, readErr)
+}
+
 // resolveModeLogic is the pure precedence layer extracted for unit testing.
 // want is the flag-requested mode ("" if none). got/readErr come from ReadMarker.
 // Non-ErrNoMarker read errors are propagated unchanged.

--- a/cmd/app/restart.go
+++ b/cmd/app/restart.go
@@ -26,7 +26,7 @@ var restartCmd = &cobra.Command{
 		}
 		defer func() { _ = ctx.Client.Close() }()
 
-		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
+		mode, err := ResolveModeFromCtx(cmd, ctx)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
 				return notInitializedError(ctx.AppName, ctx.ServerID, "")

--- a/cmd/app/status.go
+++ b/cmd/app/status.go
@@ -30,7 +30,7 @@ var statusCmd = &cobra.Command{
 		}
 		defer func() { _ = ctx.Client.Close() }()
 
-		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
+		mode, err := ResolveModeFromCtx(cmd, ctx)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
 				return notInitializedError(ctx.AppName, ctx.ServerID, "")
@@ -44,8 +44,17 @@ var statusCmd = &cobra.Command{
 		} else {
 			psCmd = buildStatusCmdForNoProxy(ctx.AppName)
 		}
-		if _, err := internalssh.RunCommand(ctx.Client, psCmd, os.Stdout, os.Stderr); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: compose ps: %v\n", err)
+		// A non-nil err from RunCommand is an SSH-layer failure (auth, transport,
+		// channel close) — not something `compose ps` could produce by having no
+		// containers to show. Surface it as a non-zero exit so scripts that check
+		// $? don't silently get wrong information. Remote non-zero exit codes are
+		// downgraded to a warning because an empty project is a normal state.
+		code, err := internalssh.RunCommand(ctx.Client, psCmd, os.Stdout, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("status (compose ps via SSH): %w", err)
+		}
+		if code != 0 {
+			fmt.Fprintf(os.Stderr, "warning: compose ps exited with code %d\n", code)
 		}
 
 		if mode != ModeProxy {

--- a/cmd/app/stop.go
+++ b/cmd/app/stop.go
@@ -29,7 +29,7 @@ var stopCmd = &cobra.Command{
 
 		// Resolve mode + slot before the prompt so flag/marker conflicts or
 		// "not deployed" errors abort without asking the user to confirm (I3).
-		mode, err := ResolveMode(cmd, ctx.Client, ctx.AppName, ctx.ServerID)
+		mode, err := ResolveModeFromCtx(cmd, ctx)
 		if err != nil {
 			if errors.Is(err, ErrNoMarker) {
 				return notInitializedError(ctx.AppName, ctx.ServerID, "")


### PR DESCRIPTION
## Summary
- **#104** — Add \`appContext.Marker()\` sync.Once cache so the \`.conoha-mode\` SSH read happens at most once per command. New \`ResolveModeFromCtx\` consumes the cache. Six call sites (logs, stop, restart, status, destroy, env-warning) migrate to it.
- **#105** — \`status.go\` now distinguishes SSH-layer failure from remote non-zero exit. The former returns a non-zero exit code (scripts can trust \`\$?\`); the latter stays a warning (empty compose project is a normal state).

## Round-trip reduction
\`conoha app env list\`: 2 \`cat\` round-trips → 1 (the env file read is the only remaining one; the warning consumes the cached marker).

\`conoha app logs/stop/restart/status/destroy\`: \`ReadMarker\` is called once via the cache, not twice through \`ResolveMode\` chained after a ctx construction.

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` full suite passes (no behavioral change to ResolveMode).
- [ ] Reviewer: confirm the status error-surfacing doesn't regress the "compose ps returns non-zero on no containers" case — covered by the comment explaining the downgrade.