### PR TITLE
feat(filter): add ~ (contains) and ~= (regex) operators (closes #156)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&flagYes, "yes", "y", false, "skip confirmation prompts")
 	rootCmd.PersistentFlags().BoolVar(&flagSSHInsecure, "insecure", false, "disable SSH host-key verification (not recommended; for lab / throwaway VPS)")
 	rootCmd.PersistentFlags().Bool("no-headers", false, "hide table/CSV headers")
-	rootCmd.PersistentFlags().StringArray("filter", nil, "filter rows by key=value (repeatable)")
+	rootCmd.PersistentFlags().StringArray("filter", nil, "filter rows: key=value (exact), key~value (contains), key~=regex (repeatable)")
 	rootCmd.PersistentFlags().String("sort-by", "", "sort rows by field name")
 
 	rootCmd.AddCommand(versionCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&flagYes, "yes", "y", false, "skip confirmation prompts")
 	rootCmd.PersistentFlags().BoolVar(&flagSSHInsecure, "insecure", false, "disable SSH host-key verification (not recommended; for lab / throwaway VPS)")
 	rootCmd.PersistentFlags().Bool("no-headers", false, "hide table/CSV headers")
-	rootCmd.PersistentFlags().StringArray("filter", nil, "filter rows: key=value (exact), key~value (contains), key~=regex (repeatable)")
+	rootCmd.PersistentFlags().StringArray("filter", nil, "filter rows (repeatable): key=value (exact), key~value (contains), key~=regex")
 	rootCmd.PersistentFlags().String("sort-by", "", "sort rows by field name")
 
 	rootCmd.AddCommand(versionCmd)

--- a/internal/output/transform.go
+++ b/internal/output/transform.go
@@ -87,6 +87,15 @@ func FilterRows(data any, filters []string) (any, error) {
 	// Validate filter fields
 	for _, fp := range parsed {
 		if _, ok := fieldIndex[fp.field]; !ok {
+			// If the parsed field name itself contains an operator char,
+			// the user probably embedded '=' or '~' in a value; splitFilter
+			// split on the earliest operator and mis-assigned the rest to
+			// the key. Surface that hint rather than a generic "unknown
+			// field" message.
+			if strings.ContainsAny(fp.field, "=~") {
+				return nil, fmt.Errorf("unknown field %q; values containing '=' or '~' are not supported (splits on the first operator); available fields: %s",
+					fp.field, strings.Join(fieldNames, ", "))
+			}
 			return nil, fmt.Errorf("unknown field %q; available fields: %s", fp.field, strings.Join(fieldNames, ", "))
 		}
 	}
@@ -130,11 +139,17 @@ func splitFilter(f string) (string, filterOp, string, error) {
 		if i == 0 {
 			return "", 0, "", fmt.Errorf("invalid filter %q: empty key", f)
 		}
+		if i+2 == len(f) {
+			return "", 0, "", fmt.Errorf("invalid filter %q: empty regex", f)
+		}
 		return f[:i], opRegex, f[i+2:], nil
 	}
 	if i := strings.Index(f, "~"); i >= 0 {
 		if i == 0 {
 			return "", 0, "", fmt.Errorf("invalid filter %q: empty key", f)
+		}
+		if i+1 == len(f) {
+			return "", 0, "", fmt.Errorf("invalid filter %q: empty value", f)
 		}
 		return f[:i], opContains, f[i+1:], nil
 	}
@@ -142,6 +157,9 @@ func splitFilter(f string) (string, filterOp, string, error) {
 		if i == 0 {
 			return "", 0, "", fmt.Errorf("invalid filter %q: empty key", f)
 		}
+		// Note: empty value ("key=") is allowed and matches rows where the
+		// field's stringified value is empty; existing behaviour kept for
+		// backward compatibility.
 		return f[:i], opEq, f[i+1:], nil
 	}
 	return "", 0, "", fmt.Errorf("invalid filter %q: expected key=value, key~value, or key~=regex", f)

--- a/internal/output/transform.go
+++ b/internal/output/transform.go
@@ -3,13 +3,28 @@ package output
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 )
 
-// FilterRows filters a slice of structs by the given key=value filters.
-// Filters are ANDed. Field names are matched against json tags (case-insensitive).
-// Non-slice data is returned as-is.
+type filterOp int
+
+const (
+	opEq filterOp = iota
+	opContains
+	opRegex
+)
+
+// FilterRows filters a slice of structs by the given filters. Supported
+// operators (checked in order):
+//
+//	key~=regex  — field matches regex (case-insensitive)
+//	key~value   — field contains value (case-insensitive substring)
+//	key=value   — field exactly equals value (case-insensitive)
+//
+// Filters are ANDed. Field names are matched against json tags
+// (case-insensitive). Non-slice data is returned as-is.
 func FilterRows(data any, filters []string) (any, error) {
 	if len(filters) == 0 {
 		return data, nil
@@ -29,15 +44,25 @@ func FilterRows(data any, filters []string) (any, error) {
 	// Parse filters
 	type filterPair struct {
 		field string
+		op    filterOp
 		value string
+		re    *regexp.Regexp
 	}
 	var parsed []filterPair
 	for _, f := range filters {
-		parts := strings.SplitN(f, "=", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid filter %q: expected key=value", f)
+		key, op, value, err := splitFilter(f)
+		if err != nil {
+			return nil, err
 		}
-		parsed = append(parsed, filterPair{field: strings.ToLower(parts[0]), value: strings.ToLower(parts[1])})
+		fp := filterPair{field: strings.ToLower(key), op: op, value: strings.ToLower(value)}
+		if op == opRegex {
+			re, err := regexp.Compile("(?i)" + value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid filter %q: bad regex: %w", f, err)
+			}
+			fp.re = re
+		}
+		parsed = append(parsed, fp)
 	}
 
 	// Build field index map from json tags
@@ -77,7 +102,16 @@ func FilterRows(data any, filters []string) (any, error) {
 		for _, fp := range parsed {
 			idx := fieldIndex[fp.field]
 			fieldVal := strings.ToLower(fmt.Sprintf("%v", row.Field(idx).Interface()))
-			if fieldVal != fp.value {
+			var ok bool
+			switch fp.op {
+			case opContains:
+				ok = strings.Contains(fieldVal, fp.value)
+			case opRegex:
+				ok = fp.re.MatchString(fieldVal)
+			default:
+				ok = fieldVal == fp.value
+			}
+			if !ok {
 				match = false
 				break
 			}
@@ -87,6 +121,30 @@ func FilterRows(data any, filters []string) (any, error) {
 		}
 	}
 	return result.Interface(), nil
+}
+
+// splitFilter parses a filter expression into (key, op, value). Operators are
+// checked longest-first so "~=" is recognised before "~" or "=".
+func splitFilter(f string) (string, filterOp, string, error) {
+	if i := strings.Index(f, "~="); i >= 0 {
+		if i == 0 {
+			return "", 0, "", fmt.Errorf("invalid filter %q: empty key", f)
+		}
+		return f[:i], opRegex, f[i+2:], nil
+	}
+	if i := strings.Index(f, "~"); i >= 0 {
+		if i == 0 {
+			return "", 0, "", fmt.Errorf("invalid filter %q: empty key", f)
+		}
+		return f[:i], opContains, f[i+1:], nil
+	}
+	if i := strings.Index(f, "="); i >= 0 {
+		if i == 0 {
+			return "", 0, "", fmt.Errorf("invalid filter %q: empty key", f)
+		}
+		return f[:i], opEq, f[i+1:], nil
+	}
+	return "", 0, "", fmt.Errorf("invalid filter %q: expected key=value, key~value, or key~=regex", f)
 }
 
 // SortRows sorts a slice of structs by the given field name.

--- a/internal/output/transform.go
+++ b/internal/output/transform.go
@@ -10,6 +10,8 @@ import (
 
 type filterOp int
 
+// opEq must stay at position 0 so that the zero value of filterOp means
+// "exact match" — the matcher's default branch relies on this.
 const (
 	opEq filterOp = iota
 	opContains
@@ -17,7 +19,8 @@ const (
 )
 
 // FilterRows filters a slice of structs by the given filters. Supported
-// operators (checked in order):
+// operators, recognised longest-first (so `~=` wins over `~`, and `~`
+// over `=`):
 //
 //	key~=regex  — field matches regex (case-insensitive)
 //	key~value   — field contains value (case-insensitive substring)

--- a/internal/output/transform_test.go
+++ b/internal/output/transform_test.go
@@ -183,6 +183,21 @@ func TestFilterRows(t *testing.T) {
 		}
 	})
 
+	t.Run("unicode contains", func(t *testing.T) {
+		u := []filterTestItem{
+			{Name: "東京サーバー", Status: "ACTIVE", Count: 1},
+			{Name: "osaka-server", Status: "ACTIVE", Count: 2},
+		}
+		result, err := FilterRows(u, []string{"name~東京"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 1 || rows[0].Name != "東京サーバー" {
+			t.Errorf("expected Tokyo row, got %+v", rows)
+		}
+	})
+
 	t.Run("numeric regex vs contains semantics", func(t *testing.T) {
 		// Documenting the difference: contains "3" also matches 13/30/300;
 		// regex "^3$" anchors to exactly 3.

--- a/internal/output/transform_test.go
+++ b/internal/output/transform_test.go
@@ -79,6 +79,83 @@ func TestFilterRows(t *testing.T) {
 		}
 	})
 
+	t.Run("contains operator", func(t *testing.T) {
+		bigger := []filterTestItem{
+			{Name: "ubuntu-24.04", Status: "ACTIVE", Count: 1},
+			{Name: "debian-12", Status: "ACTIVE", Count: 2},
+			{Name: "ubuntu-22.04", Status: "STOPPED", Count: 3},
+		}
+		result, err := FilterRows(bigger, []string{"name~ubuntu"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(rows))
+		}
+		if rows[0].Name != "ubuntu-24.04" || rows[1].Name != "ubuntu-22.04" {
+			t.Errorf("unexpected rows: %+v", rows)
+		}
+	})
+
+	t.Run("contains is case insensitive", func(t *testing.T) {
+		result, err := FilterRows(data, []string{"status~ACTI"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(rows))
+		}
+	})
+
+	t.Run("regex operator", func(t *testing.T) {
+		bigger := []filterTestItem{
+			{Name: "ubuntu-24.04", Status: "ACTIVE", Count: 1},
+			{Name: "ubuntu-22.04", Status: "STOPPED", Count: 2},
+			{Name: "debian-12", Status: "ACTIVE", Count: 3},
+		}
+		result, err := FilterRows(bigger, []string{`name~=^ubuntu-\d+\.\d+$`})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(rows))
+		}
+	})
+
+	t.Run("regex invalid", func(t *testing.T) {
+		_, err := FilterRows(data, []string{"name~=[unclosed"})
+		if err == nil {
+			t.Error("expected error for invalid regex")
+		}
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		for _, f := range []string{"=value", "~value", "~=value"} {
+			if _, err := FilterRows(data, []string{f}); err == nil {
+				t.Errorf("expected error for empty key filter %q", f)
+			}
+		}
+	})
+
+	t.Run("combined operators AND", func(t *testing.T) {
+		bigger := []filterTestItem{
+			{Name: "ubuntu-24.04", Status: "ACTIVE", Count: 1},
+			{Name: "ubuntu-22.04", Status: "STOPPED", Count: 2},
+			{Name: "debian-12", Status: "ACTIVE", Count: 3},
+		}
+		result, err := FilterRows(bigger, []string{"name~ubuntu", "status=ACTIVE"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 1 || rows[0].Name != "ubuntu-24.04" {
+			t.Errorf("expected [ubuntu-24.04 ACTIVE], got %+v", rows)
+		}
+	})
+
 	t.Run("empty filters", func(t *testing.T) {
 		result, err := FilterRows(data, nil)
 		if err != nil {

--- a/internal/output/transform_test.go
+++ b/internal/output/transform_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -137,6 +138,73 @@ func TestFilterRows(t *testing.T) {
 			if _, err := FilterRows(data, []string{f}); err == nil {
 				t.Errorf("expected error for empty key filter %q", f)
 			}
+		}
+	})
+
+	t.Run("empty value rejected for ~ and ~=", func(t *testing.T) {
+		// Empty value for contains/regex would silently match every row —
+		// almost certainly a typo, so reject.
+		for _, f := range []string{"name~", "name~="} {
+			if _, err := FilterRows(data, []string{f}); err == nil {
+				t.Errorf("expected error for %q (empty value)", f)
+			}
+		}
+	})
+
+	t.Run("empty value allowed for = (match empty field)", func(t *testing.T) {
+		// Preserve historical behaviour: `key=` matches rows whose field
+		// stringifies to the empty string.
+		withEmpty := []filterTestItem{
+			{Name: "a", Status: "ACTIVE", Count: 1},
+			{Name: "", Status: "STOPPED", Count: 2},
+		}
+		result, err := FilterRows(withEmpty, []string{"name="})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		rows := result.([]filterTestItem)
+		if len(rows) != 1 || rows[0].Status != "STOPPED" {
+			t.Errorf("expected the row with empty Name, got %+v", rows)
+		}
+	})
+
+	t.Run("ambiguous value hint", func(t *testing.T) {
+		// `name=a~b` parses as (field="name=a", contains "b") because ~ is
+		// checked before =. The resulting field-lookup failure should hint
+		// at the operator-splitting behaviour rather than a plain "unknown
+		// field" message.
+		_, err := FilterRows(data, []string{"name=a~b"})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "=") || !strings.Contains(msg, "first operator") {
+			t.Errorf("expected ambiguity hint in error, got: %q", msg)
+		}
+	})
+
+	t.Run("numeric regex vs contains semantics", func(t *testing.T) {
+		// Documenting the difference: contains "3" also matches 13/30/300;
+		// regex "^3$" anchors to exactly 3.
+		nums := []filterTestItem{
+			{Name: "a", Count: 3},
+			{Name: "b", Count: 13},
+			{Name: "c", Count: 30},
+		}
+		contains, err := FilterRows(nums, []string{"count~3"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(contains.([]filterTestItem)) != 3 {
+			t.Errorf("contains '3' should match 3/13/30, got %+v", contains)
+		}
+		regex, err := FilterRows(nums, []string{"count~=^3$"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := regex.([]filterTestItem)
+		if len(got) != 1 || got[0].Count != 3 {
+			t.Errorf("regex '^3$' should match only 3, got %+v", got)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- `--filter` now supports three operators (longest-first parse):
  - `key=value` — exact (existing)
  - `key~value` — case-insensitive substring
  - `key~=regex` — case-insensitive RE2
- Regex compiled once per filter with `(?i)`; invalid patterns error at parse time.
- Empty keys rejected for all three operators.

Resolves #156.

## Test plan

- [x] `go test ./internal/output/...` — new cases for contains, regex, case-insensitive contains, invalid regex, empty key, combined operators
- [x] `go build ./...` / `go vet ./...` clean
- [ ] Manual: `conoha image list --filter 'name~ubuntu'` returns substring matches
- [ ] Manual: `conoha image list --filter 'name~=^ubuntu-\d+\.\d+$'` returns regex matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)