### PR TITLE
ci(e2e): promote to required + add release-checklist.md (closes #96)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,15 @@ jobs:
           go-version: '1.26'
       - run: go build -o /dev/null ./...
 
-  # E2E Phase 1 (spec 2026-04-23-e2e-tests-design.md §8). Advisory until
-  # the DinD harness is proven stable across the 12-scenario set; promote
-  # to required in Phase 4.
+  # E2E DinD harness (spec 2026-04-23-e2e-tests-design.md §8).
+  # Gating on this job: the 14 scenarios in tests/e2e/run.sh cover the
+  # CLI ↔ conoha-proxy contract (boot, init, blue/green deploy + swap,
+  # rollback in/out of drain window, list, env set/migrate legacy path,
+  # destroy, proxy remove). Expected runtime is ~60-90s on ubuntu-latest.
+  # TLS/ACME and real-VPS bugs are out of scope — see docs/release-checklist.md
+  # for the manual smoke covering those.
   e2e:
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,71 @@
+# Release checklist
+
+Hand-run smoke before tagging `v0.2.0` (and every subsequent RC unless the
+section is explicitly waived). The CI `e2e` job (spec
+[`2026-04-23-e2e-tests-design.md`](superpowers/specs/2026-04-23-e2e-tests-design.md))
+gates the CLI ↔ proxy contract in DinD; this checklist covers the bug
+classes DinD cannot reproduce — documented in §7.1 of that spec.
+
+## Prerequisites
+
+- `gh auth status` succeeds (release is published via GitHub).
+- A clean ConoHa account usable for the release: tenant ID + API user + key pair.
+- A test domain you control with DNS write access (`conoha dns record add`).
+- Local `conoha` built from the RC commit: `go build -o bin/conoha ./`.
+
+## 1. Fresh-VPS smoke (spec §7 golden path)
+
+Run on the RC commit, from a workstation with the built binary.
+
+1. **Create a VPS.** `bin/conoha server create --flavor <smallest> --image vmi-docker-29.2-ubuntu-24.04-amd64 --name rc-smoke-$(date +%s)`
+   Record the server name.
+2. **Point DNS.** `bin/conoha dns record add <zone> <host> A <vps-ip>` and
+   wait until `dig +short <host>.<zone>` returns the IP (can take 1-5 min).
+3. **Boot the proxy.** `bin/conoha proxy boot --acme-email you@example.com <server>`
+   → confirm stdout reports `proxy ready` and `/readyz` returns 200 over SSH.
+4. **Init + deploy a fixture app** (reuse `tests/e2e/fixtures/` or a real
+   project with a real `Host:`). `bin/conoha app init <server>` then
+   `bin/conoha app deploy <server>`.
+5. **Hit the site over HTTPS in a browser.** Expect HTTP 200 and a valid
+   Let's Encrypt certificate (issuer: `R3` / `E1` or the current LE chain).
+6. **Tear down.** `bin/conoha app destroy --yes <server>`,
+   `bin/conoha proxy remove --purge <server>`, then
+   `bin/conoha server delete <server>` and
+   `bin/conoha dns record remove <zone> <host> A`.
+
+If any step fails, do **not** tag. File the bug against the RC commit and
+iterate on an `rcN+1` tag.
+
+## 2. VPS-only bug checks (spec §7.1)
+
+For each row: what you observe on this RC, compared to what the spec says
+should happen. Every row needs a yes/no on this checklist — if you waive
+one (e.g. ACME is rate-limited today), note the reason.
+
+| # | Bug class | What to run | Pass condition |
+|---|-----------|-------------|----------------|
+| 1 | **cloud-init timing** | `bin/conoha server create …` immediately followed by `bin/conoha proxy boot <server>` (no manual sleep). | `proxy boot` waits for cloud-init to complete before SSH-ing, then succeeds on first try. No `Connection refused`/`timeout` errors surface to the user. |
+| 2 | **systemd unit race** | `ssh <server> 'systemctl status docker conoha-proxy'` after step 1.3. | Both units are `active (running)`. `journalctl -u conoha-proxy` shows no `failed to connect to docker.sock` retries. |
+| 3 | **SSH known_hosts TOFU (#101)** | Connect from a fresh workstation (empty `~/.ssh/known_hosts`). Run `bin/conoha app status <server>` twice; between runs, `ssh-keygen -R <vps-ip>` to simulate a rebuild. | First run prompts for TOFU (or auto-accepts with `CONOHA_SSH_INSECURE=1`); second run (post-remove) re-prompts rather than silently pinning an old fingerprint. |
+| 4 | **ACME rate-limit degradation** | Trigger `app deploy` against a domain already past the LE weekly quota (reuse a known-throttled zone, or skip with reason). | CLI output ends with `TLS pending — degraded` rather than a plain-looking success. Proxy keeps serving HTTP. |
+| 5 | **DNS propagation** | `bin/conoha app init <server>` against a host whose A record was added <60s ago (before full NS propagation). | CLI either warns `hosts not yet reachable — deploy may fail until DNS propagates` or fails early with a clear message; no silent-succeed-then-502-later behavior. |
+| 6 | **ConoHa API response drift** | `bin/conoha flavor list`, `bin/conoha image list`, `bin/conoha keypair list` all against live API. | All three return non-empty tables with no `unexpected field` / `missing required` parse errors. If any parser is brittle, catch it here rather than during a `server create` mid-release. |
+
+Link the run output (asciinema / terminal log / screenshots) in the release notes.
+
+## 3. Promotion gate
+
+If §1 is green and every row in §2 is either ✓ or justified-waived:
+
+1. Push the RC tag: `git tag v0.2.0-rcN && git push origin v0.2.0-rcN`.
+2. Wait for `CI / e2e` to pass on the tag.
+3. If no regressions emerge within the agreed-on soak period, cut the
+   final tag: `git tag -s v0.2.0 && git push origin v0.2.0`.
+4. Run `gh release create v0.2.0 --generate-notes` and edit the body to
+   link back to this checklist run.
+
+## 4. Next release deltas
+
+When adding a new CLI surface or VPS-side behavior, update the §2 table
+before cutting the tag. DinD cannot catch these classes, so this document
+is where the coverage lives.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -39,17 +39,18 @@ iterate on an `rcN+1` tag.
 ## 2. VPS-only bug checks (spec §7.1)
 
 For each row: what you observe on this RC, compared to what the spec says
-should happen. Every row needs a yes/no on this checklist — if you waive
-one (e.g. ACME is rate-limited today), note the reason.
+should happen. Tick the `Done?` column (`[x]` = passed) for every row;
+leave `[ ]` and note the reason in the release notes if you waive one
+(e.g. ACME is rate-limited today) or it fails.
 
-| # | Bug class | What to run | Pass condition |
-|---|-----------|-------------|----------------|
-| 1 | **cloud-init timing** | `bin/conoha server create …` immediately followed by `bin/conoha proxy boot <server>` (no manual sleep). | `proxy boot` waits for cloud-init to complete before SSH-ing, then succeeds on first try. No `Connection refused`/`timeout` errors surface to the user. |
-| 2 | **systemd unit race** | `ssh <server> 'systemctl status docker conoha-proxy'` after step 1.3. | Both units are `active (running)`. `journalctl -u conoha-proxy` shows no `failed to connect to docker.sock` retries. |
-| 3 | **SSH known_hosts TOFU (#101)** | Connect from a fresh workstation (empty `~/.ssh/known_hosts`). Run `bin/conoha app status <server>` twice; between runs, `ssh-keygen -R <vps-ip>` to simulate a rebuild. | First run prompts for TOFU (or auto-accepts with `CONOHA_SSH_INSECURE=1`); second run (post-remove) re-prompts rather than silently pinning an old fingerprint. |
-| 4 | **ACME rate-limit degradation** | Trigger `app deploy` against a domain already past the LE weekly quota (reuse a known-throttled zone, or skip with reason). | CLI output ends with `TLS pending — degraded` rather than a plain-looking success. Proxy keeps serving HTTP. |
-| 5 | **DNS propagation** | `bin/conoha app init <server>` against a host whose A record was added <60s ago (before full NS propagation). | CLI either warns `hosts not yet reachable — deploy may fail until DNS propagates` or fails early with a clear message; no silent-succeed-then-502-later behavior. |
-| 6 | **ConoHa API response drift** | `bin/conoha flavor list`, `bin/conoha image list`, `bin/conoha keypair list` all against live API. | All three return non-empty tables with no `unexpected field` / `missing required` parse errors. If any parser is brittle, catch it here rather than during a `server create` mid-release. |
+| # | Bug class | What to run | Pass condition | Done? |
+|---|-----------|-------------|----------------|-------|
+| 1 | **cloud-init timing** | `bin/conoha server create …` immediately followed by `bin/conoha proxy boot <server>` (no manual sleep). | `proxy boot` waits for cloud-init to complete before SSH-ing, then succeeds on first try. No `Connection refused`/`timeout` errors surface to the user. | `[ ]` |
+| 2 | **systemd unit race** | `ssh <server> 'systemctl status docker conoha-proxy'` after step 1.3. | Both units are `active (running)`. `journalctl -u conoha-proxy` shows no `failed to connect to docker.sock` retries. | `[ ]` |
+| 3 | **SSH known_hosts TOFU (#101)** | Connect from a fresh workstation (empty `~/.ssh/known_hosts`). Run `bin/conoha app status <server>` twice; between runs, `ssh-keygen -R <vps-ip>` to simulate a rebuild. | First run prompts for TOFU (or auto-accepts with `CONOHA_SSH_INSECURE=1`); second run (post-remove) re-prompts rather than silently pinning an old fingerprint. | `[ ]` |
+| 4 | **ACME rate-limit degradation** | Trigger `app deploy` against a domain already past the LE weekly quota (reuse a known-throttled zone, or skip with reason). | CLI output ends with `TLS pending — degraded` rather than a plain-looking success. Proxy keeps serving HTTP. | `[ ]` |
+| 5 | **DNS propagation** | `bin/conoha app init <server>` against a host whose A record was added <60s ago (before full NS propagation). | CLI either warns `hosts not yet reachable — deploy may fail until DNS propagates` or fails early with a clear message; no silent-succeed-then-502-later behavior. | `[ ]` |
+| 6 | **ConoHa API response drift** | `bin/conoha flavor list`, `bin/conoha image list`, `bin/conoha keypair list` all against live API. | All three return non-empty tables with no `unexpected field` / `missing required` parse errors. If any parser is brittle, catch it here rather than during a `server create` mid-release. | `[ ]` |
 
 Link the run output (asciinema / terminal log / screenshots) in the release notes.
 
@@ -59,8 +60,12 @@ If §1 is green and every row in §2 is either ✓ or justified-waived:
 
 1. Push the RC tag: `git tag v0.2.0-rcN && git push origin v0.2.0-rcN`.
 2. Wait for `CI / e2e` to pass on the tag.
-3. If no regressions emerge within the agreed-on soak period, cut the
-   final tag: `git tag -s v0.2.0 && git push origin v0.2.0`.
+3. Soak the RC tag against a pre-prod ConoHa account under realistic
+   load for **24h** (or **1 week wall-clock** if no pre-prod environment
+   is available). If no regressions emerge, cut the final tag:
+   `git tag -s v0.2.0 && git push origin v0.2.0`. If you shorten the
+   soak for a time-sensitive release, record the reason in the release
+   notes.
 4. Run `gh release create v0.2.0 --generate-notes` and edit the body to
    link back to this checklist run.
 


### PR DESCRIPTION
## Summary
- Drops `continue-on-error: true` from the `e2e` CI job so failures block merges (spec §8 Phase 4).
- Updates the job's explanatory comment to describe scope and point TLS/real-VPS concerns at the release checklist.
- Adds `docs/release-checklist.md` covering the manual smoke for bug classes DinD cannot reproduce (spec §7 + §7.1).

The DinD harness (14 scenarios; added incrementally via #143/#144/#145/#146) runs in ~60-90s and the job is already green on `main`. Promoting it to a required check is the final gate for closing #96.

## Merge ordering
This PR depends on #146 landing first so the required `e2e` job covers all 14 scenarios on day one. If #146 is merged after this PR, the required job still passes — it'll just cover 12 scenarios until #146 merges.

## Test plan
- [x] `bash tests/e2e/run.sh` passes locally on `main` (12 scenarios, ~50s) and on #146 (14 scenarios, ~60s).
- [ ] CI `e2e` job is green on this PR (now gating).
- [ ] Manual review of `docs/release-checklist.md` — does the §7.1 table match the spec's bug class list, and are the run/pass instructions operational enough that someone else could actually run them?

🤖 Generated with [Claude Code](https://claude.com/claude-code)