### PR TITLE
feat(proxy): init/destroy multi-service registration (closes #151)

### DIFF
--- a/cmd/app/destroy.go
+++ b/cmd/app/destroy.go
@@ -71,11 +71,7 @@ var destroyCmd = &cobra.Command{
 			admin := proxypkg.NewClient(&proxypkg.SSHExecutor{Client: ctx.Client}, proxy.SocketPath(dataDir))
 			pf, pfErr := config.LoadProjectFile(config.ProjectFileName)
 			if pfErr == nil && pf.Validate() == nil {
-				if err := admin.Delete(pf.Name); err != nil && !errors.Is(err, proxypkg.ErrNotFound) {
-					fmt.Fprintf(os.Stderr, "warning: proxy delete %s: %v\n", pf.Name, err)
-				} else if err == nil {
-					fmt.Fprintf(os.Stderr, "==> Deregistered %q from proxy\n", pf.Name)
-				}
+				deregisterProxyServices(admin, pf, os.Stderr)
 			}
 		}
 

--- a/cmd/app/init.go
+++ b/cmd/app/init.go
@@ -80,15 +80,9 @@ func runInitProxy(cmd *cobra.Command, serverID string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "==> Registering service %q on %s (%s)\n", pf.Name, s.Name, ip)
-	svc, err := client.Upsert(proxypkg.UpsertRequest{
-		Name:         pf.Name,
-		Hosts:        pf.Hosts,
-		HealthPolicy: mapHealth(pf.Health),
-	})
-	if err != nil {
+	if err := registerProxyServices(client, pf, os.Stderr); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "Service %q registered. phase=%s tls=%s\n", svc.Name, svc.Phase, svc.TLSStatus)
 	if err := WriteMarker(sshClient, pf.Name, ModeProxy); err != nil {
 		return fmt.Errorf("write mode marker: %w", err)
 	}

--- a/cmd/app/proxyservices.go
+++ b/cmd/app/proxyservices.go
@@ -51,7 +51,7 @@ func registerProxyServices(admin proxyAdmin, pf *config.ProjectFile, log io.Writ
 		return err
 	}
 	registered = append(registered, pf.Name)
-	fmt.Fprintf(log, "Service %q registered. phase=%s tls=%s\n", rootSvc.Name, rootSvc.Phase, rootSvc.TLSStatus)
+	_, _ = fmt.Fprintf(log, "Service %q registered. phase=%s tls=%s\n", rootSvc.Name, rootSvc.Phase, rootSvc.TLSStatus)
 
 	for i := range pf.Expose {
 		b := &pf.Expose[i]
@@ -64,13 +64,13 @@ func registerProxyServices(admin proxyAdmin, pf *config.ProjectFile, log io.Writ
 		if upErr != nil {
 			for j := len(registered) - 1; j >= 0; j-- {
 				if delErr := admin.Delete(registered[j]); delErr != nil && !errors.Is(delErr, proxypkg.ErrNotFound) {
-					fmt.Fprintf(log, "warning: rollback delete %s: %v\n", registered[j], delErr)
+					_, _ = fmt.Fprintf(log, "warning: rollback delete %s: %v\n", registered[j], delErr)
 				}
 			}
 			return fmt.Errorf("upsert expose %q (%s): %w", b.Label, b.Host, upErr)
 		}
 		registered = append(registered, name)
-		fmt.Fprintf(log, "==> Registered %q on %s (phase=%s tls=%s)\n", svc.Name, b.Host, svc.Phase, svc.TLSStatus)
+		_, _ = fmt.Fprintf(log, "==> Registered %q on %s (phase=%s tls=%s)\n", svc.Name, b.Host, svc.Phase, svc.TLSStatus)
 	}
 	return nil
 }
@@ -84,14 +84,14 @@ func deregisterProxyServices(admin proxyAdmin, pf *config.ProjectFile, log io.Wr
 	for i := len(pf.Expose) - 1; i >= 0; i-- {
 		name := exposeServiceName(pf.Name, pf.Expose[i].Label)
 		if err := admin.Delete(name); err != nil && !errors.Is(err, proxypkg.ErrNotFound) {
-			fmt.Fprintf(log, "warning: proxy delete %s: %v\n", name, err)
+			_, _ = fmt.Fprintf(log, "warning: proxy delete %s: %v\n", name, err)
 		} else if err == nil {
-			fmt.Fprintf(log, "==> Deregistered %q from proxy\n", name)
+			_, _ = fmt.Fprintf(log, "==> Deregistered %q from proxy\n", name)
 		}
 	}
 	if err := admin.Delete(pf.Name); err != nil && !errors.Is(err, proxypkg.ErrNotFound) {
-		fmt.Fprintf(log, "warning: proxy delete %s: %v\n", pf.Name, err)
+		_, _ = fmt.Fprintf(log, "warning: proxy delete %s: %v\n", pf.Name, err)
 	} else if err == nil {
-		fmt.Fprintf(log, "==> Deregistered %q from proxy\n", pf.Name)
+		_, _ = fmt.Fprintf(log, "==> Deregistered %q from proxy\n", pf.Name)
 	}
 }

--- a/cmd/app/proxyservices.go
+++ b/cmd/app/proxyservices.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/crowdy/conoha-cli/internal/config"
+	proxypkg "github.com/crowdy/conoha-cli/internal/proxy"
+)
+
+// proxyAdmin is the subset of *proxypkg.Client used by init/destroy. It lets
+// tests substitute a fake without touching SSH.
+type proxyAdmin interface {
+	Upsert(req proxypkg.UpsertRequest) (*proxypkg.Service, error)
+	Delete(name string) error
+}
+
+// exposeServiceName returns the proxy service name for an expose block,
+// matching the Q-naming convention in the subdomain-split RFC (§7).
+func exposeServiceName(appName, label string) string {
+	return appName + "-" + label
+}
+
+// healthFor returns the proxy health policy a block should be registered with.
+// Each expose block may override the top-level health; if not, the root health
+// is inherited.
+func healthFor(pf *config.ProjectFile, block *config.ExposeBlock) *proxypkg.HealthPolicy {
+	if block != nil && block.Health != nil {
+		return mapHealth(block.Health)
+	}
+	return mapHealth(pf.Health)
+}
+
+// registerProxyServices upserts one proxy service for the root web target
+// plus one per expose block. If any upsert fails, every service registered
+// earlier in this call is deleted (best-effort) before the original error
+// is returned, so a partial failure cannot leave orphan services behind.
+//
+// Registration order: root first, then exposes in declaration order. Rollback
+// unwinds in reverse (expose[n-1] … expose[0] … root).
+func registerProxyServices(admin proxyAdmin, pf *config.ProjectFile, log io.Writer) error {
+	registered := make([]string, 0, 1+len(pf.Expose))
+
+	rootSvc, err := admin.Upsert(proxypkg.UpsertRequest{
+		Name:         pf.Name,
+		Hosts:        pf.Hosts,
+		HealthPolicy: mapHealth(pf.Health),
+	})
+	if err != nil {
+		return err
+	}
+	registered = append(registered, pf.Name)
+	fmt.Fprintf(log, "Service %q registered. phase=%s tls=%s\n", rootSvc.Name, rootSvc.Phase, rootSvc.TLSStatus)
+
+	for i := range pf.Expose {
+		b := &pf.Expose[i]
+		name := exposeServiceName(pf.Name, b.Label)
+		svc, upErr := admin.Upsert(proxypkg.UpsertRequest{
+			Name:         name,
+			Hosts:        []string{b.Host},
+			HealthPolicy: healthFor(pf, b),
+		})
+		if upErr != nil {
+			for j := len(registered) - 1; j >= 0; j-- {
+				if delErr := admin.Delete(registered[j]); delErr != nil && !errors.Is(delErr, proxypkg.ErrNotFound) {
+					fmt.Fprintf(log, "warning: rollback delete %s: %v\n", registered[j], delErr)
+				}
+			}
+			return fmt.Errorf("upsert expose %q (%s): %w", b.Label, b.Host, upErr)
+		}
+		registered = append(registered, name)
+		fmt.Fprintf(log, "==> Registered %q on %s (phase=%s tls=%s)\n", svc.Name, b.Host, svc.Phase, svc.TLSStatus)
+	}
+	return nil
+}
+
+// deregisterProxyServices deletes the expose services (in reverse declaration
+// order) then the root service. 404s are tolerated; other errors are logged
+// as warnings but never abort the sweep — destroy has already removed the
+// app's on-server state, so a leftover proxy registration is the lesser evil
+// compared to a half-cleaned app.
+func deregisterProxyServices(admin proxyAdmin, pf *config.ProjectFile, log io.Writer) {
+	for i := len(pf.Expose) - 1; i >= 0; i-- {
+		name := exposeServiceName(pf.Name, pf.Expose[i].Label)
+		if err := admin.Delete(name); err != nil && !errors.Is(err, proxypkg.ErrNotFound) {
+			fmt.Fprintf(log, "warning: proxy delete %s: %v\n", name, err)
+		} else if err == nil {
+			fmt.Fprintf(log, "==> Deregistered %q from proxy\n", name)
+		}
+	}
+	if err := admin.Delete(pf.Name); err != nil && !errors.Is(err, proxypkg.ErrNotFound) {
+		fmt.Fprintf(log, "warning: proxy delete %s: %v\n", pf.Name, err)
+	} else if err == nil {
+		fmt.Fprintf(log, "==> Deregistered %q from proxy\n", pf.Name)
+	}
+}

--- a/cmd/app/proxyservices_test.go
+++ b/cmd/app/proxyservices_test.go
@@ -1,0 +1,285 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/crowdy/conoha-cli/internal/config"
+	proxypkg "github.com/crowdy/conoha-cli/internal/proxy"
+)
+
+// fakeAdmin records Upsert/Delete calls in order and lets tests program
+// failure modes per-call.
+type fakeAdmin struct {
+	upserts   []proxypkg.UpsertRequest
+	deletes   []string
+	upsertErr func(req proxypkg.UpsertRequest) error
+	deleteErr func(name string) error
+}
+
+func (f *fakeAdmin) Upsert(req proxypkg.UpsertRequest) (*proxypkg.Service, error) {
+	f.upserts = append(f.upserts, req)
+	if f.upsertErr != nil {
+		if err := f.upsertErr(req); err != nil {
+			return nil, err
+		}
+	}
+	return &proxypkg.Service{Name: req.Name, Hosts: req.Hosts, Phase: "live", TLSStatus: "ready"}, nil
+}
+
+func (f *fakeAdmin) Delete(name string) error {
+	f.deletes = append(f.deletes, name)
+	if f.deleteErr != nil {
+		return f.deleteErr(name)
+	}
+	return nil
+}
+
+func projectWithExpose(n int) *config.ProjectFile {
+	pf := &config.ProjectFile{
+		Name:  "myapp",
+		Hosts: []string{"myapp.example.com"},
+		Web:   config.WebSpec{Service: "web", Port: 8080},
+	}
+	for i := 0; i < n; i++ {
+		pf.Expose = append(pf.Expose, config.ExposeBlock{
+			Label:   fmt.Sprintf("aux%d", i),
+			Host:    fmt.Sprintf("aux%d.example.com", i),
+			Service: fmt.Sprintf("svc%d", i),
+			Port:    9000 + i,
+		})
+	}
+	return pf
+}
+
+func TestRegisterProxyServices_RootOnly(t *testing.T) {
+	admin := &fakeAdmin{}
+	pf := projectWithExpose(0)
+	var log bytes.Buffer
+
+	if err := registerProxyServices(admin, pf, &log); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(admin.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(admin.upserts))
+	}
+	if admin.upserts[0].Name != "myapp" {
+		t.Errorf("root upsert name = %q", admin.upserts[0].Name)
+	}
+	if len(admin.deletes) != 0 {
+		t.Errorf("unexpected deletes: %v", admin.deletes)
+	}
+}
+
+func TestRegisterProxyServices_RootPlusExpose(t *testing.T) {
+	admin := &fakeAdmin{}
+	pf := projectWithExpose(2)
+	var log bytes.Buffer
+
+	if err := registerProxyServices(admin, pf, &log); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(admin.upserts) != 3 {
+		t.Fatalf("upserts = %d, want 3 (root + 2 expose)", len(admin.upserts))
+	}
+	want := []string{"myapp", "myapp-aux0", "myapp-aux1"}
+	for i, w := range want {
+		if admin.upserts[i].Name != w {
+			t.Errorf("upsert[%d].Name = %q, want %q", i, admin.upserts[i].Name, w)
+		}
+	}
+	// Expose upserts carry only the block's host.
+	if got, want := admin.upserts[1].Hosts, []string{"aux0.example.com"}; !stringSlicesEqual(got, want) {
+		t.Errorf("upsert[1].Hosts = %v, want %v", got, want)
+	}
+	if len(admin.deletes) != 0 {
+		t.Errorf("expected no deletes on happy path, got %v", admin.deletes)
+	}
+}
+
+func TestRegisterProxyServices_MidFailureRollsBack(t *testing.T) {
+	// Make the second expose upsert fail. Expected: earlier registrations
+	// (root + first expose) are deleted in reverse so no orphans remain.
+	admin := &fakeAdmin{
+		upsertErr: func(req proxypkg.UpsertRequest) error {
+			if req.Name == "myapp-aux1" {
+				return errors.New("boom")
+			}
+			return nil
+		},
+	}
+	pf := projectWithExpose(2)
+	var log bytes.Buffer
+
+	err := registerProxyServices(admin, pf, &log)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "aux1") {
+		t.Errorf("error should name failing block, got %q", err.Error())
+	}
+	// 3 upsert attempts were made (root, aux0 ok, aux1 fails).
+	if len(admin.upserts) != 3 {
+		t.Fatalf("upserts = %d, want 3", len(admin.upserts))
+	}
+	// Rollback: aux0 then root (reverse order of successful registrations).
+	wantDeletes := []string{"myapp-aux0", "myapp"}
+	if !stringSlicesEqual(admin.deletes, wantDeletes) {
+		t.Errorf("rollback deletes = %v, want %v", admin.deletes, wantDeletes)
+	}
+}
+
+func TestRegisterProxyServices_RootFailureNoRollback(t *testing.T) {
+	// Root upsert fails: nothing was registered, so nothing to roll back.
+	admin := &fakeAdmin{
+		upsertErr: func(req proxypkg.UpsertRequest) error {
+			return errors.New("denied")
+		},
+	}
+	pf := projectWithExpose(2)
+	var log bytes.Buffer
+
+	if err := registerProxyServices(admin, pf, &log); err == nil {
+		t.Fatal("want error")
+	}
+	if len(admin.upserts) != 1 {
+		t.Errorf("want to stop after root failure, got %d upserts", len(admin.upserts))
+	}
+	if len(admin.deletes) != 0 {
+		t.Errorf("no rollback expected, got %v", admin.deletes)
+	}
+}
+
+func TestRegisterProxyServices_RollbackTolerates404(t *testing.T) {
+	// Rollback must not abort on ErrNotFound — the service may already be
+	// gone between our Upsert and rollback attempt.
+	admin := &fakeAdmin{
+		upsertErr: func(req proxypkg.UpsertRequest) error {
+			if req.Name == "myapp-aux0" {
+				return errors.New("boom")
+			}
+			return nil
+		},
+		deleteErr: func(name string) error {
+			if name == "myapp" {
+				return fmt.Errorf("wrapped: %w", proxypkg.ErrNotFound)
+			}
+			return nil
+		},
+	}
+	pf := projectWithExpose(1)
+	var log bytes.Buffer
+
+	err := registerProxyServices(admin, pf, &log)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	if !stringSlicesEqual(admin.deletes, []string{"myapp"}) {
+		t.Errorf("delete order wrong: %v", admin.deletes)
+	}
+	if strings.Contains(log.String(), "warning: rollback delete myapp:") {
+		t.Errorf("404 during rollback should be silent, log was: %s", log.String())
+	}
+}
+
+func TestDeregisterProxyServices_AllGone(t *testing.T) {
+	admin := &fakeAdmin{}
+	pf := projectWithExpose(2)
+	var log bytes.Buffer
+
+	deregisterProxyServices(admin, pf, &log)
+
+	want := []string{"myapp-aux1", "myapp-aux0", "myapp"}
+	if !stringSlicesEqual(admin.deletes, want) {
+		t.Errorf("deletes = %v, want %v (expose reverse then root)", admin.deletes, want)
+	}
+}
+
+func TestDeregisterProxyServices_404sAreNonFatal(t *testing.T) {
+	// Every delete returns ErrNotFound. Sweep must still visit every service
+	// and emit no warnings.
+	admin := &fakeAdmin{
+		deleteErr: func(name string) error { return proxypkg.ErrNotFound },
+	}
+	pf := projectWithExpose(2)
+	var log bytes.Buffer
+
+	deregisterProxyServices(admin, pf, &log)
+
+	if len(admin.deletes) != 3 {
+		t.Errorf("deletes = %d, want 3", len(admin.deletes))
+	}
+	if strings.Contains(log.String(), "warning:") {
+		t.Errorf("404 should be silent, log: %s", log.String())
+	}
+}
+
+func TestDeregisterProxyServices_NonFatalError(t *testing.T) {
+	// A non-404 error on one service must not stop the sweep; warnings go
+	// to the log but root still gets its delete attempt.
+	admin := &fakeAdmin{
+		deleteErr: func(name string) error {
+			if name == "myapp-aux0" {
+				return errors.New("transient")
+			}
+			return nil
+		},
+	}
+	pf := projectWithExpose(1)
+	var log bytes.Buffer
+
+	deregisterProxyServices(admin, pf, &log)
+
+	if !stringSlicesEqual(admin.deletes, []string{"myapp-aux0", "myapp"}) {
+		t.Errorf("root delete was skipped: %v", admin.deletes)
+	}
+	if !strings.Contains(log.String(), "warning: proxy delete myapp-aux0") {
+		t.Errorf("warning missing for failing delete: %s", log.String())
+	}
+}
+
+func TestExposeServiceName(t *testing.T) {
+	if got := exposeServiceName("gitea", "dex"); got != "gitea-dex" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestHealthFor_BlockOverridesRoot(t *testing.T) {
+	pf := &config.ProjectFile{
+		Name:   "app",
+		Health: &config.HealthSpec{Path: "/root"},
+	}
+	block := &config.ExposeBlock{Health: &config.HealthSpec{Path: "/block"}}
+	got := healthFor(pf, block)
+	if got == nil || got.Path != "/block" {
+		t.Errorf("got %+v, want block override", got)
+	}
+
+	pf.Health = nil
+	block.Health = nil
+	if got := healthFor(pf, block); got != nil {
+		t.Errorf("both nil → nil, got %+v", got)
+	}
+
+	pf.Health = &config.HealthSpec{Path: "/root"}
+	block.Health = nil
+	got = healthFor(pf, block)
+	if got == nil || got.Path != "/root" {
+		t.Errorf("block nil → inherit root, got %+v", got)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Phase 2 of the subdomain-split RFC (spec \`2026-04-24-subdomain-split-design.md\`, merged in #149; depends on #150 merged in #159).

## What changed

- New \`cmd/app/proxyservices.go\` with two helpers behind a narrow \`proxyAdmin\` interface (satisfied by \`*proxypkg.Client\`, so tests don't need SSH):
  - \`registerProxyServices(admin, pf, log)\` — upserts root \`<name>\`, then each \`expose[i]\` as \`<name>-<label>\`. **On mid-loop failure, deletes everything already registered in reverse order**, then returns the error. A partial init cannot leave orphan services behind.
  - \`deregisterProxyServices(admin, pf, log)\` — deletes exposes in reverse declaration order, then root. \`ErrNotFound\` is silent; other errors log a warning but never abort the sweep (app files are already gone; leftover registration is the lesser evil).
- Each expose block's \`health:\` is inherited from top-level \`health:\` when unset, or overridden when present.
- \`runInitProxy\` (\`cmd/app/init.go\`) and the destroy path (\`cmd/app/destroy.go\`) now delegate to the helpers. No behaviour change when \`pf.Expose\` is empty — the root-only path is bit-identical to before.

## Acceptance (issue checklist)

- [x] \`app init\` with 2 \`expose:\` blocks registers 3 proxy services (root + 2).
- [x] Mid-init failure on 2nd expose leaves zero services (rollback in reverse).
- [x] \`app destroy\` removes all 3 proxy services.
- [x] Fixture with no \`expose:\` behaves bit-identically to main (unit test \`TestRegisterProxyServices_RootOnly\` + no changes to that call path).

## Out of scope (per issue body)

- \`app deploy\` calling \`/deploy\` on expose services — phase 3 (#152).
- \`app status\` / \`app rollback\` surfacing expose services — phase 4 (#153).

## Test plan

- [x] \`go test ./...\` clean; 10 new subtests in \`cmd/app/proxyservices_test.go\`.
- [x] \`go vet ./...\` / \`gofmt -l .\` clean.
- [ ] Manual multi-host smoke on a real VPS — deferred to phase 3 when end-to-end deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)