### PR TITLE
fix(deploy): blue_green:false expose blocks need host-port + proxy /deploy

### DIFF
--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -281,11 +281,24 @@ func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 	// Write compose override containing every block's service.
 	effectiveAccessories := collectEffectiveAccessories(pf)
 	hasAcc := len(effectiveAccessories) > 0
+	fixedExpose := collectFixedExposeBlocks(pf)
 	overrideContent := composeOverrideFor(pf.Name, slot, blocks, hasAcc)
 	overridePath := "conoha-override.yml"
 	writeOverride := fmt.Sprintf("cat > '%s/%s' <<'EOF'\n%sEOF", slotWork, overridePath, overrideContent)
 	if err := runRemoteOps(ops, writeOverride, nil); err != nil {
 		return fmt.Errorf("write override: %w", err)
+	}
+
+	// Accessory override: publishes host ports + .env.server for any
+	// blue_green:false expose blocks. Empty string when there are none —
+	// buildAccessoryUp treats that as "no override".
+	accOverridePath := ""
+	if accOverrideContent := composeOverrideForAccessories(pf.Name, fixedExpose); accOverrideContent != "" {
+		accOverridePath = "conoha-accessories-override.yml"
+		writeAccOverride := fmt.Sprintf("cat > '%s/%s' <<'EOF'\n%sEOF", slotWork, accOverridePath, accOverrideContent)
+		if err := runRemoteOps(ops, writeAccOverride, nil); err != nil {
+			return fmt.Errorf("write accessory override: %w", err)
+		}
 	}
 
 	// First-run: bring up accessories (idempotent via existence probe).
@@ -296,9 +309,32 @@ func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 		code, _, _ := ops.Run(check, nil)
 		if code != 0 {
 			fmt.Fprintf(os.Stderr, "==> Starting accessories: %v\n", effectiveAccessories)
-			if err := runRemoteOps(ops, buildAccessoryUp(slotWork, accessoryProjectName(pf.Name), p.ComposeFile, effectiveAccessories), nil); err != nil {
+			if err := runRemoteOps(ops, buildAccessoryUp(slotWork, accessoryProjectName(pf.Name), p.ComposeFile, accOverridePath, effectiveAccessories), nil); err != nil {
 				return fmt.Errorf("accessory up: %w", err)
 			}
+		}
+	}
+
+	// Push proxy targets for fixed (blue_green:false) expose blocks. They
+	// don't slot-rotate, so the deploy is a one-shot per app deploy: read
+	// the host port chosen by docker (stable across idempotent ups) and
+	// hand it to proxy /deploy. Done before slot deploy so a fresh root
+	// web slot already finds its sub-services on the new target.
+	for _, b := range fixedExpose {
+		containerName := fmt.Sprintf("%s-%s-1", accessoryProjectName(pf.Name), b.Service)
+		_, portOut, portErr := ops.Run(buildDockerPortCmd(containerName, b.Port), nil)
+		if portErr != nil {
+			return fmt.Errorf("docker port %s (accessory): %w", b.Service, portErr)
+		}
+		hostPort, perr := extractHostPort(string(portOut))
+		if perr != nil {
+			return fmt.Errorf("parse host port for %s (accessory): %w", b.Service, perr)
+		}
+		targetURL := fmt.Sprintf("http://127.0.0.1:%d", hostPort)
+		fmt.Fprintf(os.Stderr, "==> %s (accessory) → host port %d\n", b.Service, hostPort)
+		fmt.Fprintf(os.Stderr, "==> Calling proxy /deploy on %q (target=%s)\n", b.ProxyName, targetURL)
+		if _, derr := ops.Proxy().Deploy(b.ProxyName, proxypkg.DeployRequest{TargetURL: targetURL, DrainMs: 0}); derr != nil {
+			return fmt.Errorf("proxy deploy %s: %w", b.ProxyName, derr)
 		}
 	}
 

--- a/cmd/app/deploy_multiblock_test.go
+++ b/cmd/app/deploy_multiblock_test.go
@@ -59,7 +59,7 @@ func TestRunProxyDeployState_TwoBlocks_HappyPath(t *testing.T) {
 	// Override YAML has both services.
 	mustPresent(t, ops.Commands, "container_name: myapp-abc1234-web")
 	mustPresent(t, ops.Commands, "container_name: myapp-abc1234-dex")
-	mustPresent(t, ops.Commands, "up -d --build web dex")
+	mustPresent(t, ops.Commands, "up -d --build --no-deps web dex")
 
 	// No teardown of new slot on success.
 	mustAbsent(t, ops.Commands, "down 2>/dev/null")
@@ -153,9 +153,9 @@ func TestRunProxyDeployState_TwoBlocks_RollbackDrainExpiredDegrades(t *testing.T
 }
 
 func TestRunProxyDeployState_BlueGreenFalseExposeGoesToAccessories(t *testing.T) {
-	// blue_green:false expose block must NOT participate in the slot /deploy
-	// loop, but its service is added to the accessory compose project so it
-	// stays up across rotations.
+	// blue_green:false expose block doesn't participate in slot rotation
+	// (no slot /deploy entry), but the proxy still gets a target — the
+	// accessory-project container's host port. See issue #163.
 	p := baseParams()
 	falseB := false
 	p.ProjectFile.Expose = []config.ExposeBlock{
@@ -163,8 +163,10 @@ func TestRunProxyDeployState_BlueGreenFalseExposeGoesToAccessories(t *testing.T)
 	}
 
 	ops := multiBlockOps()
-	// port maps only for the blocks we actually bring up in the slot (root).
+	// No slot dex container to port-discover (it's not in the slot blocks).
 	delete(ops.Overrides, "docker port myapp-abc1234-dex 5556")
+	// Accessory project's docker-default container name = "<project>-<service>-1".
+	ops.Overrides["docker port myapp-accessories-studio-1 3000"] = fakeOpsResponse{ExitCode: 0, Stdout: "127.0.0.1:39000\n"}
 	// No accessories yet → existence probe returns non-zero (will trigger up).
 	ops.Overrides["docker compose -p myapp-accessories ps -q"] = fakeOpsResponse{ExitCode: 1, Stdout: "0\n"}
 
@@ -172,16 +174,25 @@ func TestRunProxyDeployState_BlueGreenFalseExposeGoesToAccessories(t *testing.T)
 		t.Fatalf("deploy failed: %v", err)
 	}
 
-	// One /deploy only (root).
-	if n := len(ops.Proxy_.DeployCalls); n != 1 {
-		t.Fatalf("deploys = %d, want 1 (only root rotates; blue_green:false expose is accessory-style)", n)
+	// Two /deploy calls: the fixed expose (admin) is pushed before slot deploys,
+	// then root web from the slot loop.
+	if n := len(ops.Proxy_.DeployCalls); n != 2 {
+		t.Fatalf("deploys = %d, want 2 (fixed expose + root web)", n)
 	}
-	if ops.Proxy_.DeployCalls[0].Name != "myapp" {
-		t.Errorf("only root should be deployed, got %q", ops.Proxy_.DeployCalls[0].Name)
+	if ops.Proxy_.DeployCalls[0].Name != "myapp-admin" {
+		t.Errorf("first deploy should be the fixed expose %q, got %q", "myapp-admin", ops.Proxy_.DeployCalls[0].Name)
 	}
-	// accessory compose up includes the blue_green:false service.
+	if ops.Proxy_.DeployCalls[0].Req.TargetURL != "http://127.0.0.1:39000" {
+		t.Errorf("fixed expose target = %q, want http://127.0.0.1:39000", ops.Proxy_.DeployCalls[0].Req.TargetURL)
+	}
+	if ops.Proxy_.DeployCalls[1].Name != "myapp" {
+		t.Errorf("last deploy should be root, got %q", ops.Proxy_.DeployCalls[1].Name)
+	}
+	// Accessory compose up still brings the service up alongside any true accessories.
 	mustPresent(t, ops.Commands, "-p myapp-accessories")
 	mustPresent(t, ops.Commands, "up -d studio")
+	// The accessory override (port mapping for blue_green:false expose) must be applied.
+	mustPresent(t, ops.Commands, "-f conoha-accessories-override.yml")
 }
 
 func TestCollectDeployBlocks_Shape(t *testing.T) {

--- a/cmd/app/deployblocks.go
+++ b/cmd/app/deployblocks.go
@@ -77,3 +77,25 @@ func collectEffectiveAccessories(pf *config.ProjectFile) []string {
 	}
 	return out
 }
+
+// collectFixedExposeBlocks returns expose blocks whose BlueGreen is
+// explicitly false. They live in the accessory compose project but still
+// need a host-port mapping (so the proxy can route to them) and a proxy
+// /deploy call to set the active target. Order: declaration order.
+func collectFixedExposeBlocks(pf *config.ProjectFile) []DeployBlock {
+	var out []DeployBlock
+	for i := range pf.Expose {
+		b := &pf.Expose[i]
+		if b.BlueGreen == nil || *b.BlueGreen {
+			continue
+		}
+		out = append(out, DeployBlock{
+			Label:     b.Label,
+			Service:   b.Service,
+			Port:      b.Port,
+			Host:      b.Host,
+			ProxyName: exposeServiceName(pf.Name, b.Label),
+		})
+	}
+	return out
+}

--- a/cmd/app/override.go
+++ b/cmd/app/override.go
@@ -50,6 +50,31 @@ func composeOverride(app, slot, webService string, webPort int, hasAccessories b
 	return composeOverrideFor(app, slot, []DeployBlock{{Service: webService, Port: webPort}}, hasAccessories)
 }
 
+// composeOverrideForAccessories returns a compose override (YAML) that
+// publishes a host port and attaches .env.server for each fixed expose
+// block (BlueGreen:false). Returns empty string when there are no fixed
+// blocks, so the caller can skip writing/passing the file.
+//
+// Unlike composeOverrideFor, this override does NOT pin a slot-scoped
+// container_name (these containers are slot-agnostic and live in the
+// stable accessory project) and does NOT join the accessories network
+// (they ARE in that project's default network already).
+func composeOverrideForAccessories(app string, fixedBlocks []DeployBlock) string {
+	if len(fixedBlocks) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("services:\n")
+	for _, b := range fixedBlocks {
+		fmt.Fprintf(&sb, "  %s:\n", b.Service)
+		sb.WriteString("    ports:\n")
+		fmt.Fprintf(&sb, "      - \"127.0.0.1:0:%d\"\n", b.Port)
+		sb.WriteString("    env_file:\n")
+		fmt.Fprintf(&sb, "      - /opt/conoha/%s/.env.server\n", app)
+	}
+	return sb.String()
+}
+
 // slotProjectName is the compose -p value for a blue/green slot.
 func slotProjectName(app, slot string) string {
 	return fmt.Sprintf("%s-%s", app, slot)

--- a/cmd/app/remotecmds.go
+++ b/cmd/app/remotecmds.go
@@ -21,10 +21,15 @@ func buildSlotUploadCmd(workDir, _ string) string {
 // expose.service which both flow through ValidateAgainstCompose). At least
 // one service is required — compose would otherwise start every service in
 // the file, including accessories the slot must not own.
+//
+// `--no-deps` is set: cross-service depends_on can drag accessory or
+// blue_green:false expose services into the slot project, where they
+// would start without the override env_file and crash. Slot services
+// reach accessories via the shared `accessories` network instead.
 func buildSlotComposeUp(workDir, project, composeFile, overrideFile string, services []string) string {
 	args := strings.Join(services, " ")
 	return fmt.Sprintf(
-		"cd '%s' && docker compose -p %s -f %s -f %s up -d --build %s",
+		"cd '%s' && docker compose -p %s -f %s -f %s up -d --build --no-deps %s",
 		workDir, project, composeFile, overrideFile, args)
 }
 
@@ -97,11 +102,18 @@ func buildScheduleDrainCmd(workDir, project, app, slot string, drainMs int) stri
 // buildAccessoryUp starts the accessories listed, using a dedicated compose
 // project so they survive slot teardown. WorkDir is the slot's work directory —
 // we read the compose file from there because accessories share the same file.
-func buildAccessoryUp(workDir, project, composeFile string, accessories []string) string {
+// overrideFile is optional (empty string means none); when set it's a path
+// relative to workDir that publishes host ports for blue_green:false expose
+// blocks so the proxy can reach them.
+func buildAccessoryUp(workDir, project, composeFile, overrideFile string, accessories []string) string {
 	args := strings.Join(accessories, " ")
+	overrideArg := ""
+	if overrideFile != "" {
+		overrideArg = fmt.Sprintf("-f %s ", overrideFile)
+	}
 	return fmt.Sprintf(
-		"cd '%s' && docker compose -p %s -f %s up -d %s",
-		workDir, project, composeFile, args)
+		"cd '%s' && docker compose -p %s -f %s %sup -d %s",
+		workDir, project, composeFile, overrideArg, args)
 }
 
 // buildAccessoryExists reports (via shell exit 0/1) whether the accessory project

--- a/cmd/app/remotecmds_test.go
+++ b/cmd/app/remotecmds_test.go
@@ -23,7 +23,7 @@ func TestBuildComposeUp_Slot(t *testing.T) {
 	for _, want := range []string{
 		"cd '/opt/conoha/myapp/abc1234'",
 		"docker compose -p myapp-abc1234 -f compose.yml -f override.yml",
-		"up -d --build web",
+		"up -d --build --no-deps web",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in %s", want, got)
@@ -82,11 +82,27 @@ func TestBuildScheduleDrainCmd(t *testing.T) {
 }
 
 func TestBuildAccessoryUp(t *testing.T) {
-	got := buildAccessoryUp("/opt/conoha/myapp/abc1234", "myapp-accessories", "compose.yml", []string{"db", "redis"})
+	got := buildAccessoryUp("/opt/conoha/myapp/abc1234", "myapp-accessories", "compose.yml", "", []string{"db", "redis"})
 	for _, want := range []string{
 		"docker compose -p myapp-accessories",
 		"-f compose.yml",
 		"up -d db redis",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %s", want, got)
+		}
+	}
+	if strings.Contains(got, "conoha-accessories-override.yml") {
+		t.Errorf("override path leaked when overrideFile=\"\": %s", got)
+	}
+}
+
+func TestBuildAccessoryUp_WithOverride(t *testing.T) {
+	got := buildAccessoryUp("/opt/conoha/myapp/abc1234", "myapp-accessories", "compose.yml", "conoha-accessories-override.yml", []string{"db", "dex"})
+	for _, want := range []string{
+		"-f compose.yml",
+		"-f conoha-accessories-override.yml",
+		"up -d db dex",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in %s", want, got)


### PR DESCRIPTION
Closes #163. (Replaces #167 — same commit rebased onto origin/main to escape an unrelated e2e failure inherited from PR #162.)

Spec §3.1 / §4.5.1 prescribe \`blue_green: false\` for expose blocks that aren't slot-aware. Before this PR such blocks registered fine but received no active_target — the accessory \`up\` didn't apply a host-port mapping, and the deploy state machine skipped them. Net effect: every \`blue_green: false\` expose silently 404'd at the proxy layer, forcing 6 of the 8 samples in \`conoha-cli-app-samples#54\` to use \`blue_green: true\` as a workaround.

## Summary

- New helper \`collectFixedExposeBlocks\` (deployblocks.go) returns blue_green:false blocks as DeployBlocks for downstream port mapping + proxy push.
- New helper \`composeOverrideForAccessories\` (override.go) emits a compose override that publishes \`127.0.0.1:0:<port>\` and attaches \`.env.server\` for each fixed block.
- \`buildAccessoryUp\` accepts an optional \`overrideFile\`; the deploy path writes \`conoha-accessories-override.yml\` and passes it through.
- \`buildSlotComposeUp\` adds \`--no-deps\` so cross-service \`depends_on\` chains in user compose.yml don't drag accessory or fixed-expose services into the slot project (they'd start without the slot override's env_file and crash). Surfaced during gitea smoke when slot-local Dex started without GITEA_OAUTH2_CLIENT_ID and exited with \`invalid config: ID or IDEnv field is required for a client\`.
- After accessory up, deploy state iterates fixed blocks, runs \`docker port <accessoryProj>-<svc>-1\`, and calls \`proxy.Deploy\` with \`DrainMs: 0\` before the slot loop.

## Verified

Smoke against \`conoha-cli-app-samples#76\` (gitea pilot) with spec-compliant \`blue_green: false\`:

\`\`\`
GET https://gitea.<ip>.sslip.io/api/healthz                          → 200
GET https://dex.<ip>.sslip.io/dex/healthz                            → 200
GET https://dex.<ip>.sslip.io/dex/.well-known/openid-configuration   → issuer matches FQDN
\`\`\`

Idempotent re-deploy: gitea slot rotates cleanly; dex (accessory) keeps the same proxy target.

## Test plan

- [x] \`go test ./...\` green
- [x] \`TestRunProxyDeployState_BlueGreenFalseExposeGoesToAccessories\` rewritten — asserts 2 /deploy calls (fixed → root order) + accessory override file applied
- [x] Added \`TestBuildAccessoryUp_WithOverride\`
- [x] Existing \`TestBuildComposeUp_Slot\` and \`TestRunProxyDeployState_TwoBlocks_HappyPath\` updated for \`--no-deps\`
- [x] Manual VPS smoke (HTTP layer) on fresh ConoHa VPS via sslip.io

## Out of scope (separate issues)

- #164 (proxy bind permission on Ubuntu Docker image)
- #165 (UFW blocks 80/443 by default)
- #166 (compose \`environment:\` overrides .env.server values silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)