### PR TITLE
fix(proxy): grant NET_BIND_SERVICE so :80/:443 bind on stock VPS (closes #164)

### DIFF
--- a/internal/proxy/bootstrap.go
+++ b/internal/proxy/bootstrap.go
@@ -31,13 +31,18 @@ if docker inspect %[4]s >/dev/null 2>&1; then
 fi
 
 echo "==> Starting %[4]s from %[2]s"
-# --network host is required: CLI's app deploy probes slots at
-# http://127.0.0.1:<slot-port>, which only resolves to the slot when the
-# proxy shares the host loopback. Bridge-networked containers would see
-# their own loopback and the probe would fail (spec 2026-04-20 §5 step 10).
+# --network host: CLI's app deploy probes slots at http://127.0.0.1:<slot-port>,
+# which only resolves to the slot when the proxy shares the host loopback.
+# Bridge-networked containers would see their own loopback and the probe
+# would fail (spec 2026-04-20 §5 step 10).
+# --cap-add=NET_BIND_SERVICE: image runs as uid 65532, so binding :80/:443
+# on the host network requires this cap. Without it, stock Ubuntu's
+# net.ipv4.ip_unprivileged_port_start=1024 default makes the proxy crash-loop
+# at boot (#164). DinD's --privileged masks this in CI.
 docker run -d --name %[4]s \
   --restart unless-stopped \
   --network host \
+  --cap-add=NET_BIND_SERVICE \
   -v %[3]s:%[3]s \
   %[2]s \
   run --acme-email=%[1]s
@@ -61,10 +66,13 @@ if docker inspect %[4]s >/dev/null 2>&1; then
 fi
 
 echo "==> Starting new %[4]s from %[2]s"
-# See BootScript for why --network host is required.
+# See BootScript for why --network host and --cap-add=NET_BIND_SERVICE are
+# required. The cap-add must be carried on the reboot path too — an
+# in-place upgrade that drops it would silently regress a working VPS.
 docker run -d --name %[4]s \
   --restart unless-stopped \
   --network host \
+  --cap-add=NET_BIND_SERVICE \
   -v %[3]s:%[3]s \
   %[2]s \
   run --acme-email=%[1]s

--- a/internal/proxy/bootstrap.go
+++ b/internal/proxy/bootstrap.go
@@ -38,7 +38,10 @@ echo "==> Starting %[4]s from %[2]s"
 # --cap-add=NET_BIND_SERVICE: image runs as uid 65532, so binding :80/:443
 # on the host network requires this cap. Without it, stock Ubuntu's
 # net.ipv4.ip_unprivileged_port_start=1024 default makes the proxy crash-loop
-# at boot (#164). DinD's --privileged masks this in CI.
+# at boot (#164). DinD's --privileged masks this in CI. Note: --network host
+# does NOT bypass the bind capability check — the bind syscall still goes
+# through inet_csk_get_port → ns_capable regardless of which netns the
+# container shares — so the cap is independently required.
 docker run -d --name %[4]s \
   --restart unless-stopped \
   --network host \

--- a/internal/proxy/bootstrap_test.go
+++ b/internal/proxy/bootstrap_test.go
@@ -21,6 +21,11 @@ func TestBootScript_ContainsEssentials(t *testing.T) {
 		"ghcr.io/crowdy/conoha-proxy:latest",
 		"--acme-email=ops@example.com",
 		"--name conoha-proxy",
+		// #164: container runs as uid 65532 — without NET_BIND_SERVICE it
+		// can't bind :80/:443 on stock Ubuntu (default
+		// net.ipv4.ip_unprivileged_port_start=1024). DinD masks this with
+		// --privileged. Ship the cap on docker run so production matches.
+		"--cap-add=NET_BIND_SERVICE",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("BootScript missing %q:\n%s", want, s)
@@ -41,6 +46,9 @@ func TestRebootScript_PullsStopsRemovesStarts(t *testing.T) {
 		"docker rm conoha-proxy",
 		"--network host",
 		"--acme-email=ops@example.com",
+		// #164: same cap-add must be on the reboot path so an in-place
+		// upgrade doesn't silently regress a previously-working VPS.
+		"--cap-add=NET_BIND_SERVICE",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("RebootScript missing %q:\n%s", want, s)


### PR DESCRIPTION
## Summary

Reproduced during the PR #162 row 7 smoke. The proxy image runs as a non-root user (uid 65532); paired with `--network host` and Ubuntu's default `net.ipv4.ip_unprivileged_port_start=1024`, it crash-loops at boot with `listen tcp :80: bind: permission denied`, the admin socket never appears, and every CLI call against the proxy surfaces as `Failed to connect to admin port 80`.

DinD hides this — the e2e target runs with `--privileged`, which grants every cap. Real VPSes don't.

## Change

Add `--cap-add=NET_BIND_SERVICE` to the `docker run` in both `BootScript` and `RebootScript` (the reboot path needs it too so an in-place upgrade doesn't silently regress a working VPS).

## Test plan

- [x] `go test ./...` — green; assertions for `--cap-add=NET_BIND_SERVICE` added to both `TestBootScript_ContainsEssentials` and `TestRebootScript_PullsStopsRemovesStarts`.
- [x] `golangci-lint run ./...` — 0 issues.
- [ ] Manual VPS re-smoke after merge: a fresh `proxy boot` should produce a healthy `admin.sock` without the `sysctl ip_unprivileged_port_start=0` workaround that #162's smoke needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)