### PR TITLE
fix(app): connectToApp falls back to conoha.yml name (closes #169)

### DIFF
--- a/cmd/app/connect.go
+++ b/cmd/app/connect.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/crowdy/conoha-cli/cmd/cmdutil"
 	"github.com/crowdy/conoha-cli/internal/api"
+	"github.com/crowdy/conoha-cli/internal/config"
 	"github.com/crowdy/conoha-cli/internal/model"
 	"github.com/crowdy/conoha-cli/internal/prompt"
 	internalssh "github.com/crowdy/conoha-cli/internal/ssh"
@@ -63,12 +64,9 @@ func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
 		return nil, err
 	}
 
-	appName, _ := cmd.Flags().GetString("app-name")
-	if appName == "" {
-		appName, err = prompt.String("App name")
-		if err != nil {
-			return nil, err
-		}
+	appName, err := resolveAppName(cmd)
+	if err != nil {
+		return nil, err
 	}
 	// Legacy-tolerant: connectToApp is reached by logs/stop/restart/status/
 	// rollback/destroy — all read/ops on already-deployed apps. Accepting the
@@ -113,6 +111,24 @@ func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
 		User:        user,
 		ComposeFile: composeFile,
 	}, nil
+}
+
+// resolveAppName picks the app name from --app-name when set, otherwise from
+// conoha.yml in cwd, otherwise via prompt. The cwd fallback matches what
+// init/deploy/rollback already do via LoadProjectFile and keeps the `app …`
+// family consistent — without it, status/destroy/logs/env/reset all surface a
+// confusing "validation error on App name: input required but --no-input is
+// set" when run from a project dir under --no-input.
+func resolveAppName(cmd *cobra.Command) (string, error) {
+	if name, _ := cmd.Flags().GetString("app-name"); name != "" {
+		return name, nil
+	}
+	if pf, err := config.LoadProjectFile(config.ProjectFileName); err == nil {
+		if vErr := pf.Validate(); vErr == nil && pf.Name != "" {
+			return pf.Name, nil
+		}
+	}
+	return prompt.String("App name")
 }
 
 func addAppFlags(cmd *cobra.Command) {

--- a/cmd/app/connect.go
+++ b/cmd/app/connect.go
@@ -116,15 +116,23 @@ func connectToApp(cmd *cobra.Command, args []string) (*appContext, error) {
 // resolveAppName picks the app name from --app-name when set, otherwise from
 // conoha.yml in cwd, otherwise via prompt. The cwd fallback matches what
 // init/deploy/rollback already do via LoadProjectFile and keeps the `app …`
-// family consistent — without it, status/destroy/logs/env/reset all surface a
-// confusing "validation error on App name: input required but --no-input is
-// set" when run from a project dir under --no-input.
+// family consistent — without it, every command that funnels through
+// connectToApp surfaces a confusing "validation error on App name: input
+// required but --no-input is set" when run from a project dir under
+// --no-input.
+//
+// Validate() is required (not just LoadProjectFile error-free): if the YAML
+// parses but the project is malformed (missing hosts, invalid name shape,
+// etc.) we'd rather surface the prompt's --no-input error than smuggle in a
+// half-valid name and let a later code path fail with a vaguer message.
 func resolveAppName(cmd *cobra.Command) (string, error) {
 	if name, _ := cmd.Flags().GetString("app-name"); name != "" {
 		return name, nil
 	}
 	if pf, err := config.LoadProjectFile(config.ProjectFileName); err == nil {
-		if vErr := pf.Validate(); vErr == nil && pf.Name != "" {
+		// Validate() guarantees Name is non-empty and DNS-1123 valid on
+		// success — no extra Name != "" check needed.
+		if pf.Validate() == nil {
 			return pf.Name, nil
 		}
 	}

--- a/cmd/app/connect_test.go
+++ b/cmd/app/connect_test.go
@@ -61,11 +61,18 @@ func TestResolveAppName_FlagWins(t *testing.T) {
 // errored with "validation error on App name: input required but --no-input
 // is set" even from inside the project dir, while init/deploy/rollback
 // happily read the same file.
+//
+// CONOHA_NO_INPUT=1 is set deliberately: the pre-fix code would fall through
+// to prompt.String("App name"), which under --no-input returns the standard
+// ValidationError. So this exact assertion (no error, name == "from-yaml")
+// would have FAILED on the buggy code — making this a real regression
+// guard, not a tautology.
 func TestResolveAppName_FallsBackToProjectFile(t *testing.T) {
 	t.Chdir(t.TempDir())
 	if err := os.WriteFile("conoha.yml", []byte("name: from-yaml\nhosts:\n  - example.local\nweb:\n  service: web\n  port: 80\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("CONOHA_NO_INPUT", "1")
 	got, err := resolveAppName(newAppCmdForTest())
 	if err != nil {
 		t.Fatalf("resolveAppName: %v", err)
@@ -89,13 +96,20 @@ func TestResolveAppName_NoFileNoInputErrors(t *testing.T) {
 	}
 }
 
+// A conoha.yml that parses but fails Validate() for a NON-name reason
+// (here: missing hosts) must still fall through to prompt — we don't want
+// to smuggle in pf.Name when the rest of the project is malformed and a
+// later code path would error with a vaguer message. Picking a non-name
+// validation failure (rather than name: "") is what makes this a real
+// guard for the Validate()-required gate: the pre-fix code went to the
+// prompt unconditionally regardless of pf state, so the only way to
+// distinguish working-as-intended fallthrough from accidental fallthrough
+// is to show that a *valid name* still doesn't leak through when the
+// project as a whole isn't valid.
 func TestResolveAppName_InvalidProjectFileFallsThroughToPrompt(t *testing.T) {
-	// A conoha.yml that fails Validate() must NOT silently override; we'd
-	// rather surface the prompt's --no-input error than smuggle in an empty
-	// or malformed name.
 	dir := t.TempDir()
 	t.Chdir(dir)
-	if err := os.WriteFile(filepath.Join(dir, "conoha.yml"), []byte("name: \"\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "conoha.yml"), []byte("name: looks-valid\nweb:\n  service: web\n  port: 80\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("CONOHA_NO_INPUT", "1")
@@ -104,6 +118,6 @@ func TestResolveAppName_InvalidProjectFileFallsThroughToPrompt(t *testing.T) {
 		t.Fatal("want error when project file is invalid + --no-input")
 	}
 	if !strings.Contains(err.Error(), "input required") {
-		t.Errorf("expected fallthrough to prompt; got: %v", err)
+		t.Errorf("expected fallthrough to prompt (no project leaked through); got: %v", err)
 	}
 }

--- a/cmd/app/connect_test.go
+++ b/cmd/app/connect_test.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -24,5 +27,83 @@ func TestAddAppFlags(t *testing.T) {
 		if f.Shorthand != short {
 			t.Errorf("flag %q shorthand: got %q, want %q", name, f.Shorthand, short)
 		}
+	}
+}
+
+func newAppCmdForTest() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	addAppFlags(cmd)
+	return cmd
+}
+
+func TestResolveAppName_FlagWins(t *testing.T) {
+	// Even with conoha.yml present in cwd, an explicit --app-name beats it.
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("conoha.yml", []byte("name: from-yaml\nhosts:\n  - example.local\nweb:\n  service: web\n  port: 80\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newAppCmdForTest()
+	if err := cmd.Flags().Set("app-name", "from-flag"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveAppName(cmd)
+	if err != nil {
+		t.Fatalf("resolveAppName: %v", err)
+	}
+	if got != "from-flag" {
+		t.Errorf("got %q, want %q", got, "from-flag")
+	}
+}
+
+// Regression for #169: status (and any other command going through
+// connectToApp) must read the project name from conoha.yml when --app-name
+// isn't given and one exists in cwd. Before this fallback, --no-input runs
+// errored with "validation error on App name: input required but --no-input
+// is set" even from inside the project dir, while init/deploy/rollback
+// happily read the same file.
+func TestResolveAppName_FallsBackToProjectFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("conoha.yml", []byte("name: from-yaml\nhosts:\n  - example.local\nweb:\n  service: web\n  port: 80\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveAppName(newAppCmdForTest())
+	if err != nil {
+		t.Fatalf("resolveAppName: %v", err)
+	}
+	if got != "from-yaml" {
+		t.Errorf("got %q, want %q", got, "from-yaml")
+	}
+}
+
+func TestResolveAppName_NoFileNoInputErrors(t *testing.T) {
+	// No conoha.yml in cwd, --app-name empty, --no-input set: prompt must
+	// surface the standard ValidationError rather than silently returning "".
+	t.Chdir(t.TempDir())
+	t.Setenv("CONOHA_NO_INPUT", "1")
+	_, err := resolveAppName(newAppCmdForTest())
+	if err == nil {
+		t.Fatal("want error under --no-input with no conoha.yml; got nil")
+	}
+	if !strings.Contains(err.Error(), "input required but --no-input is set") {
+		t.Errorf("want 'input required' validation error, got: %v", err)
+	}
+}
+
+func TestResolveAppName_InvalidProjectFileFallsThroughToPrompt(t *testing.T) {
+	// A conoha.yml that fails Validate() must NOT silently override; we'd
+	// rather surface the prompt's --no-input error than smuggle in an empty
+	// or malformed name.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "conoha.yml"), []byte("name: \"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CONOHA_NO_INPUT", "1")
+	_, err := resolveAppName(newAppCmdForTest())
+	if err == nil {
+		t.Fatal("want error when project file is invalid + --no-input")
+	}
+	if !strings.Contains(err.Error(), "input required") {
+		t.Errorf("expected fallthrough to prompt; got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`status / destroy / logs / env / reset` all funnel through `connectToApp`, which until now jumped straight to a prompt when `--app-name` was unset. Under `--no-input` (or any non-interactive run) that prompt errors out — even when the user is sitting in a project directory whose `conoha.yml` already names the app. `init / deploy / rollback` don't share this bug because they each call `LoadProjectFile` themselves.

The PR #162 row 7 smoke surfaced it on `app status`; it's filed as #169.

## Change

Extract `resolveAppName(cmd)` on the same precedence as deploy/init: flag → `conoha.yml` (only when `Validate()` passes) → prompt. The prompt fallback path is unchanged, so `--no-input` outside a project dir still fails with the existing `ValidationError`. An invalid `conoha.yml` is treated as no project file — we never silently substitute an empty or malformed name.

## Test plan

- [x] `go test ./...` — green; new tests cover all four branches (flag wins, project-file fallback, no-file + `--no-input` errors, invalid file falls through to prompt).
- [x] `golangci-lint run ./...` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)