### PR TITLE
ci(lint): disable golangci-lint-action cache (closes #136)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
+      # skip-cache: the action's per-package analysis cache is keyed on
+      # go.mod/go.sum/config, not source content, so a previous "0 issues"
+      # result short-circuits re-analysis of files whose content would now
+      # violate a rule. See #136 for the concrete false-pass we saw on
+      # PR #134. ~20s extra per run is a fair trade for lint actually
+      # being a reliable signal.
       - uses: golangci/golangci-lint-action@v7
+        with:
+          skip-cache: true
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Apply mitigation #1 from #136 — add `skip-cache: true` to the `golangci-lint-action` step.

## Why this mitigation
The action's per-package analysis cache is keyed on `go.mod` / `go.sum` / config, not source content. Once a package has a "0 issues" entry in the cache, subsequent runs short-circuit re-analysis even when the source file content would now violate a rule. #136 documents the concrete false-pass: PR #134's CI ran lint in 3.5s and reported `0 issues`, while a cold-cache run on the same base commit flagged two errcheck violations in `cmd/gpu/setup.go`.

Mitigation 2 (tightening cache invalidation interval) only narrows the window — it doesn't remove the failure mode. Mitigation 3 (install via `go install`) is heavier without a clear correctness benefit over `skip-cache`. Mitigation 4 needs investigation that isn't justified for a tiny repo.

## Cost
~+20s per CI run. Fair trade for lint being a reliable signal.

## Test plan
- [ ] This PR's `lint` check runs with a cold cache and completes in a realistic time (>15s).
- [ ] A future PR that introduces a new lint violation is flagged on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)