### PR TITLE
feat(app,errors): distinct exit codes for mode-conflict and not-initialized (closes #111)

### DIFF
--- a/cmd/app/mode.go
+++ b/cmd/app/mode.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
 
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 	internalssh "github.com/crowdy/conoha-cli/internal/ssh"
 )
 
@@ -67,6 +68,8 @@ func buildReadCurrentSlotCmd(app string) string {
 // serverID is substituted into the recovery command hint so users can copy-run.
 // When serverID is empty the literal "<server>" placeholder is kept (used when
 // the caller doesn't know the server ID at error-construction time).
+// The returned error carries ExitModeConflict (7) via the wrap chain so
+// scripts can distinguish mode-conflict aborts from generic failures.
 func formatModeConflictError(app, serverID string, got, want Mode) error {
 	oppositeInit := "conoha app init"
 	if want == ModeNoProxy {
@@ -76,32 +79,36 @@ func formatModeConflictError(app, serverID string, got, want Mode) error {
 	if server == "" {
 		server = "<server>"
 	}
-	return fmt.Errorf(
+	return cerrors.WithExitCode(fmt.Errorf(
 		`app %q is initialized in %s mode on this server, but --%s was requested.
 To switch modes:
     conoha app destroy %s               # removes the existing deployment
     %s %s       # re-initialize in %s mode
 %w`,
-		app, string(got), string(want), server, oppositeInit, server, string(want), ErrModeConflict)
+		app, string(got), string(want), server, oppositeInit, server, string(want), ErrModeConflict),
+		cerrors.ExitModeConflict)
 }
 
 // notInitializedError is the canonical error for a command that needs the
 // app's mode marker but finds it missing. The recovery hint includes the right
 // init subcommand based on mode when known; when mode is unset it suggests
-// the bare 'conoha app init' form.
+// the bare 'conoha app init' form. The returned error carries ExitNotInitialized
+// (8) via the wrap chain.
 func notInitializedError(app, serverID string, mode Mode) error {
 	server := serverID
 	if server == "" {
 		server = "<server>"
 	}
+	var msg string
 	switch mode {
 	case ModeNoProxy:
-		return fmt.Errorf("app %q not initialized on this server — run 'conoha app init --no-proxy --app-name %s %s' first", app, app, server)
-	case ModeProxy:
-		return fmt.Errorf("app %q not initialized on this server — run 'conoha app init %s' first", app, server)
+		msg = fmt.Sprintf("app %q not initialized on this server — run 'conoha app init --no-proxy --app-name %s %s' first", app, app, server)
+	case ModeProxy, "":
+		msg = fmt.Sprintf("app %q not initialized on this server — run 'conoha app init %s' first", app, server)
 	default:
-		return fmt.Errorf("app %q not initialized on this server — run 'conoha app init %s' first", app, server)
+		msg = fmt.Sprintf("app %q not initialized on this server — run 'conoha app init %s' first", app, server)
 	}
+	return cerrors.WithExitCode(errors.New(msg), cerrors.ExitNotInitialized)
 }
 
 // notDeployedError is the canonical error for "marker present but CURRENT_SLOT

--- a/cmd/app/mode_test.go
+++ b/cmd/app/mode_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 )
 
 func TestMode_String(t *testing.T) {
@@ -212,4 +214,35 @@ func TestNotDeployedError(t *testing.T) {
 			t.Errorf("missing %q in %s", want, got)
 		}
 	}
+}
+
+func TestModeErrorsCarryExitCode(t *testing.T) {
+	t.Run("mode conflict → 7", func(t *testing.T) {
+		err := formatModeConflictError("myapp", "srv", ModeProxy, ModeNoProxy)
+		if code := cerrors.GetExitCode(err); code != cerrors.ExitModeConflict {
+			t.Errorf("GetExitCode = %d, want ExitModeConflict (%d)", code, cerrors.ExitModeConflict)
+		}
+		// errors.Is still matches the sentinel — existing checks in the
+		// tree (dispatch helpers) keep working.
+		if !errors.Is(err, ErrModeConflict) {
+			t.Errorf("errors.Is(ErrModeConflict) broken after WithExitCode")
+		}
+	})
+	t.Run("not initialized → 8", func(t *testing.T) {
+		for _, m := range []Mode{ModeProxy, ModeNoProxy, ""} {
+			err := notInitializedError("myapp", "srv", m)
+			if code := cerrors.GetExitCode(err); code != cerrors.ExitNotInitialized {
+				t.Errorf("mode=%q: GetExitCode = %d, want ExitNotInitialized (%d)", m, code, cerrors.ExitNotInitialized)
+			}
+		}
+	})
+	t.Run("wrapped by fmt.Errorf still resolves", func(t *testing.T) {
+		// deploy.go:179 wraps notInitializedError with fmt.Errorf %w — make
+		// sure the exit code survives the outer wrap.
+		inner := notInitializedError("myapp", "srv", ModeProxy)
+		outer := errors.Join(inner, errors.New("outer context"))
+		if code := cerrors.GetExitCode(outer); code != cerrors.ExitNotInitialized {
+			t.Errorf("lost exit code through wrap: got %d", code)
+		}
+	})
 }

--- a/cmd/app/mode_test.go
+++ b/cmd/app/mode_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -237,10 +238,12 @@ func TestModeErrorsCarryExitCode(t *testing.T) {
 		}
 	})
 	t.Run("wrapped by fmt.Errorf still resolves", func(t *testing.T) {
-		// deploy.go:179 wraps notInitializedError with fmt.Errorf %w — make
-		// sure the exit code survives the outer wrap.
+		// Mirror the exact wrap pattern at deploy.go:179 —
+		// `fmt.Errorf("%w: %v", notInitializedError(...), err)` — so this
+		// test breaks if a future GetExitCode change stops traversing the
+		// wrap chain for linear %w wraps.
 		inner := notInitializedError("myapp", "srv", ModeProxy)
-		outer := errors.Join(inner, errors.New("outer context"))
+		outer := fmt.Errorf("%w: %v", inner, errors.New("admin.Get failed"))
 		if code := cerrors.GetExitCode(outer); code != cerrors.ExitNotInitialized {
 			t.Errorf("lost exit code through wrap: got %d", code)
 		}

--- a/docs/superpowers/specs/2026-04-21-no-proxy-mode-design.md
+++ b/docs/superpowers/specs/2026-04-21-no-proxy-mode-design.md
@@ -221,16 +221,20 @@ SSH は既存パターン通り `internalssh.RunCommand` を interface 化して
 
 ## 5. エラー・終了コード
 
-| code | 意味 | 発生例 |
-|---|---|---|
-| 0 | 成功 | |
-| 1 | 一般失敗 | SSH 切断、docker 失敗 |
-| 2 | usage / 引数エラー | `--no-proxy` with no `--app-name` |
-| 4 | validation | conoha.yml 解析失敗 (既存) |
-| **5 (新)** | mode-conflict | §2.3、rollback in no-proxy |
-| **6 (新)** | not-initialized | logs/stop/restart/status でマーカー & CURRENT_SLOT 両方不在 |
+当初案では 5/6 を本 feature のエラーに割り当てていたが、`internal/errors/exitcodes.go` が既に 5=`ExitAPI`、6=`ExitNetwork` を使用していたため、#111 実装時に 7/8 へ繰り下げた。spec 初稿の時点で CLI-wide の割り当てを確認していなかった設計ミス。
 
-実装は `cmd/cmdutil` に `ExitWithCode(err, code)` が既に存在すれば流用、無ければ `return` 値で cobra に任せ Run ラッパーでコード設定。
+| code | 定数 | 意味 | 発生例 |
+|---|---|---|---|
+| 0 | `ExitOK` | 成功 | |
+| 1 | `ExitGeneral` | 一般失敗 | SSH 切断、docker 失敗 |
+| 2 | `ExitAuth` | auth / usage | `--no-proxy` with no `--app-name` |
+| 4 | `ExitValidation` | validation | conoha.yml 解析失敗 (既存) |
+| 5 | `ExitAPI` | API error (既存) | |
+| 6 | `ExitNetwork` | network error (既存) | |
+| **7 (新)** | `ExitModeConflict` | mode-conflict | §2.3、rollback in no-proxy |
+| **8 (新)** | `ExitNotInitialized` | not-initialized | logs/stop/restart/status でマーカー不在 |
+
+実装: `internal/errors.WithExitCode(err, code)` で対象エラーに exit code を annotate し、`GetExitCode` が errors.As で wrap chain を辿って解決する。`formatModeConflictError` は `ExitModeConflict`、`notInitializedError` は `ExitNotInitialized` を付与する。
 
 ## 6. 設定・CLI 表面まとめ
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,10 +1,34 @@
 package errors
 
-import "fmt"
+import (
+	stderrors "errors"
+	"fmt"
+)
 
 // ExitCoder is implemented by errors that carry a process exit code.
 type ExitCoder interface {
 	ExitCode() int
+}
+
+// exitCodeErr annotates an underlying error with a specific process exit code
+// while preserving its message and wrap chain. Used by packages (cmd/app, ...)
+// that want typed sub-failures without defining a new struct per case.
+type exitCodeErr struct {
+	err  error
+	code int
+}
+
+func (e *exitCodeErr) Error() string { return e.err.Error() }
+func (e *exitCodeErr) Unwrap() error { return e.err }
+func (e *exitCodeErr) ExitCode() int { return e.code }
+
+// WithExitCode wraps err so that GetExitCode returns code. The wrapped error
+// remains errors.Is/As-compatible with whatever err already wraps.
+func WithExitCode(err error, code int) error {
+	if err == nil {
+		return nil
+	}
+	return &exitCodeErr{err: err, code: code}
 }
 
 // APIError represents an error returned by the ConoHa API.
@@ -99,14 +123,15 @@ func (e *NetworkError) ExitCode() int {
 	return ExitNetwork
 }
 
-// GetExitCode returns the exit code for the given error. If the error
-// implements the ExitCoder interface its code is returned; otherwise
-// ExitGeneral is returned.
+// GetExitCode returns the exit code for the given error. Traverses the
+// error wrap chain (errors.As) to find the first ExitCoder; returns
+// ExitGeneral when no ExitCoder is reachable.
 func GetExitCode(err error) int {
 	if err == nil {
 		return ExitOK
 	}
-	if ec, ok := err.(ExitCoder); ok {
+	var ec ExitCoder
+	if stderrors.As(err, &ec) {
 		return ec.ExitCode()
 	}
 	return ExitGeneral

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -64,4 +64,31 @@ func TestGetExitCode(t *testing.T) {
 	if code := GetExitCode(fmt.Errorf("generic")); code != ExitGeneral {
 		t.Errorf("expected %d, got %d", ExitGeneral, code)
 	}
+	if code := GetExitCode(nil); code != ExitOK {
+		t.Errorf("expected ExitOK for nil, got %d", code)
+	}
+}
+
+func TestWithExitCode(t *testing.T) {
+	base := fmt.Errorf("something went wrong")
+	annotated := WithExitCode(base, ExitModeConflict)
+	if code := GetExitCode(annotated); code != ExitModeConflict {
+		t.Errorf("expected %d, got %d", ExitModeConflict, code)
+	}
+	// Preserve the underlying error message.
+	if annotated.Error() != base.Error() {
+		t.Errorf("message changed: got %q, want %q", annotated.Error(), base.Error())
+	}
+	// Nil input produces nil.
+	if WithExitCode(nil, ExitNotInitialized) != nil {
+		t.Errorf("WithExitCode(nil, ...) should be nil")
+	}
+}
+
+func TestGetExitCode_TraversesWrapChain(t *testing.T) {
+	inner := WithExitCode(fmt.Errorf("inner"), ExitNotInitialized)
+	outer := fmt.Errorf("outer wrap: %w", inner)
+	if code := GetExitCode(outer); code != ExitNotInitialized {
+		t.Errorf("expected %d through wrap chain, got %d", ExitNotInitialized, code)
+	}
 }

--- a/internal/errors/exitcodes.go
+++ b/internal/errors/exitcodes.go
@@ -1,12 +1,14 @@
 package errors
 
 const (
-	ExitOK         = 0
-	ExitGeneral    = 1
-	ExitAuth       = 2
-	ExitNotFound   = 3
-	ExitValidation = 4
-	ExitAPI        = 5
-	ExitNetwork    = 6
-	ExitCancelled  = 10
+	ExitOK             = 0
+	ExitGeneral        = 1
+	ExitAuth           = 2
+	ExitNotFound       = 3
+	ExitValidation     = 4
+	ExitAPI            = 5
+	ExitNetwork        = 6
+	ExitModeConflict   = 7 // cmd/app: --proxy/--no-proxy disagrees with server marker
+	ExitNotInitialized = 8 // cmd/app: a command requiring a server-side marker found none
+	ExitCancelled      = 10
 )


### PR DESCRIPTION
## Summary
- Allocate \`ExitModeConflict = 7\` and \`ExitNotInitialized = 8\` in \`internal/errors/exitcodes.go\`. Spec §5 originally said 5/6, but those were already taken by \`ExitAPI\`/\`ExitNetwork\` — spec updated to document the reallocation with a note on the oversight.
- Add \`internal/errors.WithExitCode(err, code)\` helper that annotates any error with an exit code without losing its message or wrap chain.
- Teach \`GetExitCode\` to use \`errors.As\`, so the exit code survives being wrapped again by \`fmt.Errorf(\"...: %w\", typedErr)\` at call sites (e.g. \`deploy.go:179\`).
- \`formatModeConflictError\` and \`notInitializedError\` in \`cmd/app/mode.go\` return errors carrying the new codes. Every call site already routes through these two helpers (after #106), so no further wiring needed.

## Behavioral outcome
- \`conoha app deploy --no-proxy <srv>\` against a proxy-marker app → exits 7.
- \`conoha app logs <srv>\` against an unmarked server → exits 8.
- Everything that used to exit 1 still does.

## Test plan
- [x] \`internal/errors\`: new tests for \`WithExitCode\`, \`GetExitCode\` nil / generic / wrap-chain traversal.
- [x] \`cmd/app\`: \`TestModeErrorsCarryExitCode\` covers both typed helpers across every mode branch, including the \`errors.Is(ErrModeConflict)\` preservation check so the existing dispatch helpers keep working.
- [x] \`go test ./...\` full suite passes.
- [x] \`go build ./...\` clean.

## Spec impact
Spec \`docs/superpowers/specs/2026-04-21-no-proxy-mode-design.md\` §5 replaced — now tables the full CLI-wide exit-code map and explains the 5→7, 6→8 slide.