### PR TITLE
refactor(app/list): enumerate via proxy /v1/services (closes #95)

### DIFF
--- a/cmd/app/list.go
+++ b/cmd/app/list.go
@@ -2,12 +2,17 @@ package app
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
+	"github.com/crowdy/conoha-cli/cmd/proxy"
 	"github.com/crowdy/conoha-cli/internal/api"
+	proxypkg "github.com/crowdy/conoha-cli/internal/proxy"
 	internalssh "github.com/crowdy/conoha-cli/internal/ssh"
 )
 
@@ -15,18 +20,28 @@ func init() {
 	listCmd.Flags().StringP("user", "l", "root", "SSH user")
 	listCmd.Flags().StringP("port", "p", "22", "SSH port")
 	listCmd.Flags().StringP("identity", "i", "", "SSH private key path")
+	listCmd.Flags().String("data-dir", proxy.DefaultDataDir, "proxy data directory on the server")
 }
 
 var listCmd = &cobra.Command{
 	Use:   "list <id|name>",
-	Short: "List deployed apps on a server",
-	Args:  cobra.ExactArgs(1),
+	Short: "List apps registered with conoha-proxy on a server",
+	Long: `Enumerate apps by asking conoha-proxy for its registered services.
+
+Columns: NAME, PHASE, ACTIVE, HOSTS. Empty output (exit 0) means the
+proxy has no services registered — either 'conoha app init' hasn't
+been run, or every app has been destroyed.
+
+Legacy /opt/conoha/*.git scanning was removed. Apps deployed via
+v0.1.x that were never migrated to the proxy model are not listed
+here — use 'ssh <server> ls /opt/conoha/' manually.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := cmdutil.NewClient(cmd)
+		apiClient, err := cmdutil.NewClient(cmd)
 		if err != nil {
 			return err
 		}
-		compute := api.NewComputeAPI(client)
+		compute := api.NewComputeAPI(apiClient)
 
 		s, err := compute.FindServer(args[0])
 		if err != nil {
@@ -41,6 +56,7 @@ var listCmd = &cobra.Command{
 		user, _ := cmd.Flags().GetString("user")
 		port, _ := cmd.Flags().GetString("port")
 		identity, _ := cmd.Flags().GetString("identity")
+		dataDir, _ := cmd.Flags().GetString("data-dir")
 
 		if identity == "" {
 			identity = internalssh.ResolveKeyPath(s.KeyName)
@@ -60,34 +76,32 @@ var listCmd = &cobra.Command{
 		}
 		defer func() { _ = sshClient.Close() }()
 
-		script := generateListScript()
-		exitCode, err := internalssh.RunScript(sshClient, script, nil, os.Stdout, os.Stderr)
+		admin := proxypkg.NewClient(&proxypkg.SSHExecutor{Client: sshClient}, proxy.SocketPath(dataDir))
+		services, err := admin.List()
 		if err != nil {
-			return fmt.Errorf("list failed: %w", err)
+			return fmt.Errorf("list services: %w", err)
 		}
-		if exitCode != 0 {
-			return fmt.Errorf("list exited with code %d", exitCode)
-		}
-		return nil
+
+		return printAppList(os.Stdout, services)
 	},
 }
 
-func generateListScript() []byte {
-	return []byte(`#!/bin/bash
-for repo in /opt/conoha/*.git; do
-    [ -d "$repo" ] || continue
-    APP_NAME=$(basename "$repo" .git)
-    WORK_DIR="/opt/conoha/${APP_NAME}"
-
-    if [ -d "$WORK_DIR" ] && (cd "$WORK_DIR" && docker compose ps --status running -q 2>/dev/null | grep -q .); then
-        STATUS="running"
-    elif [ -d "$WORK_DIR" ] && (cd "$WORK_DIR" && docker compose ps -q 2>/dev/null | grep -q .); then
-        STATUS="stopped"
-    else
-        STATUS="no containers"
-    fi
-
-    printf "%-30s %s\n" "$APP_NAME" "$STATUS"
-done
-`)
+// printAppList renders services as a padded NAME / PHASE / ACTIVE / HOSTS
+// table. Empty input prints nothing (header with zero rows would look like
+// corrupted state to scripts grepping by service name).
+func printAppList(w io.Writer, services []proxypkg.Service) error {
+	if len(services) == 0 {
+		return nil
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tPHASE\tACTIVE\tHOSTS")
+	for _, svc := range services {
+		active := "-"
+		if svc.ActiveTarget != nil {
+			active = svc.ActiveTarget.URL
+		}
+		hosts := strings.Join(svc.Hosts, ",")
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", svc.Name, svc.Phase, active, hosts)
+	}
+	return tw.Flush()
 }

--- a/cmd/app/list.go
+++ b/cmd/app/list.go
@@ -83,9 +83,9 @@ here — use 'ssh <server> ls /opt/conoha/' manually.`,
 		}
 
 		if len(services) == 0 {
-			fmt.Fprintf(os.Stderr, "no proxy-managed apps registered on %s\n", args[0])
-			fmt.Fprintln(os.Stderr, "  for v0.1.x apps never migrated to the proxy model, run:")
-			fmt.Fprintf(os.Stderr, "    ssh %s ls /opt/conoha/\n", args[0])
+			_, _ = fmt.Fprintf(os.Stderr, "no proxy-managed apps registered on %s\n", args[0])
+			_, _ = fmt.Fprintln(os.Stderr, "  for v0.1.x apps never migrated to the proxy model, run:")
+			_, _ = fmt.Fprintf(os.Stderr, "    ssh %s ls /opt/conoha/\n", args[0])
 		}
 		return printAppList(os.Stdout, services)
 	},
@@ -99,14 +99,16 @@ func printAppList(w io.Writer, services []proxypkg.Service) error {
 		return nil
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tPHASE\tACTIVE\tHOSTS")
+	// tabwriter.Writer returns an error only if the underlying writer does;
+	// defer surfacing it until Flush().
+	_, _ = fmt.Fprintln(tw, "NAME\tPHASE\tACTIVE\tHOSTS")
 	for _, svc := range services {
 		active := "-"
 		if svc.ActiveTarget != nil {
 			active = svc.ActiveTarget.URL
 		}
 		hosts := strings.Join(svc.Hosts, ",")
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", svc.Name, svc.Phase, active, hosts)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", svc.Name, svc.Phase, active, hosts)
 	}
 	return tw.Flush()
 }

--- a/cmd/app/list.go
+++ b/cmd/app/list.go
@@ -79,9 +79,14 @@ here — use 'ssh <server> ls /opt/conoha/' manually.`,
 		admin := proxypkg.NewClient(&proxypkg.SSHExecutor{Client: sshClient}, proxy.SocketPath(dataDir))
 		services, err := admin.List()
 		if err != nil {
-			return fmt.Errorf("list services: %w", err)
+			return fmt.Errorf("list services (is conoha-proxy running on %s? try 'conoha proxy status %s'): %w", args[0], args[0], err)
 		}
 
+		if len(services) == 0 {
+			fmt.Fprintf(os.Stderr, "no proxy-managed apps registered on %s\n", args[0])
+			fmt.Fprintln(os.Stderr, "  for v0.1.x apps never migrated to the proxy model, run:")
+			fmt.Fprintf(os.Stderr, "    ssh %s ls /opt/conoha/\n", args[0])
+		}
 		return printAppList(os.Stdout, services)
 	},
 }

--- a/cmd/app/list_test.go
+++ b/cmd/app/list_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	proxypkg "github.com/crowdy/conoha-cli/internal/proxy"
+)
+
+func TestPrintAppList_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printAppList(&buf, nil); err != nil {
+		t.Fatalf("printAppList(nil): %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+func TestPrintAppList_Formatting(t *testing.T) {
+	services := []proxypkg.Service{
+		{
+			Name:  "myapp",
+			Hosts: []string{"app.example.com"},
+			ActiveTarget: &proxypkg.Target{
+				URL: "http://127.0.0.1:34567",
+			},
+			Phase: proxypkg.Phase("active"),
+		},
+		{
+			Name:  "staging",
+			Hosts: []string{"staging.example.com", "alt.example.com"},
+			Phase: proxypkg.Phase("pending"),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := printAppList(&buf, services); err != nil {
+		t.Fatalf("printAppList: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"NAME", "PHASE", "ACTIVE", "HOSTS",
+		"myapp", "app.example.com", "http://127.0.0.1:34567", "active",
+		"staging", "staging.example.com,alt.example.com", "pending",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+
+	// No target → "-" placeholder.
+	lines := strings.Split(out, "\n")
+	foundStaging := false
+	for _, l := range lines {
+		if strings.HasPrefix(l, "staging") {
+			foundStaging = true
+			if !strings.Contains(l, "-") {
+				t.Errorf("staging row should show '-' for active target: %q", l)
+			}
+		}
+	}
+	if !foundStaging {
+		t.Error("staging row not found in output")
+	}
+}

--- a/cmd/app/list_test.go
+++ b/cmd/app/list_test.go
@@ -75,7 +75,7 @@ func TestPrintAppList_Formatting(t *testing.T) {
 	idxName := strings.Index(myappRow, "myapp")
 	idxPhase := strings.Index(myappRow, "live")
 	idxActive := strings.Index(myappRow, "http://")
-	if !(idxName < idxPhase && idxPhase < idxActive) {
+	if idxName >= idxPhase || idxPhase >= idxActive {
 		t.Errorf("column order broken in myapp row: %q", myappRow)
 	}
 

--- a/cmd/app/list_test.go
+++ b/cmd/app/list_test.go
@@ -26,12 +26,12 @@ func TestPrintAppList_Formatting(t *testing.T) {
 			ActiveTarget: &proxypkg.Target{
 				URL: "http://127.0.0.1:34567",
 			},
-			Phase: proxypkg.Phase("active"),
+			Phase: proxypkg.PhaseLive,
 		},
 		{
 			Name:  "staging",
 			Hosts: []string{"staging.example.com", "alt.example.com"},
-			Phase: proxypkg.Phase("pending"),
+			Phase: proxypkg.PhaseConfigured,
 		},
 	}
 
@@ -43,26 +43,44 @@ func TestPrintAppList_Formatting(t *testing.T) {
 	out := buf.String()
 	for _, want := range []string{
 		"NAME", "PHASE", "ACTIVE", "HOSTS",
-		"myapp", "app.example.com", "http://127.0.0.1:34567", "active",
-		"staging", "staging.example.com,alt.example.com", "pending",
+		"myapp", "app.example.com", "http://127.0.0.1:34567", "live",
+		"staging", "staging.example.com,alt.example.com", "configured",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in:\n%s", want, out)
 		}
 	}
 
-	// No target → "-" placeholder.
+	// Row-shape check: myapp row must have PHASE=live positioned between
+	// the name and the active URL (catches a column-swap bug that whole-
+	// buffer Contains would miss).
 	lines := strings.Split(out, "\n")
-	foundStaging := false
+	var myappRow, stagingRow string
 	for _, l := range lines {
-		if strings.HasPrefix(l, "staging") {
-			foundStaging = true
-			if !strings.Contains(l, "-") {
-				t.Errorf("staging row should show '-' for active target: %q", l)
-			}
+		switch {
+		case strings.HasPrefix(l, "myapp"):
+			myappRow = l
+		case strings.HasPrefix(l, "staging"):
+			stagingRow = l
 		}
 	}
-	if !foundStaging {
-		t.Error("staging row not found in output")
+	if myappRow == "" {
+		t.Fatal("myapp row not found")
+	}
+	if stagingRow == "" {
+		t.Fatal("staging row not found")
+	}
+
+	// PHASE column must sit between NAME and ACTIVE in the myapp row.
+	idxName := strings.Index(myappRow, "myapp")
+	idxPhase := strings.Index(myappRow, "live")
+	idxActive := strings.Index(myappRow, "http://")
+	if !(idxName < idxPhase && idxPhase < idxActive) {
+		t.Errorf("column order broken in myapp row: %q", myappRow)
+	}
+
+	// No target → "-" placeholder in ACTIVE column.
+	if !strings.Contains(stagingRow, " - ") {
+		t.Errorf("staging row should show '-' for active target: %q", stagingRow)
 	}
 }


### PR DESCRIPTION
## Summary
\`conoha app list\` now queries the proxy Admin API (\`GET /v1/services\`) instead of shelling out a bash loop over \`/opt/conoha/*.git\`. The legacy loop was inherited from v0.1.x and found nothing on post-#98 servers.

## Output
\`\`\`
NAME      PHASE    ACTIVE                   HOSTS
myapp     active   http://127.0.0.1:34567   app.example.com
staging   pending  -                        staging.example.com,alt.example.com
\`\`\`

Empty list → empty output + exit 0 (not an error).

## Test plan
- [x] \`TestPrintAppList_Empty\` / \`TestPrintAppList_Formatting\` cover the renderer.
- [x] \`go test ./...\` full suite passes.
- [x] \`go build ./...\` clean.
- [ ] Manual: against a server with \`conoha app init\` completed, verify the registered service shows up.

## Breaking
- v0.1.x-era apps (never migrated to the proxy model) are no longer listed. The Long help points at \`ssh <server> ls /opt/conoha/\` for manual inspection.
- Output format changed from \`<name>  <status>\` to \`NAME / PHASE / ACTIVE / HOSTS\`. Scripts parsing the old format need updating.