### PR TITLE
feat(deploy): multi-block blue/green deploy (closes #152)

### DIFF
--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -229,8 +229,17 @@ func makeArchiveOfCwd() (io.Reader, error) {
 // runProxyDeployState drives the blue/green deploy state machine without
 // any direct SSH or filesystem dependencies. Every side effect flows
 // through ops, which tests substitute with a recording fake.
+//
+// Multi-block (phase 3 of the subdomain-split RFC): when pf.Expose has
+// any blue_green: true blocks, a single slot holds containers for the
+// root web service plus every such block, and proxy /deploy is called
+// once per block — expose blocks first, root web last. A partial failure
+// (424 probe_failed from block N) reverse-rolls back blocks 0..N-1 and
+// tears down the slot; 409 no_drain_target on a rollback degrades to a
+// warning and continues, per spec §7 Q-rollback default.
 func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 	pf := p.ProjectFile
+	blocks := collectDeployBlocks(pf)
 
 	// Service must exist — init registers it. Missing = user skipped init.
 	if _, err := ops.Proxy().Get(pf.Name); err != nil {
@@ -255,6 +264,9 @@ func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 
 	fmt.Fprintf(os.Stderr, "==> Deploying %q to %s (%s)\n", pf.Name, p.ServerName, p.ServerIP)
 	fmt.Fprintf(os.Stderr, "==> Slot: %s (compose project: %s)\n", slot, slotProjectName(pf.Name, slot))
+	if len(blocks) > 1 {
+		fmt.Fprintf(os.Stderr, "==> %d blue/green blocks in this deploy (root + %d expose)\n", len(blocks), len(blocks)-1)
+	}
 
 	// Upload archive to slot work dir.
 	archive, err := p.Archive()
@@ -266,8 +278,10 @@ func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 		return fmt.Errorf("upload: %w", err)
 	}
 
-	// Write compose override into the slot dir.
-	overrideContent := composeOverride(pf.Name, slot, pf.Web.Service, pf.Web.Port, len(pf.Accessories) > 0)
+	// Write compose override containing every block's service.
+	effectiveAccessories := collectEffectiveAccessories(pf)
+	hasAcc := len(effectiveAccessories) > 0
+	overrideContent := composeOverrideFor(pf.Name, slot, blocks, hasAcc)
 	overridePath := "conoha-override.yml"
 	writeOverride := fmt.Sprintf("cat > '%s/%s' <<'EOF'\n%sEOF", slotWork, overridePath, overrideContent)
 	if err := runRemoteOps(ops, writeOverride, nil); err != nil {
@@ -275,48 +289,78 @@ func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 	}
 
 	// First-run: bring up accessories (idempotent via existence probe).
-	if len(pf.Accessories) > 0 {
+	// BlueGreen:false expose blocks piggy-back on the same compose project
+	// so they stay up across slot rotations.
+	if hasAcc {
 		check := buildAccessoryExists(accessoryProjectName(pf.Name))
 		code, _, _ := ops.Run(check, nil)
 		if code != 0 {
-			fmt.Fprintf(os.Stderr, "==> Starting accessories: %v\n", pf.Accessories)
-			if err := runRemoteOps(ops, buildAccessoryUp(slotWork, accessoryProjectName(pf.Name), p.ComposeFile, pf.Accessories), nil); err != nil {
+			fmt.Fprintf(os.Stderr, "==> Starting accessories: %v\n", effectiveAccessories)
+			if err := runRemoteOps(ops, buildAccessoryUp(slotWork, accessoryProjectName(pf.Name), p.ComposeFile, effectiveAccessories), nil); err != nil {
 				return fmt.Errorf("accessory up: %w", err)
 			}
 		}
 	}
 
-	// Start the new slot's web service.
-	fmt.Fprintf(os.Stderr, "==> Building and starting %s in new slot\n", pf.Web.Service)
-	if err := runRemoteOps(ops, buildSlotComposeUp(slotWork, slotProjectName(pf.Name, slot), p.ComposeFile, overridePath, pf.Web.Service), nil); err != nil {
+	// Start every block's service in the new slot. Services MUST be listed
+	// explicitly; compose would otherwise start accessories too.
+	services := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		services = append(services, b.Service)
+	}
+	fmt.Fprintf(os.Stderr, "==> Building and starting %v in new slot\n", services)
+	if err := runRemoteOps(ops, buildSlotComposeUp(slotWork, slotProjectName(pf.Name, slot), p.ComposeFile, overridePath, services), nil); err != nil {
 		return fmt.Errorf("compose up (slot): %w", err)
 	}
 
-	// Discover kernel-picked host port.
-	containerName := fmt.Sprintf("%s-%s-%s", pf.Name, slot, pf.Web.Service)
-	_, portOut, portErr := ops.Run(buildDockerPortCmd(containerName, pf.Web.Port), nil)
-	if portErr != nil {
-		tearDownSlotOps(ops, pf.Name, slot)
-		return fmt.Errorf("docker port: %w", portErr)
+	// Discover kernel-picked host port per block.
+	targetURLs := make(map[int]string, len(blocks)) // index-into-blocks → url
+	for i, b := range blocks {
+		containerName := fmt.Sprintf("%s-%s-%s", pf.Name, slot, b.Service)
+		_, portOut, portErr := ops.Run(buildDockerPortCmd(containerName, b.Port), nil)
+		if portErr != nil {
+			tearDownSlotOps(ops, pf.Name, slot)
+			return fmt.Errorf("docker port %s: %w", b.Service, portErr)
+		}
+		hostPort, perr := extractHostPort(string(portOut))
+		if perr != nil {
+			tearDownSlotOps(ops, pf.Name, slot)
+			return fmt.Errorf("parse host port for %s: %w", b.Service, perr)
+		}
+		targetURLs[i] = fmt.Sprintf("http://127.0.0.1:%d", hostPort)
+		fmt.Fprintf(os.Stderr, "==> %s → host port %d\n", b.Service, hostPort)
 	}
-	hostPort, err := extractHostPort(string(portOut))
-	if err != nil {
-		tearDownSlotOps(ops, pf.Name, slot)
-		return err
-	}
-	targetURL := fmt.Sprintf("http://127.0.0.1:%d", hostPort)
-	fmt.Fprintf(os.Stderr, "==> Host port: %d. Calling proxy /deploy\n", hostPort)
 
 	drainMs := 30000
 	if pf.Deploy != nil && pf.Deploy.DrainMs > 0 {
 		drainMs = pf.Deploy.DrainMs
 	}
 
-	// Call proxy /deploy. On 424 the proxy did not mutate state — tear down new slot.
-	updated, err := ops.Proxy().Deploy(pf.Name, proxypkg.DeployRequest{TargetURL: targetURL, DrainMs: drainMs})
-	if err != nil {
-		tearDownSlotOps(ops, pf.Name, slot)
-		return err
+	// /deploy order: expose blocks first (indices 1..N-1), root web last
+	// (index 0). Rationale (spec §3.3): users hit root URLs which often
+	// redirect to sub-hosts (dex / admin); flipping sub-hosts first keeps
+	// the redirect consistent with the new code.
+	deployOrder := make([]int, 0, len(blocks))
+	for i := 1; i < len(blocks); i++ {
+		deployOrder = append(deployOrder, i)
+	}
+	deployOrder = append(deployOrder, 0)
+
+	swapped := make([]int, 0, len(blocks)) // blocks successfully /deploy'd
+	var rootUpdated *proxypkg.Service
+	for _, idx := range deployOrder {
+		b := blocks[idx]
+		fmt.Fprintf(os.Stderr, "==> Calling proxy /deploy on %q (target=%s)\n", b.ProxyName, targetURLs[idx])
+		svc, derr := ops.Proxy().Deploy(b.ProxyName, proxypkg.DeployRequest{TargetURL: targetURLs[idx], DrainMs: drainMs})
+		if derr != nil {
+			reverseRollbackBlocks(ops, blocks, swapped, drainMs)
+			tearDownSlotOps(ops, pf.Name, slot)
+			return derr
+		}
+		swapped = append(swapped, idx)
+		if idx == 0 {
+			rootUpdated = svc
+		}
 	}
 
 	// Read old slot pointer (empty on first deploy), then update to current.
@@ -345,11 +389,37 @@ func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 	}
 
 	active := "<unknown>"
-	if updated.ActiveTarget != nil {
-		active = updated.ActiveTarget.URL
+	if rootUpdated != nil && rootUpdated.ActiveTarget != nil {
+		active = rootUpdated.ActiveTarget.URL
 	}
-	fmt.Fprintf(os.Stderr, "Deploy complete. active=%s phase=%s\n", active, updated.Phase)
+	phase := ""
+	if rootUpdated != nil {
+		phase = string(rootUpdated.Phase)
+	}
+	fmt.Fprintf(os.Stderr, "Deploy complete. active=%s phase=%s\n", active, phase)
 	return nil
+}
+
+// reverseRollbackBlocks issues /rollback against every block in `swapped`
+// (reverse order) using the shared drainMs. 409 no_drain_target on any one
+// rollback degrades to a stderr warning and the loop continues — the spec
+// §7 Q-rollback default: drain window closed is safe (proxy already points
+// at previous target) and must not abort the wider recovery. Other errors
+// are also logged but don't stop the loop so every successful swap gets a
+// rollback attempt.
+func reverseRollbackBlocks(ops DeployOps, blocks []DeployBlock, swapped []int, drainMs int) {
+	for i := len(swapped) - 1; i >= 0; i-- {
+		idx := swapped[i]
+		b := blocks[idx]
+		fmt.Fprintf(os.Stderr, "==> Rolling back %q (partial deploy recovery)\n", b.ProxyName)
+		if _, err := ops.Proxy().Rollback(b.ProxyName, drainMs); err != nil {
+			if errors.Is(err, proxypkg.ErrNoDrainTarget) {
+				fmt.Fprintf(os.Stderr, "warning: drain window expired for %s; manual intervention required\n", b.ProxyName)
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "warning: rollback %s: %v\n", b.ProxyName, err)
+		}
+	}
 }
 
 // runRemote runs command on cli. When stdinData is non-nil it is streamed as stdin.

--- a/cmd/app/deploy_multiblock_test.go
+++ b/cmd/app/deploy_multiblock_test.go
@@ -1,0 +1,288 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/crowdy/conoha-cli/internal/config"
+	proxypkg "github.com/crowdy/conoha-cli/internal/proxy"
+)
+
+// twoBlockParams returns a proxyDeployParams with one root web + one expose
+// block, both participating in blue/green rotation.
+func twoBlockParams() proxyDeployParams {
+	p := baseParams()
+	p.ProjectFile.Expose = []config.ExposeBlock{
+		{Label: "dex", Host: "dex.example.com", Service: "dex", Port: 5556},
+	}
+	return p
+}
+
+// multiBlockOps wires successOps for both blocks: `docker port` must return
+// distinct host ports for the two containers.
+func multiBlockOps() *fakeOps {
+	ops := successOps()
+	// Default "docker port" override returns one value; replace with a
+	// per-container rule via longer-matching substrings.
+	delete(ops.Overrides, "docker port")
+	ops.Overrides["docker port myapp-abc1234-web 8080"] = fakeOpsResponse{ExitCode: 0, Stdout: "127.0.0.1:34567\n"}
+	ops.Overrides["docker port myapp-abc1234-dex 5556"] = fakeOpsResponse{ExitCode: 0, Stdout: "127.0.0.1:34568\n"}
+	return ops
+}
+
+func TestRunProxyDeployState_TwoBlocks_HappyPath(t *testing.T) {
+	ops := multiBlockOps()
+	if err := runProxyDeployState(twoBlockParams(), ops); err != nil {
+		t.Fatalf("happy 2-block deploy failed: %v", err)
+	}
+
+	// Both /deploy calls were made, expose before root.
+	if n := len(ops.Proxy_.DeployCalls); n != 2 {
+		t.Fatalf("deploys = %d, want 2", n)
+	}
+	order := []string{ops.Proxy_.DeployCalls[0].Name, ops.Proxy_.DeployCalls[1].Name}
+	if order[0] != "myapp-dex" || order[1] != "myapp" {
+		t.Errorf("deploy order = %v, want [myapp-dex, myapp]", order)
+	}
+	if got := ops.Proxy_.DeployCalls[0].Req.TargetURL; got != "http://127.0.0.1:34568" {
+		t.Errorf("expose target URL = %q, want http://127.0.0.1:34568", got)
+	}
+	if got := ops.Proxy_.DeployCalls[1].Req.TargetURL; got != "http://127.0.0.1:34567" {
+		t.Errorf("root target URL = %q, want http://127.0.0.1:34567", got)
+	}
+	if len(ops.Proxy_.RollbackCalls) != 0 {
+		t.Errorf("no rollbacks expected on happy path, got %v", ops.Proxy_.RollbackCalls)
+	}
+
+	// Override YAML has both services.
+	mustPresent(t, ops.Commands, "container_name: myapp-abc1234-web")
+	mustPresent(t, ops.Commands, "container_name: myapp-abc1234-dex")
+	mustPresent(t, ops.Commands, "up -d --build web dex")
+
+	// No teardown of new slot on success.
+	mustAbsent(t, ops.Commands, "down 2>/dev/null")
+}
+
+func TestRunProxyDeployState_TwoBlocks_RootFailsMidway(t *testing.T) {
+	// The root /deploy (last in the order) fails with 424. Expected: the
+	// expose block that already swapped is rolled back, and the new slot
+	// is torn down.
+	ops := multiBlockOps()
+	ops.Proxy_ = &fakeProxyAPI{
+		DeployErrByName: map[string]error{
+			"myapp": &proxypkg.ProbeFailedError{Message: "upstream /up returned 500"},
+		},
+	}
+
+	err := runProxyDeployState(twoBlockParams(), ops)
+	if err == nil {
+		t.Fatal("want error from failing root deploy")
+	}
+	var pe *proxypkg.ProbeFailedError
+	if !errors.As(err, &pe) {
+		t.Errorf("want ProbeFailedError, got %T: %v", err, err)
+	}
+
+	// One rollback issued, against the earlier-swapped expose block.
+	if len(ops.Proxy_.RollbackCalls) != 1 {
+		t.Fatalf("rollbacks = %d, want 1", len(ops.Proxy_.RollbackCalls))
+	}
+	if got := ops.Proxy_.RollbackCalls[0].Name; got != "myapp-dex" {
+		t.Errorf("rollback target = %q, want myapp-dex", got)
+	}
+	if got := ops.Proxy_.RollbackCalls[0].DrainMs; got != 2000 {
+		t.Errorf("rollback drainMs = %d, want 2000 (pf.Deploy.DrainMs)", got)
+	}
+
+	// Slot teardown must happen.
+	mustPresent(t, ops.Commands, "down 2>/dev/null")
+	mustPresent(t, ops.Commands, "rm -rf '/opt/conoha/myapp/abc1234'")
+}
+
+func TestRunProxyDeployState_TwoBlocks_ExposeFailsFirst(t *testing.T) {
+	// First /deploy (expose) fails. Nothing to roll back. Root /deploy must
+	// not have been called. Slot torn down.
+	ops := multiBlockOps()
+	ops.Proxy_ = &fakeProxyAPI{
+		DeployErrByName: map[string]error{
+			"myapp-dex": &proxypkg.ProbeFailedError{Message: "dex probe failed"},
+		},
+	}
+
+	err := runProxyDeployState(twoBlockParams(), ops)
+	if err == nil {
+		t.Fatal("want error")
+	}
+
+	if got := callNames(ops.Proxy_.DeployCalls); len(got) != 1 || got[0] != "myapp-dex" {
+		t.Errorf("deploy calls = %v, want only [myapp-dex]", got)
+	}
+	if len(ops.Proxy_.RollbackCalls) != 0 {
+		t.Errorf("no rollbacks expected when first /deploy fails, got %v", rollbackNames(ops.Proxy_.RollbackCalls))
+	}
+	mustPresent(t, ops.Commands, "down 2>/dev/null")
+}
+
+func TestRunProxyDeployState_TwoBlocks_RollbackDrainExpiredDegrades(t *testing.T) {
+	// Root /deploy fails after expose swapped; rollback of the expose
+	// returns ErrNoDrainTarget (409). The CLI must degrade to a warning
+	// and still propagate the original /deploy error (not the rollback's).
+	ops := multiBlockOps()
+	ops.Proxy_ = &fakeProxyAPI{
+		DeployErrByName: map[string]error{
+			"myapp": &proxypkg.ProbeFailedError{Message: "root probe failed"},
+		},
+		RollbackErrByName: map[string]error{
+			"myapp-dex": fmt.Errorf("rollback: %w", proxypkg.ErrNoDrainTarget),
+		},
+	}
+
+	err := runProxyDeployState(twoBlockParams(), ops)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var pe *proxypkg.ProbeFailedError
+	if !errors.As(err, &pe) {
+		t.Errorf("caller must see the original ProbeFailedError, not the rollback's 409. got %T: %v", err, err)
+	}
+	if len(ops.Proxy_.RollbackCalls) != 1 {
+		t.Errorf("rollback must still have been attempted, got %d", len(ops.Proxy_.RollbackCalls))
+	}
+}
+
+func TestRunProxyDeployState_BlueGreenFalseExposeGoesToAccessories(t *testing.T) {
+	// blue_green:false expose block must NOT participate in the slot /deploy
+	// loop, but its service is added to the accessory compose project so it
+	// stays up across rotations.
+	p := baseParams()
+	falseB := false
+	p.ProjectFile.Expose = []config.ExposeBlock{
+		{Label: "admin", Host: "admin.example.com", Service: "studio", Port: 3000, BlueGreen: &falseB},
+	}
+
+	ops := multiBlockOps()
+	// port maps only for the blocks we actually bring up in the slot (root).
+	delete(ops.Overrides, "docker port myapp-abc1234-dex 5556")
+	// No accessories yet → existence probe returns non-zero (will trigger up).
+	ops.Overrides["docker compose -p myapp-accessories ps -q"] = fakeOpsResponse{ExitCode: 1, Stdout: "0\n"}
+
+	if err := runProxyDeployState(p, ops); err != nil {
+		t.Fatalf("deploy failed: %v", err)
+	}
+
+	// One /deploy only (root).
+	if n := len(ops.Proxy_.DeployCalls); n != 1 {
+		t.Fatalf("deploys = %d, want 1 (only root rotates; blue_green:false expose is accessory-style)", n)
+	}
+	if ops.Proxy_.DeployCalls[0].Name != "myapp" {
+		t.Errorf("only root should be deployed, got %q", ops.Proxy_.DeployCalls[0].Name)
+	}
+	// accessory compose up includes the blue_green:false service.
+	mustPresent(t, ops.Commands, "-p myapp-accessories")
+	mustPresent(t, ops.Commands, "up -d studio")
+}
+
+func TestCollectDeployBlocks_Shape(t *testing.T) {
+	trueB, falseB := true, false
+	pf := &config.ProjectFile{
+		Name: "app",
+		Web:  config.WebSpec{Service: "web", Port: 80},
+		Expose: []config.ExposeBlock{
+			{Label: "dex", Service: "dex", Host: "dex.example.com", Port: 5556, BlueGreen: &trueB},
+			{Label: "admin", Service: "studio", Host: "admin.example.com", Port: 3000, BlueGreen: &falseB},
+			{Label: "api", Service: "api", Host: "api.example.com", Port: 8000}, // nil → default true
+		},
+	}
+	got := collectDeployBlocks(pf)
+	if len(got) != 3 {
+		t.Fatalf("blocks = %d, want 3 (root + 2 blue/green expose; admin is blue_green:false)", len(got))
+	}
+	want := []struct{ svc, proxy string }{
+		{"web", "app"},
+		{"dex", "app-dex"},
+		{"api", "app-api"},
+	}
+	for i, w := range want {
+		if got[i].Service != w.svc || got[i].ProxyName != w.proxy {
+			t.Errorf("block[%d] = %+v, want svc=%q proxy=%q", i, got[i], w.svc, w.proxy)
+		}
+	}
+	if !got[0].isRoot() {
+		t.Errorf("block[0] must be root")
+	}
+	if got[1].isRoot() {
+		t.Errorf("block[1] must not be root")
+	}
+}
+
+func TestCollectEffectiveAccessories_IncludesBlueGreenFalse(t *testing.T) {
+	falseB := true
+	falseB2 := false
+	pf := &config.ProjectFile{
+		Accessories: []string{"db"},
+		Expose: []config.ExposeBlock{
+			{Service: "on", BlueGreen: &falseB},
+			{Service: "off", BlueGreen: &falseB2},
+		},
+	}
+	got := collectEffectiveAccessories(pf)
+	if got := strings.Join(got, ","); got != "db,off" {
+		t.Errorf("effective accessories = %q, want %q", got, "db,off")
+	}
+}
+
+func TestComposeOverrideFor_TwoBlocks(t *testing.T) {
+	blocks := []DeployBlock{
+		{Service: "web", Port: 8080},
+		{Label: "dex", Service: "dex", Port: 5556},
+	}
+	got := composeOverrideFor("myapp", "abc1234", blocks, false)
+	for _, want := range []string{
+		"  web:",
+		"    container_name: myapp-abc1234-web",
+		`      - "127.0.0.1:0:8080"`,
+		"  dex:",
+		"    container_name: myapp-abc1234-dex",
+		`      - "127.0.0.1:0:5556"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	// Single env_file line per block.
+	if n := strings.Count(got, "/opt/conoha/myapp/.env.server"); n != 2 {
+		t.Errorf("env_file lines = %d, want 2 (one per block)", n)
+	}
+}
+
+func TestComposeOverride_BackwardCompat_SingleRoot(t *testing.T) {
+	// No-expose fixture should produce output equivalent to pre-phase-3
+	// composeOverride (tested as substring coverage in override_test.go;
+	// re-assert here that the single-block wrapper path does not accidentally
+	// include an empty expose section or extra blocks).
+	got := composeOverride("myapp", "a1b2c3d", "web", 8080, false)
+	if strings.Count(got, "container_name:") != 1 {
+		t.Errorf("single-block form should emit exactly one container_name, got:\n%s", got)
+	}
+	if strings.Contains(got, "  :") {
+		t.Errorf("empty service key leaked into output:\n%s", got)
+	}
+}
+
+func callNames(calls []fakeDeployCall) []string {
+	out := make([]string, len(calls))
+	for i, c := range calls {
+		out[i] = c.Name
+	}
+	return out
+}
+
+func rollbackNames(calls []fakeRollbackCall) []string {
+	out := make([]string, len(calls))
+	for i, c := range calls {
+		out[i] = c.Name
+	}
+	return out
+}

--- a/cmd/app/deploy_ops.go
+++ b/cmd/app/deploy_ops.go
@@ -34,10 +34,12 @@ type DeployOps interface {
 }
 
 // DeployProxyAPI is the subset of proxypkg.Client that runProxyDeploy uses.
-// Kept tight so fakes don't drift.
+// Kept tight so fakes don't drift. Rollback is wired in for phase 3's
+// reverse-rollback-on-partial-failure path.
 type DeployProxyAPI interface {
 	Get(name string) (*proxypkg.Service, error)
 	Deploy(name string, req proxypkg.DeployRequest) (*proxypkg.Service, error)
+	Rollback(name string, drainMs int) (*proxypkg.Service, error)
 }
 
 // sshDeployOps is the production DeployOps: wraps a live *ssh.Client +

--- a/cmd/app/deploy_ops_test.go
+++ b/cmd/app/deploy_ops_test.go
@@ -85,12 +85,31 @@ func (f *fakeOps) Proxy() DeployProxyAPI {
 
 // fakeProxyAPI is a minimal DeployProxyAPI fake.
 type fakeProxyAPI struct {
-	GetCalls     int
-	DeployCalls  []proxypkg.DeployRequest
-	GetReturn    *proxypkg.Service
-	GetErr       error
-	DeployReturn *proxypkg.Service
-	DeployErr    error
+	GetCalls      int
+	DeployCalls   []fakeDeployCall
+	RollbackCalls []fakeRollbackCall
+	GetReturn     *proxypkg.Service
+	GetErr        error
+	DeployReturn  *proxypkg.Service
+	// DeployErrByName lets tests inject per-service /deploy errors for the
+	// multi-block path. If nil, falls back to DeployErr (applied to every
+	// call) for compatibility with single-block tests.
+	DeployErrByName map[string]error
+	DeployErr       error
+	RollbackErr     error
+	// RollbackErrByName, like DeployErrByName, lets tests inject per-service
+	// rollback errors (ErrNoDrainTarget on one block, success on another).
+	RollbackErrByName map[string]error
+}
+
+type fakeDeployCall struct {
+	Name string
+	Req  proxypkg.DeployRequest
+}
+
+type fakeRollbackCall struct {
+	Name    string
+	DrainMs int
 }
 
 func (f *fakeProxyAPI) Get(name string) (*proxypkg.Service, error) {
@@ -105,7 +124,10 @@ func (f *fakeProxyAPI) Get(name string) (*proxypkg.Service, error) {
 }
 
 func (f *fakeProxyAPI) Deploy(name string, req proxypkg.DeployRequest) (*proxypkg.Service, error) {
-	f.DeployCalls = append(f.DeployCalls, req)
+	f.DeployCalls = append(f.DeployCalls, fakeDeployCall{Name: name, Req: req})
+	if err, ok := f.DeployErrByName[name]; ok {
+		return nil, err
+	}
 	if f.DeployErr != nil {
 		return nil, f.DeployErr
 	}
@@ -117,6 +139,17 @@ func (f *fakeProxyAPI) Deploy(name string, req proxypkg.DeployRequest) (*proxypk
 		Phase:        proxypkg.PhaseLive,
 		ActiveTarget: &proxypkg.Target{URL: req.TargetURL},
 	}, nil
+}
+
+func (f *fakeProxyAPI) Rollback(name string, drainMs int) (*proxypkg.Service, error) {
+	f.RollbackCalls = append(f.RollbackCalls, fakeRollbackCall{Name: name, DrainMs: drainMs})
+	if err, ok := f.RollbackErrByName[name]; ok {
+		return nil, err
+	}
+	if f.RollbackErr != nil {
+		return nil, f.RollbackErr
+	}
+	return &proxypkg.Service{Name: name, Phase: proxypkg.PhaseLive}, nil
 }
 
 // baseParams constructs a minimal proxyDeployParams suitable for most tests.
@@ -172,11 +205,14 @@ func TestRunProxyDeployState_HappyPath_FirstDeploy(t *testing.T) {
 	if len(ops.Proxy_.DeployCalls) != 1 {
 		t.Fatalf("expected 1 admin.Deploy call, got %d", len(ops.Proxy_.DeployCalls))
 	}
-	if got := ops.Proxy_.DeployCalls[0].TargetURL; got != "http://127.0.0.1:34567" {
+	if got := ops.Proxy_.DeployCalls[0].Req.TargetURL; got != "http://127.0.0.1:34567" {
 		t.Errorf("TargetURL = %q, want http://127.0.0.1:34567", got)
 	}
-	if got := ops.Proxy_.DeployCalls[0].DrainMs; got != 2000 {
+	if got := ops.Proxy_.DeployCalls[0].Req.DrainMs; got != 2000 {
 		t.Errorf("DrainMs = %d, want 2000 (from pf.Deploy override)", got)
+	}
+	if got := ops.Proxy_.DeployCalls[0].Name; got != "myapp" {
+		t.Errorf("Name = %q, want myapp", got)
 	}
 
 	// Expected command ordering:

--- a/cmd/app/deployblocks.go
+++ b/cmd/app/deployblocks.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"github.com/crowdy/conoha-cli/internal/config"
+)
+
+// DeployBlock is the unified per-target record that runProxyDeployState
+// iterates over — root web plus every blue/green expose block. It decouples
+// the state machine from ProjectFile field plumbing so a single loop handles
+// N targets.
+type DeployBlock struct {
+	// Label distinguishes this block for log lines and proxy service naming.
+	// Empty for the root web block.
+	Label string
+	// Service is the compose service name to bring up in the slot. It maps
+	// to container_name "<app>-<slot>-<service>" via the compose override.
+	Service string
+	// Port is the container-internal port the service listens on.
+	Port int
+	// Host is the public host the proxy routes to this block. Only used for
+	// human-facing log output; the proxy service registration already carries
+	// authoritative host list (phase 2).
+	Host string
+	// ProxyName is the proxy service name: "<app>" for root, "<app>-<label>"
+	// for an expose block. Identifies the /deploy and /rollback target.
+	ProxyName string
+}
+
+// isRoot reports whether this block is the root web target (Label is empty).
+func (b DeployBlock) isRoot() bool { return b.Label == "" }
+
+// collectDeployBlocks returns the blocks that participate in blue/green
+// rotation on a deploy: the root web, plus every expose block whose
+// BlueGreen is nil (default-true) or explicitly true. Expose blocks with
+// BlueGreen == false are handled by collectEffectiveAccessories instead —
+// they go up once in the shared accessory compose project and never rotate.
+//
+// Order: root first in the slice, expose blocks in declaration order.
+// runProxyDeployState iterates /deploy the other direction (expose first,
+// root last) so callers must explicitly reorder at that boundary.
+func collectDeployBlocks(pf *config.ProjectFile) []DeployBlock {
+	out := make([]DeployBlock, 0, 1+len(pf.Expose))
+	out = append(out, DeployBlock{
+		Service:   pf.Web.Service,
+		Port:      pf.Web.Port,
+		ProxyName: pf.Name,
+	})
+	for i := range pf.Expose {
+		b := &pf.Expose[i]
+		if b.BlueGreen != nil && !*b.BlueGreen {
+			continue
+		}
+		out = append(out, DeployBlock{
+			Label:     b.Label,
+			Service:   b.Service,
+			Port:      b.Port,
+			Host:      b.Host,
+			ProxyName: exposeServiceName(pf.Name, b.Label),
+		})
+	}
+	return out
+}
+
+// collectEffectiveAccessories returns the set of compose services that
+// should come up in the persistent accessory project: the explicit
+// pf.Accessories list plus any expose block whose BlueGreen is explicitly
+// false. BlueGreen-false blocks declare a public host but are started once
+// (accessory-style) and never rotate with a slot.
+func collectEffectiveAccessories(pf *config.ProjectFile) []string {
+	out := make([]string, 0, len(pf.Accessories))
+	out = append(out, pf.Accessories...)
+	for i := range pf.Expose {
+		b := &pf.Expose[i]
+		if b.BlueGreen != nil && !*b.BlueGreen {
+			out = append(out, b.Service)
+		}
+	}
+	return out
+}

--- a/cmd/app/override.go
+++ b/cmd/app/override.go
@@ -1,39 +1,53 @@
 package app
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
-// composeOverride returns a compose override document (YAML) that:
-//   - pins the web service's container name to <project>-<slot>-<web>
+// composeOverrideFor returns a compose override document (YAML) with one
+// entry per blue/green DeployBlock. Each entry:
+//   - pins container name to <app>-<slot>-<service>
 //   - maps 127.0.0.1:0:<port> so the kernel picks a free host port
-//   - attaches env_file: /opt/conoha/<app>/.env.server so values written by
-//     `conoha app env set` apply at deploy time (spec 2026-04-23-app-env-redesign).
-//     The env file is created as an empty stub by `conoha app init` so compose
-//     never fails with "env_file not found".
-//   - when hasAccessories, joins the <app>-accessories_default network so the
-//     web container can resolve and reach accessory services (db/cache/etc.)
+//   - attaches env_file: /opt/conoha/<app>/.env.server
+//   - when hasAccessories, joins the <app>-accessories_default network
 //
-// It does not touch any other service; accessories keep their compose-declared
-// container_name, ports, and env config.
-func composeOverride(app, slot, webService string, webPort int, hasAccessories bool) string {
-	base := fmt.Sprintf(`services:
-  %[3]s:
-    container_name: %[1]s-%[2]s-%[3]s
-    ports:
-      - "127.0.0.1:0:%[4]d"
-    env_file:
-      - /opt/conoha/%[1]s/.env.server
-`, app, slot, webService, webPort)
-	if !hasAccessories {
-		return base
+// Per RFC §7 Q-env the env_file is shared across all blocks; a later RFC
+// will introduce per-block overrides if needed.
+//
+// For backward compatibility with phase 2 and earlier, a single-block call
+// (root web only, no expose entries) produces byte-identical output to the
+// pre-phase-3 composeOverride.
+func composeOverrideFor(app, slot string, blocks []DeployBlock, hasAccessories bool) string {
+	var sb strings.Builder
+	sb.WriteString("services:\n")
+	for _, b := range blocks {
+		fmt.Fprintf(&sb, "  %s:\n", b.Service)
+		fmt.Fprintf(&sb, "    container_name: %s-%s-%s\n", app, slot, b.Service)
+		sb.WriteString("    ports:\n")
+		fmt.Fprintf(&sb, "      - \"127.0.0.1:0:%d\"\n", b.Port)
+		sb.WriteString("    env_file:\n")
+		fmt.Fprintf(&sb, "      - /opt/conoha/%s/.env.server\n", app)
+		if hasAccessories {
+			sb.WriteString("    networks:\n")
+			sb.WriteString("      - default\n")
+			sb.WriteString("      - accessories\n")
+		}
 	}
-	return base + fmt.Sprintf(`    networks:
-      - default
-      - accessories
-networks:
-  accessories:
-    name: %[1]s-accessories_default
-    external: true
-`, app)
+	if hasAccessories {
+		sb.WriteString("networks:\n")
+		sb.WriteString("  accessories:\n")
+		fmt.Fprintf(&sb, "    name: %s-accessories_default\n", app)
+		sb.WriteString("    external: true\n")
+	}
+	return sb.String()
+}
+
+// composeOverride is the legacy single-web-service form. Preserved so call
+// sites outside runProxyDeployState (and the pre-existing gold tests) need
+// no change.
+func composeOverride(app, slot, webService string, webPort int, hasAccessories bool) string {
+	return composeOverrideFor(app, slot, []DeployBlock{{Service: webService, Port: webPort}}, hasAccessories)
 }
 
 // slotProjectName is the compose -p value for a blue/green slot.

--- a/cmd/app/remotecmds.go
+++ b/cmd/app/remotecmds.go
@@ -16,11 +16,16 @@ func buildSlotUploadCmd(workDir, _ string) string {
 		workDir)
 }
 
-// buildSlotComposeUp starts the single web service inside a slot-scoped project.
-func buildSlotComposeUp(workDir, project, composeFile, overrideFile, webService string) string {
+// buildSlotComposeUp starts the given compose services inside a slot-scoped
+// project. Services must be caller-validated (they come from pf.Web.Service /
+// expose.service which both flow through ValidateAgainstCompose). At least
+// one service is required — compose would otherwise start every service in
+// the file, including accessories the slot must not own.
+func buildSlotComposeUp(workDir, project, composeFile, overrideFile string, services []string) string {
+	args := strings.Join(services, " ")
 	return fmt.Sprintf(
 		"cd '%s' && docker compose -p %s -f %s -f %s up -d --build %s",
-		workDir, project, composeFile, overrideFile, webService)
+		workDir, project, composeFile, overrideFile, args)
 }
 
 // buildDockerPortCmd produces a command that prints the host:port mapping

--- a/cmd/app/remotecmds_test.go
+++ b/cmd/app/remotecmds_test.go
@@ -19,7 +19,7 @@ func TestBuildSlotUploadCmd(t *testing.T) {
 }
 
 func TestBuildComposeUp_Slot(t *testing.T) {
-	got := buildSlotComposeUp("/opt/conoha/myapp/abc1234", "myapp-abc1234", "compose.yml", "override.yml", "web")
+	got := buildSlotComposeUp("/opt/conoha/myapp/abc1234", "myapp-abc1234", "compose.yml", "override.yml", []string{"web"})
 	for _, want := range []string{
 		"cd '/opt/conoha/myapp/abc1234'",
 		"docker compose -p myapp-abc1234 -f compose.yml -f override.yml",


### PR DESCRIPTION
Phase 3 of the subdomain-split RFC. Depends on #150 (schema, merged) + #151 (proxy register/deregister, merged).

## What changed

- \`cmd/app/deployblocks.go\` (new): \`DeployBlock\`, \`collectDeployBlocks\`, \`collectEffectiveAccessories\`.
- \`runProxyDeployState\` (\`deploy.go\`):
  - Builds a block list (root + \`blue_green != false\` exposes).
  - Writes a multi-service compose override via \`composeOverrideFor\`.
  - \`docker port\` discovers a host port per block.
  - **/deploy order: expose blocks first, root LAST** (spec §3.3).
  - **Partial failure (424): reverse-rollbacks every already-swapped block, then tears down the new slot.**
  - **Rollback 409 \`no_drain_target\`**: stderr warning, sweep continues (spec §7 Q-rollback default).
- \`composeOverride\` → \`composeOverrideFor(app, slot, blocks, hasAcc)\`; the legacy signature is preserved as a single-block wrapper so existing gold tests and the root-only path stay bit-identical.
- \`buildSlotComposeUp\` takes \`[]string\` services (explicit list avoids compose implicitly starting accessories in the slot project).
- \`blue_green: false\` expose blocks are routed through the accessory compose project so they come up once and never rotate (spec §3.1).
- \`DeployProxyAPI\` gains \`Rollback\`; \`fakeProxyAPI\` records per-call service names + lets tests inject per-service errors.

## Acceptance

- [x] \`TestRunProxyDeployState_TwoBlocks_HappyPath\` — 2 /deploy calls in [expose, root] order, both host ports discovered, override YAML has both container names, \`up -d --build web dex\`.
- [x] \`TestRunProxyDeployState_TwoBlocks_RootFailsMidway\` — expose rolled back, slot torn down.
- [x] \`TestRunProxyDeployState_TwoBlocks_ExposeFailsFirst\` — no rollbacks (nothing swapped), root not deployed, slot torn down.
- [x] \`TestRunProxyDeployState_TwoBlocks_RollbackDrainExpiredDegrades\` — 409 → warning, caller still sees original \`ProbeFailedError\`.
- [x] \`TestRunProxyDeployState_BlueGreenFalseExposeGoesToAccessories\` — service added to accessory compose up; /deploy only for root.
- [x] No-expose fixture unchanged (\`TestRunProxyDeployState_HappyPath_FirstDeploy\` + existing gold tests all pass bit-identically).

## Out of scope (next phases)

- \`app status\` surfacing expose services + \`app rollback --target=<label>\` (phase 4, #153).
- e2e multi-host fixture + scenario (#154).
- README / recipes / release checklist (#153 docs sub-item).

## Test plan

- [x] \`go test ./...\` clean (including new 10 subtests)
- [x] \`go vet ./...\` / \`gofmt -l .\` clean
- [ ] End-to-end smoke on real VPS — deferred to #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)