### PR TITLE
refactor(app/deploy): extract DeployOps + orchestration tests (closes #99)

### DIFF
--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -181,14 +182,62 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 	admin := proxypkg.NewClient(&proxypkg.SSHExecutor{Client: sshClient}, proxy.SocketPath(dataDir))
-
-	// Service must exist — init registers it. Missing = user skipped init.
-	if _, err := admin.Get(pf.Name); err != nil {
-		return fmt.Errorf("%w: %v", notInitializedError(pf.Name, serverID, ModeProxy), err)
-	}
+	ops := newSSHDeployOps(sshClient, admin)
 
 	slotOverride, _ := cmd.Flags().GetString("slot")
-	slot := slotOverride
+
+	return runProxyDeployState(proxyDeployParams{
+		ProjectFile:  pf,
+		ComposeFile:  composeFile,
+		ServerID:     serverID,
+		ServerName:   s.Name,
+		ServerIP:     ip,
+		SlotOverride: slotOverride,
+		Archive:      makeArchiveOfCwd,
+	}, ops)
+}
+
+// proxyDeployParams is the input to the runProxyDeployState state machine.
+// Pulled into a struct so tests can populate it without mocking the local
+// filesystem / cobra.Command machinery.
+type proxyDeployParams struct {
+	ProjectFile  *config.ProjectFile
+	ComposeFile  string
+	ServerID     string
+	ServerName   string
+	ServerIP     string
+	SlotOverride string
+	// Archive builds the tar.gz of the deploy payload on demand. The
+	// production code tarballs the cwd; tests pass a pre-made buffer.
+	Archive func() (io.Reader, error)
+}
+
+// makeArchiveOfCwd is the production Archive func: load .dockerignore
+// patterns and tar.gz the current directory.
+func makeArchiveOfCwd() (io.Reader, error) {
+	patterns, err := loadIgnorePatterns(".")
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := createTarGz(".", patterns, &buf); err != nil {
+		return nil, fmt.Errorf("create archive: %w", err)
+	}
+	return &buf, nil
+}
+
+// runProxyDeployState drives the blue/green deploy state machine without
+// any direct SSH or filesystem dependencies. Every side effect flows
+// through ops, which tests substitute with a recording fake.
+func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
+	pf := p.ProjectFile
+
+	// Service must exist — init registers it. Missing = user skipped init.
+	if _, err := ops.Proxy().Get(pf.Name); err != nil {
+		return fmt.Errorf("%w: %v", notInitializedError(pf.Name, p.ServerID, ModeProxy), err)
+	}
+
+	slot := p.SlotOverride
 	if slot == "" {
 		base, err := determineSlotID(".", IsGitRepo("."))
 		if err != nil {
@@ -196,7 +245,7 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 		}
 		slot = suffixIfTaken(base, func(candidate string) bool {
 			probe := buildComposeProjectExists(slotProjectName(pf.Name, candidate))
-			code, _ := internalssh.RunCommand(sshClient, probe, os.Stderr, os.Stderr)
+			code, _, _ := ops.Run(probe, nil)
 			return code == 0
 		})
 	}
@@ -204,20 +253,16 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "==> Deploying %q to %s (%s)\n", pf.Name, s.Name, ip)
+	fmt.Fprintf(os.Stderr, "==> Deploying %q to %s (%s)\n", pf.Name, p.ServerName, p.ServerIP)
 	fmt.Fprintf(os.Stderr, "==> Slot: %s (compose project: %s)\n", slot, slotProjectName(pf.Name, slot))
 
 	// Upload archive to slot work dir.
-	patterns, err := loadIgnorePatterns(".")
+	archive, err := p.Archive()
 	if err != nil {
 		return err
 	}
-	var buf bytes.Buffer
-	if err := createTarGz(".", patterns, &buf); err != nil {
-		return fmt.Errorf("create archive: %w", err)
-	}
 	slotWork := fmt.Sprintf("/opt/conoha/%s/%s", pf.Name, slot)
-	if err := runRemote(sshClient, buildSlotUploadCmd(slotWork, ""), &buf); err != nil {
+	if err := runRemoteOps(ops, buildSlotUploadCmd(slotWork, ""), archive); err != nil {
 		return fmt.Errorf("upload: %w", err)
 	}
 
@@ -225,17 +270,17 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 	overrideContent := composeOverride(pf.Name, slot, pf.Web.Service, pf.Web.Port, len(pf.Accessories) > 0)
 	overridePath := "conoha-override.yml"
 	writeOverride := fmt.Sprintf("cat > '%s/%s' <<'EOF'\n%sEOF", slotWork, overridePath, overrideContent)
-	if err := runRemote(sshClient, writeOverride, nil); err != nil {
+	if err := runRemoteOps(ops, writeOverride, nil); err != nil {
 		return fmt.Errorf("write override: %w", err)
 	}
 
 	// First-run: bring up accessories (idempotent via existence probe).
 	if len(pf.Accessories) > 0 {
 		check := buildAccessoryExists(accessoryProjectName(pf.Name))
-		code, _ := internalssh.RunCommand(sshClient, check, os.Stderr, os.Stderr)
+		code, _, _ := ops.Run(check, nil)
 		if code != 0 {
 			fmt.Fprintf(os.Stderr, "==> Starting accessories: %v\n", pf.Accessories)
-			if err := runRemote(sshClient, buildAccessoryUp(slotWork, accessoryProjectName(pf.Name), composeFile, pf.Accessories), nil); err != nil {
+			if err := runRemoteOps(ops, buildAccessoryUp(slotWork, accessoryProjectName(pf.Name), p.ComposeFile, pf.Accessories), nil); err != nil {
 				return fmt.Errorf("accessory up: %w", err)
 			}
 		}
@@ -243,20 +288,20 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 
 	// Start the new slot's web service.
 	fmt.Fprintf(os.Stderr, "==> Building and starting %s in new slot\n", pf.Web.Service)
-	if err := runRemote(sshClient, buildSlotComposeUp(slotWork, slotProjectName(pf.Name, slot), composeFile, overridePath, pf.Web.Service), nil); err != nil {
+	if err := runRemoteOps(ops, buildSlotComposeUp(slotWork, slotProjectName(pf.Name, slot), p.ComposeFile, overridePath, pf.Web.Service), nil); err != nil {
 		return fmt.Errorf("compose up (slot): %w", err)
 	}
 
 	// Discover kernel-picked host port.
 	containerName := fmt.Sprintf("%s-%s-%s", pf.Name, slot, pf.Web.Service)
-	var portOut bytes.Buffer
-	if _, err := internalssh.RunCommand(sshClient, buildDockerPortCmd(containerName, pf.Web.Port), &portOut, os.Stderr); err != nil {
-		tearDownSlot(sshClient, pf.Name, slot)
-		return fmt.Errorf("docker port: %w", err)
+	_, portOut, portErr := ops.Run(buildDockerPortCmd(containerName, pf.Web.Port), nil)
+	if portErr != nil {
+		tearDownSlotOps(ops, pf.Name, slot)
+		return fmt.Errorf("docker port: %w", portErr)
 	}
-	hostPort, err := extractHostPort(portOut.String())
+	hostPort, err := extractHostPort(string(portOut))
 	if err != nil {
-		tearDownSlot(sshClient, pf.Name, slot)
+		tearDownSlotOps(ops, pf.Name, slot)
 		return err
 	}
 	targetURL := fmt.Sprintf("http://127.0.0.1:%d", hostPort)
@@ -268,17 +313,16 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 	}
 
 	// Call proxy /deploy. On 424 the proxy did not mutate state — tear down new slot.
-	updated, err := admin.Deploy(pf.Name, proxypkg.DeployRequest{TargetURL: targetURL, DrainMs: drainMs})
+	updated, err := ops.Proxy().Deploy(pf.Name, proxypkg.DeployRequest{TargetURL: targetURL, DrainMs: drainMs})
 	if err != nil {
-		tearDownSlot(sshClient, pf.Name, slot)
+		tearDownSlotOps(ops, pf.Name, slot)
 		return err
 	}
 
 	// Read old slot pointer (empty on first deploy), then update to current.
 	ptrPath := fmt.Sprintf("/opt/conoha/%s/CURRENT_SLOT", pf.Name)
-	var ptrBuf bytes.Buffer
-	_, _ = internalssh.RunCommand(sshClient, fmt.Sprintf("cat '%s' 2>/dev/null || true", ptrPath), &ptrBuf, os.Stderr)
-	oldSlot := strings.TrimSpace(ptrBuf.String())
+	_, ptrBytes, _ := ops.Run(fmt.Sprintf("cat '%s' 2>/dev/null || true", ptrPath), nil)
+	oldSlot := strings.TrimSpace(string(ptrBytes))
 	if oldSlot != "" {
 		if err := ValidateSlotID(oldSlot); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: CURRENT_SLOT contained %q, ignoring: %v\n", oldSlot, err)
@@ -286,14 +330,14 @@ func runProxyDeploy(cmd *cobra.Command, serverID string) error {
 		}
 	}
 
-	if err := runRemote(sshClient, fmt.Sprintf("printf %%s '%s' > '%s'", slot, ptrPath), nil); err != nil {
+	if err := runRemoteOps(ops, fmt.Sprintf("printf %%s '%s' > '%s'", slot, ptrPath), nil); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: update CURRENT_SLOT pointer (MANUAL: write %q to %s): %v\n", slot, ptrPath, err)
 	}
 
 	if oldSlot != "" && oldSlot != slot {
 		oldWork := fmt.Sprintf("/opt/conoha/%s/%s", pf.Name, oldSlot)
 		schedule := buildScheduleDrainCmd(oldWork, slotProjectName(pf.Name, oldSlot), pf.Name, oldSlot, drainMs)
-		if err := runRemote(sshClient, schedule, nil); err != nil {
+		if err := runRemoteOps(ops, schedule, nil); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: schedule drain teardown: %v\n", err)
 		} else {
 			fmt.Fprintf(os.Stderr, "==> Scheduled teardown of old slot %q in %dms\n", oldSlot, drainMs)

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -370,13 +370,3 @@ func runRemote(cli *ssh.Client, command string, stdinData *bytes.Buffer) error {
 	}
 	return nil
 }
-
-// tearDownSlot brings down a slot's compose project and removes its work dir.
-// Best-effort; the caller already has a more interesting error to return.
-func tearDownSlot(cli *ssh.Client, app, slot string) {
-	work := fmt.Sprintf("/opt/conoha/%s/%s", app, slot)
-	cmd := fmt.Sprintf(
-		"docker compose -p %s -f '%s/conoha-override.yml' down 2>/dev/null || true; rm -rf '%s' || true",
-		slotProjectName(app, slot), work, work)
-	_, _ = internalssh.RunCommand(cli, cmd, os.Stderr, os.Stderr)
-}

--- a/cmd/app/deploy_ops.go
+++ b/cmd/app/deploy_ops.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+
+	proxypkg "github.com/crowdy/conoha-cli/internal/proxy"
+	internalssh "github.com/crowdy/conoha-cli/internal/ssh"
+)
+
+// DeployOps abstracts every side-effecting dependency that runProxyDeploy
+// needs: SSH command execution (bytes in, bytes out) and proxy Admin API
+// calls. Separates the state machine from the transport so it can be unit-
+// tested with a fake.
+//
+// Semantics:
+//   - Run: execute cmd on the remote. Returns exit code + stdout bytes.
+//     stderr is forwarded to the local process stderr (so operators see
+//     `docker compose` output in real time). A non-nil Go error is a
+//     transport-level failure (SSH auth, channel close, etc.), distinct
+//     from a non-zero exit code.
+//   - RunStream: like Run but streams stdout to the caller's writer
+//     without buffering. Used for upload paths where stdout isn't inspected.
+//   - Proxy: the Admin API client. Injected rather than constructed so
+//     tests can swap it without setting up a fake Executor.
+type DeployOps interface {
+	Run(cmd string, stdin io.Reader) (exitCode int, stdout []byte, err error)
+	RunStream(cmd string, stdin io.Reader, stdout io.Writer) (exitCode int, err error)
+	Proxy() DeployProxyAPI
+}
+
+// DeployProxyAPI is the subset of proxypkg.Client that runProxyDeploy uses.
+// Kept tight so fakes don't drift.
+type DeployProxyAPI interface {
+	Get(name string) (*proxypkg.Service, error)
+	Deploy(name string, req proxypkg.DeployRequest) (*proxypkg.Service, error)
+}
+
+// sshDeployOps is the production DeployOps: wraps a live *ssh.Client +
+// proxypkg.Client.
+type sshDeployOps struct {
+	client *ssh.Client
+	admin  *proxypkg.Client
+}
+
+func newSSHDeployOps(client *ssh.Client, admin *proxypkg.Client) *sshDeployOps {
+	return &sshDeployOps{client: client, admin: admin}
+}
+
+func (o *sshDeployOps) Run(cmd string, stdin io.Reader) (int, []byte, error) {
+	var buf bytes.Buffer
+	var code int
+	var err error
+	if stdin != nil {
+		code, err = internalssh.RunWithStdin(o.client, cmd, stdin, &buf, os.Stderr)
+	} else {
+		code, err = internalssh.RunCommand(o.client, cmd, &buf, os.Stderr)
+	}
+	return code, buf.Bytes(), err
+}
+
+func (o *sshDeployOps) RunStream(cmd string, stdin io.Reader, stdout io.Writer) (int, error) {
+	if stdin != nil {
+		return internalssh.RunWithStdin(o.client, cmd, stdin, stdout, os.Stderr)
+	}
+	return internalssh.RunCommand(o.client, cmd, stdout, os.Stderr)
+}
+
+func (o *sshDeployOps) Proxy() DeployProxyAPI { return o.admin }
+
+// runRemoteOps is the ops-side analog of runRemote: returns a typed error
+// when the remote exit is non-zero, otherwise the transport error. Streams
+// stdout to the local process.
+func runRemoteOps(ops DeployOps, command string, stdin io.Reader) error {
+	code, err := ops.RunStream(command, stdin, os.Stdout)
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return fmt.Errorf("remote exit %d", code)
+	}
+	return nil
+}
+
+// tearDownSlotOps is the ops-side analog of tearDownSlot: best-effort,
+// discards the exit code + output.
+func tearDownSlotOps(ops DeployOps, app, slot string) {
+	work := fmt.Sprintf("/opt/conoha/%s/%s", app, slot)
+	cmd := fmt.Sprintf(
+		"docker compose -p %s -f '%s/conoha-override.yml' down 2>/dev/null || true; rm -rf '%s' || true",
+		slotProjectName(app, slot), work, work)
+	_, _, _ = ops.Run(cmd, nil)
+}

--- a/cmd/app/deploy_ops_test.go
+++ b/cmd/app/deploy_ops_test.go
@@ -1,0 +1,360 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/crowdy/conoha-cli/internal/config"
+	proxypkg "github.com/crowdy/conoha-cli/internal/proxy"
+)
+
+// fakeOps is a DeployOps fake that records every command it receives.
+// Commands are matched against a RunOverrides table so individual tests can
+// inject specific responses (stdout bytes, exit codes, errors) without
+// having to stub the full sequence.
+type fakeOps struct {
+	Commands  []fakeOpsCall
+	Overrides map[string]fakeOpsResponse // substring → response
+	Default   fakeOpsResponse            // applied when no override matches
+	Proxy_    *fakeProxyAPI
+}
+
+type fakeOpsCall struct {
+	Cmd    string
+	Stdin  []byte
+	Stream bool // was this a RunStream call?
+}
+
+type fakeOpsResponse struct {
+	ExitCode int
+	Stdout   string
+	Err      error
+}
+
+func (f *fakeOps) resolve(cmd string) fakeOpsResponse {
+	for sub, r := range f.Overrides {
+		if strings.Contains(cmd, sub) {
+			return r
+		}
+	}
+	return f.Default
+}
+
+func (f *fakeOps) record(cmd string, stdin io.Reader, stream bool) []byte {
+	call := fakeOpsCall{Cmd: cmd, Stream: stream}
+	if stdin != nil {
+		call.Stdin, _ = io.ReadAll(stdin)
+	}
+	f.Commands = append(f.Commands, call)
+	return call.Stdin
+}
+
+func (f *fakeOps) Run(cmd string, stdin io.Reader) (int, []byte, error) {
+	f.record(cmd, stdin, false)
+	r := f.resolve(cmd)
+	return r.ExitCode, []byte(r.Stdout), r.Err
+}
+
+func (f *fakeOps) RunStream(cmd string, stdin io.Reader, stdout io.Writer) (int, error) {
+	f.record(cmd, stdin, true)
+	r := f.resolve(cmd)
+	if r.Stdout != "" {
+		_, _ = io.WriteString(stdout, r.Stdout)
+	}
+	return r.ExitCode, r.Err
+}
+
+func (f *fakeOps) Proxy() DeployProxyAPI {
+	if f.Proxy_ == nil {
+		f.Proxy_ = &fakeProxyAPI{}
+	}
+	return f.Proxy_
+}
+
+// fakeProxyAPI is a minimal DeployProxyAPI fake.
+type fakeProxyAPI struct {
+	GetCalls    int
+	DeployCalls []proxypkg.DeployRequest
+	GetReturn   *proxypkg.Service
+	GetErr      error
+	DeployReturn *proxypkg.Service
+	DeployErr    error
+}
+
+func (f *fakeProxyAPI) Get(name string) (*proxypkg.Service, error) {
+	f.GetCalls++
+	if f.GetErr != nil {
+		return nil, f.GetErr
+	}
+	if f.GetReturn != nil {
+		return f.GetReturn, nil
+	}
+	return &proxypkg.Service{Name: name}, nil
+}
+
+func (f *fakeProxyAPI) Deploy(name string, req proxypkg.DeployRequest) (*proxypkg.Service, error) {
+	f.DeployCalls = append(f.DeployCalls, req)
+	if f.DeployErr != nil {
+		return nil, f.DeployErr
+	}
+	if f.DeployReturn != nil {
+		return f.DeployReturn, nil
+	}
+	return &proxypkg.Service{
+		Name:         name,
+		Phase:        proxypkg.PhaseLive,
+		ActiveTarget: &proxypkg.Target{URL: req.TargetURL},
+	}, nil
+}
+
+var _ DeployOps = (*fakeOps)(nil)
+
+// baseParams constructs a minimal proxyDeployParams suitable for most tests.
+// Tests override specific fields.
+func baseParams() proxyDeployParams {
+	return proxyDeployParams{
+		ProjectFile: &config.ProjectFile{
+			Name:  "myapp",
+			Hosts: []string{"app.example.com"},
+			Web: config.WebSpec{
+				Service: "web",
+				Port:    8080,
+			},
+			Deploy: &config.DeploySpec{DrainMs: 2000},
+		},
+		ComposeFile:  "docker-compose.yml",
+		ServerID:     "srv-1",
+		ServerName:   "test-vps",
+		ServerIP:     "203.0.113.9",
+		SlotOverride: "abc1234",
+		Archive: func() (io.Reader, error) {
+			return bytes.NewReader([]byte("fake-tar-payload")), nil
+		},
+	}
+}
+
+// successOps returns a fakeOps pre-configured so the happy path flows
+// end-to-end. Port discovery emits the expected `docker port` format.
+func successOps() *fakeOps {
+	return &fakeOps{
+		Default: fakeOpsResponse{ExitCode: 0},
+		Overrides: map[string]fakeOpsResponse{
+			// `docker port` output is "addr:port" per line, not the "->" form
+			// emitted by `docker ps`. See extractHostPort / parseColonPort.
+			"docker port": {ExitCode: 0, Stdout: "127.0.0.1:34567\n"},
+			// accessory probe: 0 = exists (skip up). Happy path has no accessories
+			// so this isn't hit, but defensive.
+			"docker inspect": {ExitCode: 0},
+			// CURRENT_SLOT read (cat form only — the write uses printf).
+			"cat '/opt/conoha/myapp/CURRENT_SLOT'": {ExitCode: 0, Stdout: ""},
+		},
+	}
+}
+
+func TestRunProxyDeployState_HappyPath_FirstDeploy(t *testing.T) {
+	ops := successOps()
+	if err := runProxyDeployState(baseParams(), ops); err != nil {
+		t.Fatalf("happy path failed: %v", err)
+	}
+	if ops.Proxy_.GetCalls != 1 {
+		t.Errorf("expected 1 admin.Get call, got %d", ops.Proxy_.GetCalls)
+	}
+	if len(ops.Proxy_.DeployCalls) != 1 {
+		t.Fatalf("expected 1 admin.Deploy call, got %d", len(ops.Proxy_.DeployCalls))
+	}
+	if got := ops.Proxy_.DeployCalls[0].TargetURL; got != "http://127.0.0.1:34567" {
+		t.Errorf("TargetURL = %q, want http://127.0.0.1:34567", got)
+	}
+	if got := ops.Proxy_.DeployCalls[0].DrainMs; got != 2000 {
+		t.Errorf("DrainMs = %d, want 2000 (from pf.Deploy override)", got)
+	}
+
+	// Expected command ordering:
+	//   1. upload (RunStream with stdin)
+	//   2. write compose override
+	//   3. compose up slot
+	//   4. docker port
+	//   5. cat CURRENT_SLOT
+	//   6. printf slot > CURRENT_SLOT
+	// Teardown must NOT appear.
+	mustOrdered(t, ops.Commands,
+		"tar xzf",
+		"conoha-override.yml",
+		"docker compose -p myapp-abc1234",
+		"docker port",
+		"CURRENT_SLOT",
+		"printf %s 'abc1234'",
+	)
+	mustAbsent(t, ops.Commands, "down 2>/dev/null")
+}
+
+func TestRunProxyDeployState_ServiceNotInitialized(t *testing.T) {
+	ops := successOps()
+	ops.Proxy_ = &fakeProxyAPI{GetErr: errors.New("404 not_found")}
+	err := runProxyDeployState(baseParams(), ops)
+	if err == nil {
+		t.Fatal("expected error when admin.Get fails")
+	}
+	if !strings.Contains(err.Error(), "not initialized") {
+		t.Errorf("want 'not initialized' hint, got: %v", err)
+	}
+	// No side-effecting commands should have run.
+	for _, c := range ops.Commands {
+		if strings.Contains(c.Cmd, "tar xzf") || strings.Contains(c.Cmd, "compose up") {
+			t.Errorf("unexpected command executed after init check failed: %q", c.Cmd)
+		}
+	}
+}
+
+func TestRunProxyDeployState_PortDiscoveryFails_TearsDown(t *testing.T) {
+	ops := successOps()
+	ops.Overrides["docker port"] = fakeOpsResponse{Err: errors.New("ssh channel closed")}
+	err := runProxyDeployState(baseParams(), ops)
+	if err == nil {
+		t.Fatal("expected error from docker port failure")
+	}
+	if !strings.Contains(err.Error(), "docker port") {
+		t.Errorf("want 'docker port' context in error, got: %v", err)
+	}
+	// Teardown must be called.
+	mustPresent(t, ops.Commands, "down 2>/dev/null")
+	mustPresent(t, ops.Commands, "rm -rf '/opt/conoha/myapp/abc1234'")
+	// admin.Deploy must NOT have been called.
+	if len(ops.Proxy_.DeployCalls) != 0 {
+		t.Errorf("admin.Deploy should not be called after port discovery failure, got %d calls", len(ops.Proxy_.DeployCalls))
+	}
+}
+
+func TestRunProxyDeployState_PortParseFails_TearsDown(t *testing.T) {
+	ops := successOps()
+	// docker port returns garbage — extractHostPort should fail.
+	ops.Overrides["docker port"] = fakeOpsResponse{ExitCode: 0, Stdout: "not a port mapping\n"}
+	err := runProxyDeployState(baseParams(), ops)
+	if err == nil {
+		t.Fatal("expected error from unparseable port output")
+	}
+	mustPresent(t, ops.Commands, "down 2>/dev/null")
+}
+
+func TestRunProxyDeployState_ProxyDeployFails_TearsDown(t *testing.T) {
+	ops := successOps()
+	ops.Proxy_ = &fakeProxyAPI{
+		DeployErr: &proxypkg.ProbeFailedError{Message: "upstream /up returned 500"},
+	}
+	err := runProxyDeployState(baseParams(), ops)
+	if err == nil {
+		t.Fatal("expected error from admin.Deploy failure")
+	}
+	var pe *proxypkg.ProbeFailedError
+	if !errors.As(err, &pe) {
+		t.Errorf("expected ProbeFailedError to propagate, got %T: %v", err, err)
+	}
+	// Teardown MUST run on 424 — the proxy didn't mutate state.
+	mustPresent(t, ops.Commands, "down 2>/dev/null")
+}
+
+func TestRunProxyDeployState_OldSlotDrainScheduled(t *testing.T) {
+	ops := successOps()
+	ops.Overrides["cat '/opt/conoha/myapp/CURRENT_SLOT'"] = fakeOpsResponse{ExitCode: 0, Stdout: "prev5678\n"}
+	if err := runProxyDeployState(baseParams(), ops); err != nil {
+		t.Fatalf("deploy failed: %v", err)
+	}
+	// Should schedule drain teardown for "prev5678", referencing the drain ms.
+	var scheduled string
+	for _, c := range ops.Commands {
+		if strings.Contains(c.Cmd, "schedule") || strings.Contains(c.Cmd, "sleep 2") {
+			scheduled = c.Cmd
+		}
+	}
+	// Accept either phrasing — buildScheduleDrainCmd's exact shape is a
+	// separate concern; the contract under test is "something referencing
+	// the old slot gets run".
+	if !strings.Contains(strings.Join(commandTexts(ops.Commands), "\n"), "prev5678") {
+		t.Errorf("expected old slot 'prev5678' to be referenced in scheduled teardown. Commands:\n%s", strings.Join(commandTexts(ops.Commands), "\n"))
+	}
+	_ = scheduled
+}
+
+func TestRunProxyDeployState_InvalidCurrentSlot_IgnoresWithWarning(t *testing.T) {
+	ops := successOps()
+	ops.Overrides["cat '/opt/conoha/myapp/CURRENT_SLOT'"] = fakeOpsResponse{ExitCode: 0, Stdout: "CapitalsNotAllowed!"}
+	err := runProxyDeployState(baseParams(), ops)
+	if err != nil {
+		t.Fatalf("deploy should succeed despite invalid CURRENT_SLOT: %v", err)
+	}
+	// No schedule drain teardown should happen for an invalid slot name.
+	for _, c := range ops.Commands {
+		if strings.Contains(c.Cmd, "CapitalsNotAllowed") {
+			t.Errorf("invalid slot name leaked into a follow-up command: %q", c.Cmd)
+		}
+	}
+}
+
+// --- command-sequence helpers ---
+
+func commandTexts(cs []fakeOpsCall) []string {
+	out := make([]string, len(cs))
+	for i, c := range cs {
+		out[i] = c.Cmd
+	}
+	return out
+}
+
+// mustOrdered checks that each substring appears in the command list in the
+// given order (not necessarily contiguously).
+func mustOrdered(t *testing.T, cs []fakeOpsCall, subs ...string) {
+	t.Helper()
+	cmds := commandTexts(cs)
+	pos := 0
+	for _, want := range subs {
+		found := -1
+		for i := pos; i < len(cmds); i++ {
+			if strings.Contains(cmds[i], want) {
+				found = i
+				break
+			}
+		}
+		if found == -1 {
+			t.Errorf("missing (in order) %q after position %d. Commands:\n  %s", want, pos, strings.Join(cmds, "\n  "))
+			return
+		}
+		pos = found + 1
+	}
+}
+
+func mustPresent(t *testing.T, cs []fakeOpsCall, sub string) {
+	t.Helper()
+	for _, c := range cs {
+		if strings.Contains(c.Cmd, sub) {
+			return
+		}
+	}
+	t.Errorf("expected a command containing %q, got:\n  %s", sub, strings.Join(commandTexts(cs), "\n  "))
+}
+
+func mustAbsent(t *testing.T, cs []fakeOpsCall, sub string) {
+	t.Helper()
+	for _, c := range cs {
+		if strings.Contains(c.Cmd, sub) {
+			t.Errorf("command %q should not be present. Actual: %q", sub, c.Cmd)
+			return
+		}
+	}
+}
+
+// Sanity: make sure our fake doesn't drift away from the real proxypkg.Client
+// surface. This is a nil assertion — the real thing implements DeployProxyAPI.
+func TestDeployProxyAPI_MatchesProxyClient(t *testing.T) {
+	// If proxypkg.Client stops implementing DeployProxyAPI (e.g. by removing
+	// Deploy or Get), this line fails to compile in the test binary.
+	var _ DeployProxyAPI = (*proxypkg.Client)(nil)
+
+	// And vice-versa: keep our fake honest.
+	var _ DeployProxyAPI = (*fakeProxyAPI)(nil)
+
+	_ = fmt.Sprintf
+}

--- a/cmd/app/deploy_ops_test.go
+++ b/cmd/app/deploy_ops_test.go
@@ -3,13 +3,21 @@ package app
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/crowdy/conoha-cli/internal/config"
 	proxypkg "github.com/crowdy/conoha-cli/internal/proxy"
+)
+
+// Compile-time assertions: the real proxy client and our fake must both
+// satisfy DeployProxyAPI. If either drifts (e.g. Get/Deploy renamed), the
+// test binary will fail to build.
+var (
+	_ DeployOps      = (*fakeOps)(nil)
+	_ DeployProxyAPI = (*proxypkg.Client)(nil)
+	_ DeployProxyAPI = (*fakeProxyAPI)(nil)
 )
 
 // fakeOps is a DeployOps fake that records every command it receives.
@@ -77,10 +85,10 @@ func (f *fakeOps) Proxy() DeployProxyAPI {
 
 // fakeProxyAPI is a minimal DeployProxyAPI fake.
 type fakeProxyAPI struct {
-	GetCalls    int
-	DeployCalls []proxypkg.DeployRequest
-	GetReturn   *proxypkg.Service
-	GetErr      error
+	GetCalls     int
+	DeployCalls  []proxypkg.DeployRequest
+	GetReturn    *proxypkg.Service
+	GetErr       error
 	DeployReturn *proxypkg.Service
 	DeployErr    error
 }
@@ -110,8 +118,6 @@ func (f *fakeProxyAPI) Deploy(name string, req proxypkg.DeployRequest) (*proxypk
 		ActiveTarget: &proxypkg.Target{URL: req.TargetURL},
 	}, nil
 }
-
-var _ DeployOps = (*fakeOps)(nil)
 
 // baseParams constructs a minimal proxyDeployParams suitable for most tests.
 // Tests override specific fields.
@@ -263,20 +269,19 @@ func TestRunProxyDeployState_OldSlotDrainScheduled(t *testing.T) {
 	if err := runProxyDeployState(baseParams(), ops); err != nil {
 		t.Fatalf("deploy failed: %v", err)
 	}
-	// Should schedule drain teardown for "prev5678", referencing the drain ms.
-	var scheduled string
+	// The old slot's compose project must be the target of the drain
+	// teardown — buildScheduleDrainCmd embeds the slot name in the project
+	// (myapp-prev5678) and in the work dir (/opt/conoha/myapp/prev5678).
+	mustPresent(t, ops.Commands, "myapp-prev5678")
+	mustPresent(t, ops.Commands, "/opt/conoha/myapp/prev5678")
+	// The NEW slot must NOT be torn down on the success path — a regression
+	// that inverted old/new would still leak the app live but kill it mid-
+	// drain. Guard that explicitly.
 	for _, c := range ops.Commands {
-		if strings.Contains(c.Cmd, "schedule") || strings.Contains(c.Cmd, "sleep 2") {
-			scheduled = c.Cmd
+		if strings.Contains(c.Cmd, "myapp-abc1234") && strings.Contains(c.Cmd, " down ") {
+			t.Errorf("new slot abc1234 was torn down on success path: %q", c.Cmd)
 		}
 	}
-	// Accept either phrasing — buildScheduleDrainCmd's exact shape is a
-	// separate concern; the contract under test is "something referencing
-	// the old slot gets run".
-	if !strings.Contains(strings.Join(commandTexts(ops.Commands), "\n"), "prev5678") {
-		t.Errorf("expected old slot 'prev5678' to be referenced in scheduled teardown. Commands:\n%s", strings.Join(commandTexts(ops.Commands), "\n"))
-	}
-	_ = scheduled
 }
 
 func TestRunProxyDeployState_InvalidCurrentSlot_IgnoresWithWarning(t *testing.T) {
@@ -344,17 +349,4 @@ func mustAbsent(t *testing.T, cs []fakeOpsCall, sub string) {
 			return
 		}
 	}
-}
-
-// Sanity: make sure our fake doesn't drift away from the real proxypkg.Client
-// surface. This is a nil assertion — the real thing implements DeployProxyAPI.
-func TestDeployProxyAPI_MatchesProxyClient(t *testing.T) {
-	// If proxypkg.Client stops implementing DeployProxyAPI (e.g. by removing
-	// Deploy or Get), this line fails to compile in the test binary.
-	var _ DeployProxyAPI = (*proxypkg.Client)(nil)
-
-	// And vice-versa: keep our fake honest.
-	var _ DeployProxyAPI = (*fakeProxyAPI)(nil)
-
-	_ = fmt.Sprintf
 }


### PR DESCRIPTION
## Summary
Completes the #99 test suite by splitting \`runProxyDeploy\` into an SSH transport layer (\`sshDeployOps\`) and a pure state machine (\`runProxyDeployState\`). The 190-line pipeline that had zero tests now has seven orchestration tests covering every teardown branch.

## API shape
\`\`\`go
// cmd/app/deploy_ops.go
type DeployOps interface {
    Run(cmd string, stdin io.Reader) (exitCode int, stdout []byte, err error)
    RunStream(cmd string, stdin io.Reader, stdout io.Writer) (int, error)
    Proxy() DeployProxyAPI
}
type DeployProxyAPI interface {
    Get(name string) (*proxypkg.Service, error)
    Deploy(name string, req proxypkg.DeployRequest) (*proxypkg.Service, error)
}
\`\`\`

Public \`runProxyDeploy\` signature unchanged — the RunE func, \`app reset\`'s Phase 3, and \`runDeployDispatch\` all keep working.

## Tests added
| Test | What it pins down |
|---|---|
| HappyPath_FirstDeploy | Command ordering (upload → override → compose up → docker port → CURRENT_SLOT), TargetURL + DrainMs flow into admin.Deploy, no teardown |
| ServiceNotInitialized | admin.Get 404 → typed not-initialized error, zero side effects |
| PortDiscoveryFails_TearsDown | Run error on \`docker port\` → teardown + no admin.Deploy call |
| PortParseFails_TearsDown | Unparseable \`docker port\` stdout → teardown |
| ProxyDeployFails_TearsDown | 424 from admin.Deploy → teardown + ProbeFailedError propagates |
| OldSlotDrainScheduled | CURRENT_SLOT=prev5678 → scheduled teardown references that slot |
| InvalidCurrentSlot_IgnoresWithWarning | Corrupted marker → deploy succeeds, name never leaks into later commands |

## Why this + #141 together
The #141 E2E spec tests the real wire contract against a live proxy container. These orchestration tests cover the state-machine logic. Cheaper to catch "forgot to call teardown on 424" here; cheaper to catch "serialization field renamed" there.

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` full suite passes; \`-v\` inspected for TestRunProxyDeployState_*.
- [x] Build tags unchanged — new tests run under the default \`go test ./...\`.

## Closes
#99 (complete: items 1-5 covered; #140 closed 3-5 partial, this PR closes 1 via the Executor refactor).