### PR TITLE
feat(app/env): implement B1 redesign for blue/green (closes #94)

### DIFF
--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -116,10 +116,12 @@ func buildNoProxyUploadCmd(workDir string) string {
 // buildNoProxyDeployCmd brings the flat-layout compose project up in place.
 // The compose project name equals the app name (no slot suffix).
 //
-// Env merge (v0.1.x parity, spec §3.6): appends /opt/conoha/<app>.env.server
-// (written by `conoha app env set`) to <workDir>/.env so server-side values
-// win over repo-level ones via last-occurrence semantics. This is the
-// expected precedence for runtime-secret override.
+// Env merge (v0.2+, spec 2026-04-23-app-env-redesign.md §2.3):
+// appends /opt/conoha/<app>/.env.server (new canonical location) to
+// <workDir>/.env. When that file is absent but the v0.1.x path
+// /opt/conoha/<app>.env.server exists, the legacy path is used and a
+// deprecation warning is emitted to stderr. `app env migrate` moves
+// users forward.
 //
 // Because buildNoProxyUploadCmd cleared any prior merged .env before tar
 // extraction, each deploy starts from the repo's committed .env (if any)
@@ -130,13 +132,19 @@ func buildNoProxyUploadCmd(workDir string) string {
 // composeFile is defensively single-quoted — today it comes from the
 // ResolveComposeFile whitelist, but quoting hardens against future callers.
 func buildNoProxyDeployCmd(workDir, app, composeFile string) string {
-	envServer := fmt.Sprintf("/opt/conoha/%s.env.server", app)
+	newEnv := envFilePath(app)
+	legacyEnv := legacyEnvFilePath(app)
 	return fmt.Sprintf(
 		"cd '%s' && { "+
 			"touch .env; "+
-			"if [ -s '%s' ]; then printf '\\n' >> .env && cat '%s' >> .env; fi; "+
+			"if [ -s '%s' ]; then "+
+			"    printf '\\n' >> .env && cat '%s' >> .env; "+
+			"elif [ -s '%s' ]; then "+
+			"    echo 'warning: merging legacy env file %s (run conoha app env migrate <server> to move it)' >&2; "+
+			"    printf '\\n' >> .env && cat '%s' >> .env; "+
+			"fi; "+
 			"} && docker compose -p %s -f '%s' up -d --build",
-		workDir, envServer, envServer, app, composeFile)
+		workDir, newEnv, newEnv, legacyEnv, legacyEnv, legacyEnv, app, composeFile)
 }
 
 func runProxyDeploy(cmd *cobra.Command, serverID string) error {

--- a/cmd/app/deploy_test.go
+++ b/cmd/app/deploy_test.go
@@ -24,8 +24,11 @@ func TestBuildNoProxyDeployCmd(t *testing.T) {
 		"docker compose -p myapp",
 		"-f 'compose.yml'",
 		"up -d --build",
-		// .env.server appended to .env so server-side values override repo (spec §3.6).
+		// .env.server merged into .env: new canonical path (v0.2+) preferred,
+		// legacy path used as read fallback with a deprecation warning.
+		"/opt/conoha/myapp/.env.server",
 		"/opt/conoha/myapp.env.server",
+		"warning: merging legacy env file",
 		">> .env",
 	} {
 		if !strings.Contains(got, want) {

--- a/cmd/app/env.go
+++ b/cmd/app/env.go
@@ -11,21 +11,37 @@ import (
 	internalssh "github.com/crowdy/conoha-cli/internal/ssh"
 )
 
-// proxyEnvWarningMessage returns the one-line warning emitted when `app env`
-// is run against a proxy-mode app. See #94 for the planned redesign.
-func proxyEnvWarningMessage() string {
-	return "warning: app env has no effect on proxy-mode deployed slots; see #94 for the redesign\n"
+// envFilePath returns the canonical server-side env file path for app.
+// v0.2+ location: app-dir local dotfile so it rides along with the rest
+// of the app state under /opt/conoha/<name>/ and gets wiped cleanly by
+// `rm -rf /opt/conoha/<name>` on destroy.
+func envFilePath(app string) string {
+	return fmt.Sprintf("/opt/conoha/%s/.env.server", app)
 }
 
-// maybeWarnProxyEnvMode emits the proxy-mode warning to stderr once per env
-// subcommand invocation. Silent on no-proxy or when marker lookup fails.
-// Consumes the ctx-cached marker so read-only subcommands (get, list) don't
-// pay a second SSH round-trip alongside the env file read.
-func maybeWarnProxyEnvMode(ctx *appContext) {
-	m, err := ctx.Marker()
-	if err == nil && m == ModeProxy {
-		fmt.Fprint(os.Stderr, proxyEnvWarningMessage())
-	}
+// legacyEnvFilePath returns the v0.1.x env file location — one level up from
+// the app dir. Still read on-the-fly for backward compat until v0.3.x; the
+// `app env migrate` subcommand copies content to the new location.
+func legacyEnvFilePath(app string) string {
+	return fmt.Sprintf("/opt/conoha/%s.env.server", app)
+}
+
+// effectiveEnvFileScript renders a bash snippet that sets ENV_FILE to the
+// first existing file between the new and legacy paths, falling back to the
+// new path (+ a deprecation warning on stderr) when only the legacy one
+// exists. Every env subcommand uses this to stay read-compatible with old
+// servers without auto-migrating content.
+func effectiveEnvFileScript(app string) string {
+	return fmt.Sprintf(
+		`NEW_ENV="%s"
+LEGACY_ENV="%s"
+if [ ! -f "$NEW_ENV" ] && [ -f "$LEGACY_ENV" ]; then
+    echo "warning: reading legacy env file $LEGACY_ENV (run 'conoha app env migrate <server>' to move it to $NEW_ENV; legacy path will stop being read in v0.3)" >&2
+    ENV_FILE="$LEGACY_ENV"
+else
+    ENV_FILE="$NEW_ENV"
+fi
+`, envFilePath(app), legacyEnvFilePath(app))
 }
 
 var envCmd = &cobra.Command{
@@ -38,11 +54,13 @@ func init() {
 	envCmd.AddCommand(envGetCmd)
 	envCmd.AddCommand(envListCmd)
 	envCmd.AddCommand(envUnsetCmd)
+	envCmd.AddCommand(envMigrateCmd)
 
 	addAppFlags(envSetCmd)
 	addAppFlags(envGetCmd)
 	addAppFlags(envListCmd)
 	addAppFlags(envUnsetCmd)
+	addAppFlags(envMigrateCmd)
 }
 
 var envSetCmd = &cobra.Command{
@@ -55,7 +73,6 @@ var envSetCmd = &cobra.Command{
 			return err
 		}
 		defer func() { _ = ctx.Client.Close() }()
-		maybeWarnProxyEnvMode(ctx)
 
 		env := make(map[string]string)
 		for _, arg := range args[1:] {
@@ -86,6 +103,7 @@ var envSetCmd = &cobra.Command{
 		for _, k := range keys {
 			fmt.Fprintf(os.Stderr, "Set %s\n", k)
 		}
+		fmt.Fprintf(os.Stderr, "Next: run 'conoha app deploy %s' to apply.\n", ctx.ServerID)
 		return nil
 	},
 }
@@ -93,7 +111,11 @@ var envSetCmd = &cobra.Command{
 func generateEnvSetScript(appName string, env map[string]string) []byte {
 	var b strings.Builder
 	b.WriteString("#!/bin/bash\nset -euo pipefail\n")
-	fmt.Fprintf(&b, "ENV_FILE=\"/opt/conoha/%s.env.server\"\n", appName)
+	// Writes always go to the new location. Legacy servers get a one-time
+	// migrate path via 'conoha app env migrate' — set intentionally does not
+	// auto-copy legacy content to avoid overwriting it.
+	fmt.Fprintf(&b, "mkdir -p '/opt/conoha/%s'\n", appName)
+	fmt.Fprintf(&b, "ENV_FILE=%q\n", envFilePath(appName))
 	b.WriteString("touch \"$ENV_FILE\"\n")
 
 	keys := make([]string, 0, len(env))
@@ -122,7 +144,6 @@ var envGetCmd = &cobra.Command{
 			return err
 		}
 		defer func() { _ = ctx.Client.Close() }()
-		maybeWarnProxyEnvMode(ctx)
 
 		key := args[1]
 		if err := internalssh.ValidateEnvKey(key); err != nil {
@@ -142,9 +163,9 @@ var envGetCmd = &cobra.Command{
 }
 
 func generateEnvGetCommand(appName, key string) string {
-	return fmt.Sprintf(
-		`grep "^%s=" /opt/conoha/%s.env.server | cut -d= -f2-`,
-		key, appName)
+	return fmt.Sprintf("bash -c '%s grep \"^%s=\" \"$ENV_FILE\" | cut -d= -f2-'",
+		strings.ReplaceAll(effectiveEnvFileScript(appName), "'", "'\\''"),
+		key)
 }
 
 var envListCmd = &cobra.Command{
@@ -157,7 +178,6 @@ var envListCmd = &cobra.Command{
 			return err
 		}
 		defer func() { _ = ctx.Client.Close() }()
-		maybeWarnProxyEnvMode(ctx)
 
 		command := generateEnvListCommand(ctx.AppName)
 		_, err = internalssh.RunCommand(ctx.Client, command, os.Stdout, os.Stderr)
@@ -169,7 +189,8 @@ var envListCmd = &cobra.Command{
 }
 
 func generateEnvListCommand(appName string) string {
-	return fmt.Sprintf(`cat /opt/conoha/%s.env.server 2>/dev/null || true`, appName)
+	return fmt.Sprintf("bash -c '%s cat \"$ENV_FILE\" 2>/dev/null || true'",
+		strings.ReplaceAll(effectiveEnvFileScript(appName), "'", "'\\''"))
 }
 
 var envUnsetCmd = &cobra.Command{
@@ -182,7 +203,6 @@ var envUnsetCmd = &cobra.Command{
 			return err
 		}
 		defer func() { _ = ctx.Client.Close() }()
-		maybeWarnProxyEnvMode(ctx)
 
 		keys := args[1:]
 		for _, k := range keys {
@@ -203,6 +223,7 @@ var envUnsetCmd = &cobra.Command{
 		for _, k := range keys {
 			fmt.Fprintf(os.Stderr, "Unset %s\n", k)
 		}
+		fmt.Fprintf(os.Stderr, "Next: run 'conoha app deploy %s' to apply.\n", ctx.ServerID)
 		return nil
 	},
 }
@@ -210,7 +231,7 @@ var envUnsetCmd = &cobra.Command{
 func generateEnvUnsetScript(appName string, keys []string) []byte {
 	var b strings.Builder
 	b.WriteString("#!/bin/bash\nset -euo pipefail\n")
-	fmt.Fprintf(&b, "ENV_FILE=\"/opt/conoha/%s.env.server\"\n", appName)
+	b.WriteString(effectiveEnvFileScript(appName))
 	b.WriteString("[ -f \"$ENV_FILE\" ] || exit 0\n")
 	b.WriteString("cp \"$ENV_FILE\" \"$ENV_FILE.tmp\"\n")
 	for _, k := range keys {
@@ -219,4 +240,57 @@ func generateEnvUnsetScript(appName string, keys []string) []byte {
 	}
 	b.WriteString("mv \"$ENV_FILE.tmp\" \"$ENV_FILE\"\n")
 	return []byte(b.String())
+}
+
+var envMigrateCmd = &cobra.Command{
+	Use:   "migrate <server>",
+	Short: "Move legacy /opt/conoha/<app>.env.server to /opt/conoha/<app>/.env.server",
+	Long: `One-time operator step: relocates the v0.1.x env file at the legacy path
+(one level up from the app work dir) to the v0.2+ canonical location
+(dotfile inside the app work dir). Safe to re-run — a no-op when the
+legacy path is already absent.
+
+Fails with a clear error when both old and new locations exist, to avoid
+silently overwriting either.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, err := connectToApp(cmd, args[:1])
+		if err != nil {
+			return err
+		}
+		defer func() { _ = ctx.Client.Close() }()
+
+		script := generateEnvMigrateScript(ctx.AppName)
+		exitCode, err := internalssh.RunScript(ctx.Client, script, nil, os.Stdout, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("env migrate failed: %w", err)
+		}
+		if exitCode != 0 {
+			return fmt.Errorf("env migrate exited with code %d", exitCode)
+		}
+		return nil
+	},
+}
+
+func generateEnvMigrateScript(appName string) []byte {
+	return []byte(fmt.Sprintf(`#!/bin/bash
+set -euo pipefail
+
+NEW_ENV=%q
+LEGACY_ENV=%q
+
+if [ ! -f "$LEGACY_ENV" ]; then
+    echo "Nothing to migrate: $LEGACY_ENV does not exist."
+    exit 0
+fi
+if [ -f "$NEW_ENV" ]; then
+    echo "Both $NEW_ENV and $LEGACY_ENV exist." >&2
+    echo "Resolve manually: merge and delete one." >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$NEW_ENV")"
+mv "$LEGACY_ENV" "$NEW_ENV"
+echo "Migrated: $LEGACY_ENV -> $NEW_ENV"
+`, envFilePath(appName), legacyEnvFilePath(appName)))
 }

--- a/cmd/app/env.go
+++ b/cmd/app/env.go
@@ -108,15 +108,37 @@ var envSetCmd = &cobra.Command{
 	},
 }
 
+// legacyOnlyGuardScript aborts the calling script when only the legacy env
+// file exists. Without this guard, writing to $NEW_ENV would create a second
+// file, and the deploy-time "new wins if present" logic would silently hide
+// any KEY=VALUE previously stored in legacy — unrecoverable without backups.
+func legacyOnlyGuardScript(appName string) string {
+	return fmt.Sprintf(
+		`NEW_ENV=%q
+LEGACY_ENV=%q
+if [ ! -f "$NEW_ENV" ] && [ -f "$LEGACY_ENV" ]; then
+    echo "error: legacy env file $LEGACY_ENV exists but $NEW_ENV does not." >&2
+    echo "Writing here would silently hide legacy values on next deploy." >&2
+    echo "Run 'conoha app env migrate <server>' first, then retry." >&2
+    exit 2
+fi
+`, envFilePath(appName), legacyEnvFilePath(appName))
+}
+
 func generateEnvSetScript(appName string, env map[string]string) []byte {
 	var b strings.Builder
 	b.WriteString("#!/bin/bash\nset -euo pipefail\n")
-	// Writes always go to the new location. Legacy servers get a one-time
-	// migrate path via 'conoha app env migrate' — set intentionally does not
-	// auto-copy legacy content to avoid overwriting it.
+	// Guard against legacy-only state (data-loss prevention). Then write to
+	// the new canonical location only — migrate is the explicit path for
+	// legacy content movement.
+	b.WriteString(legacyOnlyGuardScript(appName))
 	fmt.Fprintf(&b, "mkdir -p '/opt/conoha/%s'\n", appName)
 	fmt.Fprintf(&b, "ENV_FILE=%q\n", envFilePath(appName))
 	b.WriteString("touch \"$ENV_FILE\"\n")
+	// Enforce 0600 on every write; `touch` honors umask (usually 0644) and
+	// `mv` preserves the source mode, neither of which is appropriate for a
+	// file that may contain credentials.
+	b.WriteString("chmod 600 \"$ENV_FILE\"\n")
 
 	keys := make([]string, 0, len(env))
 	for k := range env {
@@ -130,6 +152,7 @@ func generateEnvSetScript(appName string, env map[string]string) []byte {
 		escaped := strings.ReplaceAll(v, "'", "'\\''")
 		fmt.Fprintf(&b, "echo '%s=%s' >> \"$ENV_FILE.tmp\"\n", k, escaped)
 		b.WriteString("mv \"$ENV_FILE.tmp\" \"$ENV_FILE\"\n")
+		b.WriteString("chmod 600 \"$ENV_FILE\"\n")
 	}
 	return []byte(b.String())
 }
@@ -231,6 +254,9 @@ var envUnsetCmd = &cobra.Command{
 func generateEnvUnsetScript(appName string, keys []string) []byte {
 	var b strings.Builder
 	b.WriteString("#!/bin/bash\nset -euo pipefail\n")
+	// Symmetric with set: refuse on legacy-only state so unset can't silently
+	// act on a file that will be hidden at deploy time.
+	b.WriteString(legacyOnlyGuardScript(appName))
 	b.WriteString(effectiveEnvFileScript(appName))
 	b.WriteString("[ -f \"$ENV_FILE\" ] || exit 0\n")
 	b.WriteString("cp \"$ENV_FILE\" \"$ENV_FILE.tmp\"\n")
@@ -239,6 +265,7 @@ func generateEnvUnsetScript(appName string, keys []string) []byte {
 		b.WriteString("mv \"$ENV_FILE.tmp2\" \"$ENV_FILE.tmp\"\n")
 	}
 	b.WriteString("mv \"$ENV_FILE.tmp\" \"$ENV_FILE\"\n")
+	b.WriteString("chmod 600 \"$ENV_FILE\"\n")
 	return []byte(b.String())
 }
 
@@ -291,6 +318,7 @@ fi
 
 mkdir -p "$(dirname "$NEW_ENV")"
 mv "$LEGACY_ENV" "$NEW_ENV"
+chmod 600 "$NEW_ENV"
 echo "Migrated: $LEGACY_ENV -> $NEW_ENV"
 `, envFilePath(appName), legacyEnvFilePath(appName)))
 }

--- a/cmd/app/env_test.go
+++ b/cmd/app/env_test.go
@@ -27,15 +27,26 @@ func TestGenerateEnvSetScript(t *testing.T) {
 		"touch",
 		"DB_HOST=localhost",
 		"DB_PORT=5432",
+		// Data-loss guard must appear; the script must abort on legacy-only.
+		`exit 2`,
+		`'conoha app env migrate`,
+		// Credentials-bearing file: 0600 enforced.
+		`chmod 600 "$ENV_FILE"`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("missing %q in script:\n%s", want, s)
 		}
 	}
-	// Set writes to new path only; legacy path must not appear in a write
-	// context (it still shows up on the read side for backward compat).
-	if strings.Contains(s, legacyEnvFilePath("myapp")) {
-		t.Errorf("set script should not reference the legacy path: %s", s)
+	// Write target must be the new path only. Legacy appears in the guard
+	// as a source-side check, never on the left side of a write-redirect.
+	for _, forbidden := range []string{
+		`> "/opt/conoha/myapp.env.server"`,
+		`>> "/opt/conoha/myapp.env.server"`,
+		`mv "$ENV_FILE.tmp" "/opt/conoha/myapp.env.server"`,
+	} {
+		if strings.Contains(s, forbidden) {
+			t.Errorf("set script must not write to legacy path (%q):\n%s", forbidden, s)
+		}
 	}
 }
 
@@ -48,9 +59,28 @@ func TestGenerateEnvUnsetScript(t *testing.T) {
 		"LEGACY_ENV=\"/opt/conoha/myapp.env.server\"",
 		`grep -v "^DB_HOST="`,
 		`grep -v "^DB_PORT="`,
+		// Data-loss guard symmetric with set.
+		`exit 2`,
+		// Mode enforced after the final mv.
+		`chmod 600 "$ENV_FILE"`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("missing %q in unset script:\n%s", want, s)
+		}
+	}
+}
+
+func TestLegacyOnlyGuardRejects(t *testing.T) {
+	s := legacyOnlyGuardScript("myapp")
+	for _, want := range []string{
+		`NEW_ENV="/opt/conoha/myapp/.env.server"`,
+		`LEGACY_ENV="/opt/conoha/myapp.env.server"`,
+		`if [ ! -f "$NEW_ENV" ] && [ -f "$LEGACY_ENV" ]`,
+		`Writing here would silently hide legacy values`,
+		`exit 2`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in guard script:\n%s", want, s)
 		}
 	}
 }
@@ -89,6 +119,9 @@ func TestGenerateEnvMigrateScript(t *testing.T) {
 		"Nothing to migrate",
 		"Both",
 		`mv "$LEGACY_ENV" "$NEW_ENV"`,
+		// `mv` preserves the source mode; enforce 0600 post-move since the
+		// legacy path may have been 0644 on old servers.
+		`chmod 600 "$NEW_ENV"`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("missing %q in migrate script:\n%s", want, s)

--- a/cmd/app/env_test.go
+++ b/cmd/app/env_test.go
@@ -5,6 +5,15 @@ import (
 	"testing"
 )
 
+func TestEnvFilePaths(t *testing.T) {
+	if got := envFilePath("myapp"); got != "/opt/conoha/myapp/.env.server" {
+		t.Errorf("envFilePath = %q, want /opt/conoha/myapp/.env.server", got)
+	}
+	if got := legacyEnvFilePath("myapp"); got != "/opt/conoha/myapp.env.server" {
+		t.Errorf("legacyEnvFilePath = %q, want /opt/conoha/myapp.env.server", got)
+	}
+}
+
 func TestGenerateEnvSetScript(t *testing.T) {
 	script := generateEnvSetScript("myapp", map[string]string{
 		"DB_HOST": "localhost",
@@ -12,17 +21,21 @@ func TestGenerateEnvSetScript(t *testing.T) {
 	})
 	s := string(script)
 
-	if !strings.Contains(s, `ENV_FILE="/opt/conoha/myapp.env.server"`) {
-		t.Error("missing ENV_FILE path")
+	for _, want := range []string{
+		`"/opt/conoha/myapp/.env.server"`, // new canonical path
+		"mkdir -p '/opt/conoha/myapp'",
+		"touch",
+		"DB_HOST=localhost",
+		"DB_PORT=5432",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in script:\n%s", want, s)
+		}
 	}
-	if !strings.Contains(s, "touch") {
-		t.Error("missing touch command")
-	}
-	if !strings.Contains(s, "DB_HOST=localhost") {
-		t.Error("missing DB_HOST=localhost")
-	}
-	if !strings.Contains(s, "DB_PORT=5432") {
-		t.Error("missing DB_PORT=5432")
+	// Set writes to new path only; legacy path must not appear in a write
+	// context (it still shows up on the read side for backward compat).
+	if strings.Contains(s, legacyEnvFilePath("myapp")) {
+		t.Errorf("set script should not reference the legacy path: %s", s)
 	}
 }
 
@@ -30,44 +43,55 @@ func TestGenerateEnvUnsetScript(t *testing.T) {
 	script := generateEnvUnsetScript("myapp", []string{"DB_HOST", "DB_PORT"})
 	s := string(script)
 
-	if !strings.Contains(s, `ENV_FILE="/opt/conoha/myapp.env.server"`) {
-		t.Error("missing ENV_FILE path")
-	}
-	if !strings.Contains(s, `grep -v "^DB_HOST="`) {
-		t.Error("missing grep for DB_HOST")
-	}
-	if !strings.Contains(s, `grep -v "^DB_PORT="`) {
-		t.Error("missing grep for DB_PORT")
+	for _, want := range []string{
+		"NEW_ENV=\"/opt/conoha/myapp/.env.server\"",
+		"LEGACY_ENV=\"/opt/conoha/myapp.env.server\"",
+		`grep -v "^DB_HOST="`,
+		`grep -v "^DB_PORT="`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in unset script:\n%s", want, s)
+		}
 	}
 }
 
 func TestGenerateEnvGetCommand(t *testing.T) {
 	cmd := generateEnvGetCommand("myapp", "DB_HOST")
-	if !strings.Contains(cmd, `grep "^DB_HOST="`) {
-		t.Error("missing grep for DB_HOST")
-	}
-	if !strings.Contains(cmd, "cut -d= -f2-") {
-		t.Error("missing cut command")
+	for _, want := range []string{
+		`grep "^DB_HOST="`,
+		"cut -d= -f2-",
+		"/opt/conoha/myapp/.env.server",
+		"/opt/conoha/myapp.env.server", // legacy referenced in fallback chain
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("missing %q in get command:\n%s", want, cmd)
+		}
 	}
 }
 
 func TestGenerateEnvListCommand(t *testing.T) {
 	cmd := generateEnvListCommand("myapp")
-	if !strings.Contains(cmd, "/opt/conoha/myapp.env.server") {
-		t.Error("missing env file path")
+	for _, want := range []string{
+		"/opt/conoha/myapp/.env.server",
+		"/opt/conoha/myapp.env.server",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("missing %q in list command:\n%s", want, cmd)
+		}
 	}
 }
 
-func TestProxyEnvWarningMessage(t *testing.T) {
-	msg := proxyEnvWarningMessage()
+func TestGenerateEnvMigrateScript(t *testing.T) {
+	s := string(generateEnvMigrateScript("myapp"))
 	for _, want := range []string{
-		"warning",
-		"app env",
-		"proxy-mode",
-		"#94",
+		`NEW_ENV="/opt/conoha/myapp/.env.server"`,
+		`LEGACY_ENV="/opt/conoha/myapp.env.server"`,
+		"Nothing to migrate",
+		"Both",
+		`mv "$LEGACY_ENV" "$NEW_ENV"`,
 	} {
-		if !strings.Contains(msg, want) {
-			t.Errorf("missing %q in %s", want, msg)
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in migrate script:\n%s", want, s)
 		}
 	}
 }

--- a/cmd/app/init.go
+++ b/cmd/app/init.go
@@ -92,7 +92,26 @@ func runInitProxy(cmd *cobra.Command, serverID string) error {
 	if err := WriteMarker(sshClient, pf.Name, ModeProxy); err != nil {
 		return fmt.Errorf("write mode marker: %w", err)
 	}
+	// Touch an empty .env.server so the compose override's env_file: entry
+	// resolves on first deploy. Subsequent `app env set` grows the file.
+	if err := touchEnvFile(sshClient, pf.Name); err != nil {
+		return fmt.Errorf("touching env stub: %w", err)
+	}
 	fmt.Fprintf(os.Stderr, "Next: run 'conoha app deploy %s' to push your app.\n", serverID)
+	return nil
+}
+
+// touchEnvFile creates an empty /opt/conoha/<app>/.env.server if it doesn't
+// already exist. Idempotent; re-running app init is safe.
+func touchEnvFile(cli *ssh.Client, app string) error {
+	command := fmt.Sprintf("mkdir -p '/opt/conoha/%s' && touch '/opt/conoha/%s/.env.server'", app, app)
+	code, err := internalssh.RunCommand(cli, command, os.Stderr, os.Stderr)
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return fmt.Errorf("touch env: exit %d", code)
+	}
 	return nil
 }
 
@@ -129,6 +148,11 @@ func runInitNoProxy(cmd *cobra.Command, serverID string) error {
 	fmt.Fprintf(os.Stderr, "==> Initializing %q on %s (%s) in no-proxy mode\n", appName, s.Name, ip)
 	if err := WriteMarker(sshClient, appName, ModeNoProxy); err != nil {
 		return err
+	}
+	// Touch an empty .env.server so `app env set` / deploy merges always
+	// have a well-known file to read (even on first deploy).
+	if err := touchEnvFile(sshClient, appName); err != nil {
+		return fmt.Errorf("touching env stub: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "Initialized. Next: run 'conoha app deploy --no-proxy --app-name %s %s'\n", appName, serverID)
 	return nil

--- a/cmd/app/init.go
+++ b/cmd/app/init.go
@@ -102,9 +102,14 @@ func runInitProxy(cmd *cobra.Command, serverID string) error {
 }
 
 // touchEnvFile creates an empty /opt/conoha/<app>/.env.server if it doesn't
-// already exist. Idempotent; re-running app init is safe.
+// already exist and enforces 0600 mode (file may hold credentials; `touch`
+// alone honors umask, typically 0644). Idempotent; re-running app init is
+// safe.
 func touchEnvFile(cli *ssh.Client, app string) error {
-	command := fmt.Sprintf("mkdir -p '/opt/conoha/%s' && touch '/opt/conoha/%s/.env.server'", app, app)
+	command := fmt.Sprintf(
+		"mkdir -p '/opt/conoha/%s' && touch '/opt/conoha/%s/.env.server' && chmod 600 '/opt/conoha/%s/.env.server'",
+		app, app, app,
+	)
 	code, err := internalssh.RunCommand(cli, command, os.Stderr, os.Stderr)
 	if err != nil {
 		return err

--- a/cmd/app/override.go
+++ b/cmd/app/override.go
@@ -5,17 +5,23 @@ import "fmt"
 // composeOverride returns a compose override document (YAML) that:
 //   - pins the web service's container name to <project>-<slot>-<web>
 //   - maps 127.0.0.1:0:<port> so the kernel picks a free host port
+//   - attaches env_file: /opt/conoha/<app>/.env.server so values written by
+//     `conoha app env set` apply at deploy time (spec 2026-04-23-app-env-redesign).
+//     The env file is created as an empty stub by `conoha app init` so compose
+//     never fails with "env_file not found".
 //   - when hasAccessories, joins the <app>-accessories_default network so the
 //     web container can resolve and reach accessory services (db/cache/etc.)
 //
 // It does not touch any other service; accessories keep their compose-declared
-// container_name and ports.
+// container_name, ports, and env config.
 func composeOverride(app, slot, webService string, webPort int, hasAccessories bool) string {
 	base := fmt.Sprintf(`services:
   %[3]s:
     container_name: %[1]s-%[2]s-%[3]s
     ports:
       - "127.0.0.1:0:%[4]d"
+    env_file:
+      - /opt/conoha/%[1]s/.env.server
 `, app, slot, webService, webPort)
 	if !hasAccessories {
 		return base

--- a/cmd/app/override_test.go
+++ b/cmd/app/override_test.go
@@ -13,6 +13,8 @@ func TestComposeOverride_WebPortAndName_NoAccessories(t *testing.T) {
 		`    container_name: myapp-a1b2c3d-web`,
 		`    ports:`,
 		`      - "127.0.0.1:0:8080"`,
+		`    env_file:`,
+		`      - /opt/conoha/myapp/.env.server`,
 	}
 	for _, line := range want {
 		if !strings.Contains(got, line) {


### PR DESCRIPTION
## Summary
Implements the \`app env\` redesign approved in #134. Proxy-mode \`app env set\` now actually takes effect on the next deploy via a compose override \`env_file:\` entry. Storage moves from \`/opt/conoha/<app>.env.server\` to \`/opt/conoha/<app>/.env.server\`; reads remain backward-compatible with a deprecation warning.

## Changes
- \`cmd/app/env.go\`: rewritten. Writes go to the new canonical location only. Reads use a bash \`effectiveEnvFileScript\` that falls back to the legacy path + warns. New \`app env migrate <server>\` subcommand.
- \`cmd/app/init.go\`: touch empty \`.env.server\` at init time so compose \`env_file:\` resolves on first deploy (both modes).
- \`cmd/app/deploy.go\`: \`runNoProxyDeploy\` reads new path, falls back to legacy with warning.
- \`cmd/app/override.go\`: web service \`env_file: - /opt/conoha/<app>/.env.server\` injected for proxy mode.
- \`maybeWarnProxyEnvMode\` / \`proxyEnvWarningMessage\` removed — no longer accurate.
- Tests updated (env_test.go, deploy_test.go, override_test.go) + new TestGenerateEnvMigrateScript, TestEnvFilePaths.

## Migration path for operators
Servers initialized pre-v0.2 will continue to work:
\`\`\`
$ conoha app env list <srv>
warning: reading legacy env file /opt/conoha/myapp.env.server (run 'conoha app env migrate <server>' to move it to /opt/conoha/myapp/.env.server; legacy path will stop being read in v0.3)
FOO=bar

$ conoha app env migrate <srv>
Migrated: /opt/conoha/myapp.env.server -> /opt/conoha/myapp/.env.server
\`\`\`

## Test plan
- [x] \`go test ./...\` passes.
- [x] \`go build ./...\` clean.
- [ ] Manual: proxy-mode \`app env set FOO=bar\` → \`app deploy\` → exec into container → \`echo \$FOO\` shows \`bar\`.
- [ ] Manual: legacy-server flow (move current \`.env.server\` to legacy location, run \`app env list\` to see warning, run migrate, verify new location).

## Follow-ups
- README sections documenting the new location + migrate command (tracked informally; not blocking this PR).
- v0.3.x: remove the legacy fallback (per spec §5.3).