### PR TITLE
feat(server): open-port shortcut for ingress rules (closes #90)

### DIFF
--- a/cmd/gpu/setup.go
+++ b/cmd/gpu/setup.go
@@ -77,7 +77,7 @@ image vmi-docker-* for a ready-made base.`,
 
 		// Phase 1: install toolkit + driver.
 		code, err := internalssh.RunScript(sshClient, gpuInstallScript(), nil, os.Stdout, os.Stderr)
-		sshClient.Close()
+		_ = sshClient.Close()
 		if err != nil {
 			return fmt.Errorf("install script: %w", err)
 		}
@@ -105,7 +105,7 @@ image vmi-docker-* for a ready-made base.`,
 		if err != nil {
 			return err
 		}
-		defer sshClient.Close()
+		defer func() { _ = sshClient.Close() }()
 
 		// Phase 4: install nvidia-utils + verify.
 		code, err = internalssh.RunScript(sshClient, gpuVerifyScript(), nil, os.Stdout, os.Stderr)

--- a/cmd/server/open_port.go
+++ b/cmd/server/open_port.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/crowdy/conoha-cli/cmd/cmdutil"
+	"github.com/crowdy/conoha-cli/internal/api"
+	"github.com/crowdy/conoha-cli/internal/model"
+)
+
+func init() {
+	openPortCmd.Flags().String("sg", "", "security group name to add the rule to (default: <server-name>-sg; auto-created if missing)")
+	openPortCmd.Flags().String("remote-ip", "0.0.0.0/0", "remote IP CIDR allowed by the rule")
+	openPortCmd.Flags().String("protocol", "tcp", "IP protocol (tcp, udp)")
+}
+
+var openPortCmd = &cobra.Command{
+	Use:   "open-port <server> <ports>",
+	Short: "Open ingress ports via a custom security group",
+	Long: `Open one or more ingress ports by adding rules to a custom security group
+attached to the server. If the server has no custom security group, one
+named "<server-name>-sg" is created and attached.
+
+Port format: comma-separated list of single ports or ranges
+    7860
+    7860,8080
+    7860,8080,9000-9010
+`,
+	Args: cmdutil.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := cmdutil.NewClient(cmd)
+		if err != nil {
+			return err
+		}
+		compute := api.NewComputeAPI(client)
+		network := api.NewNetworkAPI(client)
+
+		server, err := compute.FindServer(args[0])
+		if err != nil {
+			return err
+		}
+
+		ranges, err := parsePortRanges(args[1])
+		if err != nil {
+			return err
+		}
+
+		sgNameOverride, _ := cmd.Flags().GetString("sg")
+		remoteIP, _ := cmd.Flags().GetString("remote-ip")
+		protocol, _ := cmd.Flags().GetString("protocol")
+		switch protocol {
+		case "tcp", "udp":
+		default:
+			return fmt.Errorf("unsupported --protocol %q (want tcp or udp)", protocol)
+		}
+
+		sgName := sgNameOverride
+		if sgName == "" {
+			sgName = server.Name + "-sg"
+		}
+
+		sg, err := ensureAttachedSG(network, server, sgName)
+		if err != nil {
+			return err
+		}
+
+		for _, r := range ranges {
+			min := r.min
+			max := r.max
+			desc := strconv.Itoa(min)
+			if min != max {
+				desc = fmt.Sprintf("%d-%d", min, max)
+			}
+			if _, err := network.CreateSecurityGroupRule(sg.ID, "ingress", protocol, "IPv4", &min, &max, remoteIP); err != nil {
+				return fmt.Errorf("adding rule for %s: %w", desc, err)
+			}
+			fmt.Fprintf(os.Stderr, "Added %s ingress rule %s from %s on security group %q\n", protocol, desc, remoteIP, sg.Name)
+		}
+
+		return nil
+	},
+}
+
+// ensureAttachedSG returns the security group named sgName attached to every
+// port of the server, creating the SG and/or attaching it as needed.
+//
+// The Server model does not carry a security-groups list; attachment lives on
+// the server's Neutron ports. We inspect ports once and cross-reference their
+// SG IDs against the tenant SG list.
+func ensureAttachedSG(network *api.NetworkAPI, server *model.Server, sgName string) (*model.SecurityGroup, error) {
+	sgs, err := network.ListSecurityGroups()
+	if err != nil {
+		return nil, err
+	}
+	var existing *model.SecurityGroup
+	for i := range sgs {
+		if sgs[i].Name == sgName {
+			existing = &sgs[i]
+			break
+		}
+	}
+
+	if existing != nil {
+		ports, err := network.ListPortsByDevice(server.ID)
+		if err != nil {
+			return nil, err
+		}
+		attached := len(ports) > 0
+		for _, p := range ports {
+			has := false
+			for _, id := range p.SecurityGroups {
+				if id == existing.ID {
+					has = true
+					break
+				}
+			}
+			if !has {
+				attached = false
+				break
+			}
+		}
+		if attached {
+			return existing, nil
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "==> Creating security group %q\n", sgName)
+		created, err := network.CreateSecurityGroup(sgName, fmt.Sprintf("auto-created by 'conoha server open-port' for %s", server.Name))
+		if err != nil {
+			return nil, fmt.Errorf("creating security group %q: %w", sgName, err)
+		}
+		existing = created
+	}
+
+	fmt.Fprintf(os.Stderr, "==> Attaching security group %q to server %s\n", sgName, server.Name)
+	if err := network.AddServerSecurityGroup(server.ID, sgName); err != nil {
+		return nil, fmt.Errorf("attaching security group %q to server: %w", sgName, err)
+	}
+	return existing, nil
+}
+
+type portRange struct{ min, max int }
+
+// parsePortRanges parses a comma-separated list of single ports or ranges
+// ("7860", "7860,8080", "9000-9010") into a deduped, validated list.
+func parsePortRanges(spec string) ([]portRange, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return nil, fmt.Errorf("no ports specified")
+	}
+	var out []portRange
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if strings.Contains(part, "-") {
+			lo, hi, ok := strings.Cut(part, "-")
+			if !ok {
+				return nil, fmt.Errorf("invalid port range %q", part)
+			}
+			lmin, err := parsePort(strings.TrimSpace(lo))
+			if err != nil {
+				return nil, err
+			}
+			lmax, err := parsePort(strings.TrimSpace(hi))
+			if err != nil {
+				return nil, err
+			}
+			if lmin > lmax {
+				return nil, fmt.Errorf("invalid port range %q (min > max)", part)
+			}
+			out = append(out, portRange{min: lmin, max: lmax})
+			continue
+		}
+		p, err := parsePort(part)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, portRange{min: p, max: p})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no ports specified")
+	}
+	return out, nil
+}
+
+func parsePort(s string) (int, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port %q: not a number", s)
+	}
+	if n < 1 || n > 65535 {
+		return 0, fmt.Errorf("invalid port %d (must be 1-65535)", n)
+	}
+	return n, nil
+}

--- a/cmd/server/open_port.go
+++ b/cmd/server/open_port.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -15,8 +16,8 @@ import (
 
 func init() {
 	openPortCmd.Flags().String("sg", "", "security group name to add the rule to (default: <server-name>-sg; auto-created if missing)")
-	openPortCmd.Flags().String("remote-ip", "0.0.0.0/0", "remote IP CIDR allowed by the rule")
-	openPortCmd.Flags().String("protocol", "tcp", "IP protocol (tcp, udp)")
+	openPortCmd.Flags().String("remote-ip", "0.0.0.0/0", "remote IP CIDR (IPv4 or IPv6) allowed by the rule")
+	openPortCmd.Flags().String("protocol", "tcp", "IP protocol (tcp or udp; icmp not supported)")
 }
 
 var openPortCmd = &cobra.Command{
@@ -59,6 +60,11 @@ Port format: comma-separated list of single ports or ranges
 			return fmt.Errorf("unsupported --protocol %q (want tcp or udp)", protocol)
 		}
 
+		ethertype, err := ethertypeFromCIDR(remoteIP)
+		if err != nil {
+			return err
+		}
+
 		sgName := sgNameOverride
 		if sgName == "" {
 			sgName = server.Name + "-sg"
@@ -69,21 +75,39 @@ Port format: comma-separated list of single ports or ranges
 			return err
 		}
 
-		for _, r := range ranges {
+		toCreate, skipped := filterExistingRanges(ranges, sg.Rules, protocol, remoteIP, ethertype)
+		for _, r := range skipped {
+			fmt.Fprintf(os.Stderr, "Skipped %s (rule already present on %q)\n", rangeDesc(r), sg.Name)
+		}
+
+		var added, failed int
+		var firstErr error
+		for _, r := range toCreate {
 			min := r.min
 			max := r.max
-			desc := strconv.Itoa(min)
-			if min != max {
-				desc = fmt.Sprintf("%d-%d", min, max)
+			desc := rangeDesc(r)
+			if _, err := network.CreateSecurityGroupRule(sg.ID, "ingress", protocol, ethertype, &min, &max, remoteIP); err != nil {
+				failed++
+				if firstErr == nil {
+					firstErr = fmt.Errorf("adding rule for %s: %w", desc, err)
+				}
+				fmt.Fprintf(os.Stderr, "Failed to add %s: %v\n", desc, err)
+				continue
 			}
-			if _, err := network.CreateSecurityGroupRule(sg.ID, "ingress", protocol, "IPv4", &min, &max, remoteIP); err != nil {
-				return fmt.Errorf("adding rule for %s: %w", desc, err)
-			}
+			added++
 			fmt.Fprintf(os.Stderr, "Added %s ingress rule %s from %s on security group %q\n", protocol, desc, remoteIP, sg.Name)
 		}
 
-		return nil
+		fmt.Fprintf(os.Stderr, "Summary: %d added, %d skipped, %d failed (of %d)\n", added, len(skipped), failed, len(ranges))
+		return firstErr
 	},
+}
+
+func rangeDesc(r portRange) string {
+	if r.min == r.max {
+		return strconv.Itoa(r.min)
+	}
+	return fmt.Sprintf("%d-%d", r.min, r.max)
 }
 
 // ensureAttachedSG returns the security group named sgName attached to every
@@ -97,12 +121,10 @@ func ensureAttachedSG(network *api.NetworkAPI, server *model.Server, sgName stri
 	if err != nil {
 		return nil, err
 	}
-	var existing *model.SecurityGroup
-	for i := range sgs {
-		if sgs[i].Name == sgName {
-			existing = &sgs[i]
-			break
-		}
+	existing, dupes := pickSGByName(sgs, sgName)
+	if len(dupes) > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: multiple security groups named %q found; using %s (other IDs: %s)\n",
+			sgName, existing.ID, strings.Join(dupes, ", "))
 	}
 
 	if existing != nil {
@@ -147,12 +169,21 @@ type portRange struct{ min, max int }
 
 // parsePortRanges parses a comma-separated list of single ports or ranges
 // ("7860", "7860,8080", "9000-9010") into a deduped, validated list.
+// First-occurrence order is preserved.
 func parsePortRanges(spec string) ([]portRange, error) {
 	spec = strings.TrimSpace(spec)
 	if spec == "" {
 		return nil, fmt.Errorf("no ports specified")
 	}
+	seen := make(map[portRange]bool)
 	var out []portRange
+	add := func(pr portRange) {
+		if seen[pr] {
+			return
+		}
+		seen[pr] = true
+		out = append(out, pr)
+	}
 	for _, part := range strings.Split(spec, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
@@ -174,14 +205,14 @@ func parsePortRanges(spec string) ([]portRange, error) {
 			if lmin > lmax {
 				return nil, fmt.Errorf("invalid port range %q (min > max)", part)
 			}
-			out = append(out, portRange{min: lmin, max: lmax})
+			add(portRange{min: lmin, max: lmax})
 			continue
 		}
 		p, err := parsePort(part)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, portRange{min: p, max: p})
+		add(portRange{min: p, max: p})
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("no ports specified")
@@ -198,4 +229,64 @@ func parsePort(s string) (int, error) {
 		return 0, fmt.Errorf("invalid port %d (must be 1-65535)", n)
 	}
 	return n, nil
+}
+
+// ethertypeFromCIDR returns "IPv4" or "IPv6" based on the parsed CIDR. The
+// Neutron ethertype must match the remote_ip_prefix family or the rule is
+// rejected with an opaque error; we validate and classify locally.
+func ethertypeFromCIDR(cidr string) (string, error) {
+	if cidr == "" {
+		return "", fmt.Errorf("remote-ip CIDR is empty")
+	}
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("invalid remote-ip CIDR %q: %w", cidr, err)
+	}
+	if ip.To4() != nil {
+		return "IPv4", nil
+	}
+	return "IPv6", nil
+}
+
+// filterExistingRanges splits input ranges into (new, skipped) by matching
+// against existing ingress rules on the same SG. A rule matches when
+// direction/protocol/ethertype/remote_ip_prefix and port_range_min/max all
+// align with the desired tuple.
+func filterExistingRanges(ranges []portRange, existing []model.SecurityGroupRule, protocol, remoteIP, ethertype string) (newRanges, skipped []portRange) {
+	has := make(map[portRange]bool)
+	for _, r := range existing {
+		if r.Direction != "ingress" || r.Protocol != protocol || r.EtherType != ethertype || r.RemoteIPPrefix != remoteIP {
+			continue
+		}
+		if r.PortRangeMin == nil || r.PortRangeMax == nil {
+			continue
+		}
+		has[portRange{min: *r.PortRangeMin, max: *r.PortRangeMax}] = true
+	}
+	for _, pr := range ranges {
+		if has[pr] {
+			skipped = append(skipped, pr)
+			continue
+		}
+		newRanges = append(newRanges, pr)
+	}
+	return
+}
+
+// pickSGByName returns the first SG matching name and the IDs of any
+// additional duplicates (OpenStack permits same-named SGs within a tenant).
+func pickSGByName(sgs []model.SecurityGroup, name string) (*model.SecurityGroup, []string) {
+	var first *model.SecurityGroup
+	var dupes []string
+	for i := range sgs {
+		if sgs[i].Name != name {
+			continue
+		}
+		if first == nil {
+			first = &sgs[i]
+			continue
+		}
+		dupes = append(dupes, sgs[i].ID)
+	}
+	return first, dupes
 }

--- a/cmd/server/open_port_test.go
+++ b/cmd/server/open_port_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"reflect"
 	"testing"
+
+	"github.com/crowdy/conoha-cli/internal/model"
 )
 
 func TestParsePortRanges(t *testing.T) {
@@ -18,6 +20,10 @@ func TestParsePortRanges(t *testing.T) {
 		{"mixed", "7860,8080,9000-9010", []portRange{{7860, 7860}, {8080, 8080}, {9000, 9010}}, false},
 		{"whitespace tolerant", " 7860 , 8080 ", []portRange{{7860, 7860}, {8080, 8080}}, false},
 		{"trailing comma", "7860,", []portRange{{7860, 7860}}, false},
+		{"dedup singles", "7860,7860", []portRange{{7860, 7860}}, false},
+		{"dedup range and single", "80,80-80", []portRange{{80, 80}}, false},
+		{"dedup ranges", "9000-9010,9000-9010", []portRange{{9000, 9010}}, false},
+		{"dedup preserves order", "8080,7860,8080", []portRange{{8080, 8080}, {7860, 7860}}, false},
 
 		{"empty", "", nil, true},
 		{"empty only commas", ",,,", nil, true},
@@ -38,4 +44,102 @@ func TestParsePortRanges(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEthertypeFromCIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"ipv4 any", "0.0.0.0/0", "IPv4", false},
+		{"ipv4 /32", "10.0.0.1/32", "IPv4", false},
+		{"ipv4 /8", "10.0.0.0/8", "IPv4", false},
+		{"ipv6 any", "::/0", "IPv6", false},
+		{"ipv6 /128", "2001:db8::1/128", "IPv6", false},
+		{"ipv6 /64", "2001:db8::/64", "IPv6", false},
+
+		{"empty", "", "", true},
+		{"bare ip no mask", "10.0.0.1", "", true},
+		{"bad cidr", "10.0.0/8", "", true},
+		{"garbage", "not-an-ip", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ethertypeFromCIDR(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err=%v wantErr=%v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterExistingRanges(t *testing.T) {
+	ptr := func(n int) *int { return &n }
+	existing := []model.SecurityGroupRule{
+		{Direction: "ingress", Protocol: "tcp", EtherType: "IPv4", RemoteIPPrefix: "0.0.0.0/0", PortRangeMin: ptr(80), PortRangeMax: ptr(80)},
+		{Direction: "ingress", Protocol: "tcp", EtherType: "IPv4", RemoteIPPrefix: "0.0.0.0/0", PortRangeMin: ptr(9000), PortRangeMax: ptr(9010)},
+		// should not match (different CIDR)
+		{Direction: "ingress", Protocol: "tcp", EtherType: "IPv4", RemoteIPPrefix: "10.0.0.0/8", PortRangeMin: ptr(443), PortRangeMax: ptr(443)},
+		// should not match (udp)
+		{Direction: "ingress", Protocol: "udp", EtherType: "IPv4", RemoteIPPrefix: "0.0.0.0/0", PortRangeMin: ptr(53), PortRangeMax: ptr(53)},
+		// should not match (egress)
+		{Direction: "egress", Protocol: "tcp", EtherType: "IPv4", RemoteIPPrefix: "0.0.0.0/0", PortRangeMin: ptr(22), PortRangeMax: ptr(22)},
+		// nil ports should not crash the filter
+		{Direction: "ingress", Protocol: "tcp", EtherType: "IPv4", RemoteIPPrefix: "0.0.0.0/0", PortRangeMin: nil, PortRangeMax: nil},
+	}
+
+	input := []portRange{{80, 80}, {443, 443}, {9000, 9010}, {22, 22}}
+	wantNew := []portRange{{443, 443}, {22, 22}}
+	wantSkipped := []portRange{{80, 80}, {9000, 9010}}
+
+	gotNew, gotSkipped := filterExistingRanges(input, existing, "tcp", "0.0.0.0/0", "IPv4")
+	if !reflect.DeepEqual(gotNew, wantNew) {
+		t.Errorf("new: got %v, want %v", gotNew, wantNew)
+	}
+	if !reflect.DeepEqual(gotSkipped, wantSkipped) {
+		t.Errorf("skipped: got %v, want %v", gotSkipped, wantSkipped)
+	}
+}
+
+func TestPickSGByName(t *testing.T) {
+	sgs := []model.SecurityGroup{
+		{ID: "id-a", Name: "foo-sg"},
+		{ID: "id-b", Name: "bar-sg"},
+		{ID: "id-c", Name: "foo-sg"},
+	}
+
+	t.Run("single match", func(t *testing.T) {
+		got, dupes := pickSGByName(sgs, "bar-sg")
+		if got == nil || got.ID != "id-b" {
+			t.Errorf("got %+v", got)
+		}
+		if len(dupes) != 0 {
+			t.Errorf("dupes %v, want none", dupes)
+		}
+	})
+
+	t.Run("multiple matches returns first and lists duplicate IDs", func(t *testing.T) {
+		got, dupes := pickSGByName(sgs, "foo-sg")
+		if got == nil || got.ID != "id-a" {
+			t.Errorf("got %+v", got)
+		}
+		if !reflect.DeepEqual(dupes, []string{"id-c"}) {
+			t.Errorf("dupes %v", dupes)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		got, dupes := pickSGByName(sgs, "nope")
+		if got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+		if len(dupes) != 0 {
+			t.Errorf("dupes %v", dupes)
+		}
+	})
 }

--- a/cmd/server/open_port_test.go
+++ b/cmd/server/open_port_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePortRanges(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []portRange
+		wantErr bool
+	}{
+		{"single", "7860", []portRange{{7860, 7860}}, false},
+		{"comma list", "7860,8080", []portRange{{7860, 7860}, {8080, 8080}}, false},
+		{"range", "9000-9010", []portRange{{9000, 9010}}, false},
+		{"mixed", "7860,8080,9000-9010", []portRange{{7860, 7860}, {8080, 8080}, {9000, 9010}}, false},
+		{"whitespace tolerant", " 7860 , 8080 ", []portRange{{7860, 7860}, {8080, 8080}}, false},
+		{"trailing comma", "7860,", []portRange{{7860, 7860}}, false},
+
+		{"empty", "", nil, true},
+		{"empty only commas", ",,,", nil, true},
+		{"non-numeric", "abc", nil, true},
+		{"out of range low", "0", nil, true},
+		{"out of range high", "65536", nil, true},
+		{"bad range", "8080-8000", nil, true},
+		{"range with non-number", "8080-abc", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePortRanges(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err=%v wantErr=%v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -35,6 +35,7 @@ func init() {
 	Cmd.AddCommand(deployCmd)
 	Cmd.AddCommand(addSecurityGroupCmd)
 	Cmd.AddCommand(removeSecurityGroupCmd)
+	Cmd.AddCommand(openPortCmd)
 }
 
 func getComputeAPI(cmd *cobra.Command) (*api.ComputeAPI, error) {


### PR DESCRIPTION
## Summary
New \`conoha server open-port <server> <ports>\` collapses the three-step SG-create → rule-add → attach flow into one command. Auto-creates \`<server-name>-sg\` (overridable via \`--sg\`), supports single ports / comma lists / ranges.

## Examples
\`\`\`bash
conoha server open-port fish-speech 7860,8080
conoha server open-port hermes 9000-9010 --remote-ip 10.0.0.0/8 --protocol tcp
\`\`\`

## Flags
| Flag | Default | Purpose |
|---|---|---|
| \`--sg\` | \`<server-name>-sg\` | Override target SG name (created if missing) |
| \`--remote-ip\` | \`0.0.0.0/0\` | CIDR allowed by each rule |
| \`--protocol\` | \`tcp\` | \`tcp\` or \`udp\` |

## Test plan
- [x] \`TestParsePortRanges\` covers: single, comma list, range, mixed, whitespace, trailing comma, errors (empty, non-numeric, 0, 65536, reversed range, non-numeric in range).
- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` full suite passes.
- [ ] Manual: against a real server, verify SG is created + attached + rules show up in \`conoha network sgr list\`.