### PR TITLE
fix(prompt): surface --no-input failures as ValidationError (refs #155)

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -9,12 +9,13 @@ import (
 	"golang.org/x/term"
 
 	"github.com/crowdy/conoha-cli/internal/config"
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 )
 
 // String prompts the user for a string input.
 func String(label string) (string, error) {
 	if config.IsNoInput() {
-		return "", fmt.Errorf("input required but --no-input is set")
+		return "", &cerrors.ValidationError{Field: label, Message: "input required but --no-input is set"}
 	}
 	fmt.Fprintf(os.Stderr, "%s: ", label)
 	reader := bufio.NewReader(os.Stdin)
@@ -29,7 +30,7 @@ func String(label string) (string, error) {
 // Reads in raw terminal mode to support paste on WSL2.
 func Password(label string) (string, error) {
 	if config.IsNoInput() {
-		return "", fmt.Errorf("input required but --no-input is set")
+		return "", &cerrors.ValidationError{Field: label, Message: "input required but --no-input is set"}
 	}
 	fmt.Fprintf(os.Stderr, "%s: ", label)
 

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,8 +1,12 @@
 package prompt
 
 import (
+	stderrors "errors"
 	"os"
+	"strings"
 	"testing"
+
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 )
 
 func TestString_NoInput(t *testing.T) {
@@ -14,8 +18,12 @@ func TestString_NoInput(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when CONOHA_NO_INPUT=1")
 	}
-	if got := err.Error(); got != "input required but --no-input is set" {
-		t.Fatalf("unexpected error message: %s", got)
+	if !strings.Contains(err.Error(), "input required but --no-input is set") {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+	var ve *cerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *ValidationError, got %T", err)
 	}
 }
 

--- a/internal/prompt/select.go
+++ b/internal/prompt/select.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/crowdy/conoha-cli/internal/config"
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 )
 
 // SelectItem represents a selectable item.
@@ -24,9 +25,9 @@ type SelectItem struct {
 func Select(label string, items []SelectItem, hint ...string) (string, error) {
 	if config.IsNoInput() || !term.IsTerminal(int(os.Stdin.Fd())) {
 		if len(hint) > 0 && hint[0] != "" {
-			return "", fmt.Errorf("%s; interactive selection requires a TTY", hint[0])
+			return "", &cerrors.ValidationError{Message: fmt.Sprintf("%s; interactive selection requires a TTY", hint[0])}
 		}
-		return "", fmt.Errorf("interactive selection requires a TTY for %q; use flags to specify values", label)
+		return "", &cerrors.ValidationError{Message: fmt.Sprintf("interactive selection requires a TTY for %q; use flags to specify values", label)}
 	}
 
 	searcher := func(input string, index int) bool {

--- a/internal/prompt/select_test.go
+++ b/internal/prompt/select_test.go
@@ -1,6 +1,7 @@
 package prompt
 
 import (
+	stderrors "errors"
 	"os"
 	"strings"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/crowdy/conoha-cli/internal/config"
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 )
 
 func TestSelect_NoInput_WithoutHint_IncludesLabel(t *testing.T) {
@@ -49,5 +51,34 @@ func TestSelect_NonTTY_IncludesLabel(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "pick") {
 		t.Errorf("error should include label, got: %q", err.Error())
+	}
+}
+
+func TestSelect_NoInput_ReturnsValidationError(t *testing.T) {
+	// The TTY-absence failure must surface as ValidationError so the CLI
+	// exits with ExitValidation (4) rather than the generic code. CI scripts
+	// rely on the distinct code to tell "missing required flag" apart from
+	// other runtime failures.
+	t.Setenv(config.EnvNoInput, "1")
+	items := []SelectItem{{Label: "opt", Value: "v"}}
+
+	_, err := Select("Select flavor", items)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ve *cerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+	if cerrors.GetExitCode(err) != cerrors.ExitValidation {
+		t.Errorf("expected ExitValidation (%d), got %d", cerrors.ExitValidation, cerrors.GetExitCode(err))
+	}
+
+	_, err = Select("Select sg", items, "use --security-group")
+	if err == nil {
+		t.Fatal("expected error with hint")
+	}
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("hinted path: expected *ValidationError, got %T: %v", err, err)
 	}
 }

--- a/internal/prompt/select_test.go
+++ b/internal/prompt/select_test.go
@@ -81,4 +81,7 @@ func TestSelect_NoInput_ReturnsValidationError(t *testing.T) {
 	if !stderrors.As(err, &ve) {
 		t.Fatalf("hinted path: expected *ValidationError, got %T: %v", err, err)
 	}
+	if cerrors.GetExitCode(err) != cerrors.ExitValidation {
+		t.Errorf("hinted path: expected ExitValidation (%d), got %d", cerrors.ExitValidation, cerrors.GetExitCode(err))
+	}
 }

--- a/internal/ssh/knownhosts.go
+++ b/internal/ssh/knownhosts.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 	"golang.org/x/term"
+
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 )
 
 // HostKeyCallback returns an ssh.HostKeyCallback that verifies the remote
@@ -63,7 +65,9 @@ func HostKeyCallback(insecure, noInput bool) (ssh.HostKeyCallback, error) {
 			// heredoc, wrapper without --no-input) would otherwise let
 			// `yes\n` from an untrusted source silently trust the host.
 			if noInput || !term.IsTerminal(int(os.Stdin.Fd())) {
-				return fmt.Errorf("host %s not in %s and stdin is not interactive (no-input mode or non-TTY) — refusing to trust unknown host. Add manually with ssh-keyscan or use --insecure", hostname, path)
+				return &cerrors.ValidationError{Message: fmt.Sprintf(
+					"host %s not in %s and stdin is not interactive (no-input mode or non-TTY) — refusing to trust unknown host. Add manually with ssh-keyscan or use --insecure",
+					hostname, path)}
 			}
 			return promptAndPin(path, hostname, remote, key)
 		} else {

--- a/internal/ssh/knownhosts_test.go
+++ b/internal/ssh/knownhosts_test.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 	"golang.org/x/term"
+
+	cerrors "github.com/crowdy/conoha-cli/internal/errors"
 )
 
 func TestHostKeyCallback_Insecure(t *testing.T) {
@@ -79,6 +81,15 @@ func TestHostKeyCallback_UnknownHost_NoInput(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not in") || !strings.Contains(err.Error(), "--insecure") {
 		t.Errorf("expected helpful no-input error message, got: %v", err)
+	}
+	// Must surface as ValidationError so CI can distinguish this from other
+	// SSH failures by exit code (ExitValidation = 4).
+	var ve *cerrors.ValidationError
+	if !errors.As(err, &ve) {
+		t.Errorf("expected *ValidationError, got %T", err)
+	}
+	if cerrors.GetExitCode(err) != cerrors.ExitValidation {
+		t.Errorf("expected ExitValidation (%d), got %d", cerrors.ExitValidation, cerrors.GetExitCode(err))
 	}
 }
 


### PR DESCRIPTION
## Summary

- `prompt.Select` / `prompt.String` / `prompt.Password` now return `*cerrors.ValidationError` (exit code `ExitValidation` = 4) when `--no-input` or non-TTY prevents interaction, instead of a plain `fmt.Errorf` (exit 1).
- CI scripts can now tell "missing required flag / not interactive" apart from other runtime failures by exit code.

## Note on the reported symptom

The issue states `server create --no-input` exits **0** when `--security-group` is missing. I could not reproduce exit 0 on current `main` (`d49dc72`) — the error propagates through Cobra (`SilenceErrors: true`) to `root.Execute`, which calls `os.Exit(GetExitCode(err))` = 1. That is verified with a trivial bogus-flavor reproduction (exits 1).

It is possible the reporter's `v0.5.10-38-g29e54dc` build or harness exhibited different behavior; however, the deeper concern — CI mistakes this failure mode for something else — is solved here by giving it a distinct semantic exit code (4) rather than sharing `ExitGeneral` (1) with everything else.

Partial for #155 (will leave issue open pending reporter confirmation that exit 0 no longer reproduces on current main).

## Test plan

- [x] `go test ./internal/prompt/... ./internal/errors/...`
- [x] `go test ./cmd/...` (covers server/app/proxy/volume/skill)
- [x] `go build ./...` / `go vet ./...`
- [x] End-to-end: `conoha auth login --no-input` → `EXIT=4` (was `1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)