### PR TITLE
fix(proxy): open 80/443 in UFW so ACME + traffic reach the proxy (closes #165)

### DIFF
--- a/internal/proxy/bootstrap.go
+++ b/internal/proxy/bootstrap.go
@@ -25,6 +25,16 @@ echo "==> Preparing data directory %[3]s"
 mkdir -p %[3]s
 chown 65532:65532 %[3]s
 
+# #165: stock Ubuntu cloud images run UFW with policy DROP and only SSH
+# allowed, so external traffic to :80/:443 — including LE HTTP-01 challenge
+# from the ACME servers — is silently dropped after 'proxy boot'. Open the
+# two ports here. 'command -v ufw' guards images without UFW (the rule add
+# is a no-op then). 'ufw allow' is idempotent.
+if command -v ufw >/dev/null 2>&1; then
+    ufw allow 80/tcp >/dev/null || true
+    ufw allow 443/tcp >/dev/null || true
+fi
+
 if docker inspect %[4]s >/dev/null 2>&1; then
     echo "Container %[4]s already exists. Use 'conoha proxy reboot' to upgrade."
     exit 0
@@ -61,6 +71,13 @@ set -euo pipefail
 
 echo "==> Pulling %[2]s"
 docker pull %[2]s
+
+# Re-assert the UFW rules from BootScript on the reboot path so an in-place
+# upgrade on a VPS that lost UFW state re-establishes them. See #165.
+if command -v ufw >/dev/null 2>&1; then
+    ufw allow 80/tcp >/dev/null || true
+    ufw allow 443/tcp >/dev/null || true
+fi
 
 if docker inspect %[4]s >/dev/null 2>&1; then
     echo "==> Stopping %[4]s"

--- a/internal/proxy/bootstrap.go
+++ b/internal/proxy/bootstrap.go
@@ -30,6 +30,16 @@ chown 65532:65532 %[3]s
 # from the ACME servers — is silently dropped after 'proxy boot'. Open the
 # two ports here. 'command -v ufw' guards images without UFW (the rule add
 # is a no-op then). 'ufw allow' is idempotent.
+#
+# Placement (load-bearing): this snippet runs BEFORE the docker-inspect
+# short-circuit below so a re-run of 'proxy boot' against a VPS where UFW
+# state was flushed (manual reset, snapshot revert) still re-asserts the
+# rules even when the container already exists. Don't "tidy" it past the
+# early-exit.
+#
+# Errors are intentionally swallowed via '|| true': #165 is a best-effort
+# firewall convenience, not a hard prerequisite. A future "ports closed"
+# debug should run 'ufw status' directly rather than relying on this log.
 if command -v ufw >/dev/null 2>&1; then
     ufw allow 80/tcp >/dev/null || true
     ufw allow 443/tcp >/dev/null || true

--- a/internal/proxy/bootstrap_test.go
+++ b/internal/proxy/bootstrap_test.go
@@ -26,6 +26,14 @@ func TestBootScript_ContainsEssentials(t *testing.T) {
 		// net.ipv4.ip_unprivileged_port_start=1024). DinD masks this with
 		// --privileged. Ship the cap on docker run so production matches.
 		"--cap-add=NET_BIND_SERVICE",
+		// #165: stock Ubuntu cloud images run UFW with policy DROP and only
+		// SSH allowed. Without these rules the proxy listens on :80/:443
+		// inside the VPS but external traffic — including LE HTTP-01 — is
+		// dropped. Guard with `command -v ufw` so the same script is a
+		// no-op on images without UFW.
+		"command -v ufw",
+		"ufw allow 80/tcp",
+		"ufw allow 443/tcp",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("BootScript missing %q:\n%s", want, s)
@@ -49,6 +57,12 @@ func TestRebootScript_PullsStopsRemovesStarts(t *testing.T) {
 		// #164: same cap-add must be on the reboot path so an in-place
 		// upgrade doesn't silently regress a previously-working VPS.
 		"--cap-add=NET_BIND_SERVICE",
+		// #165: reboot path keeps the rules idempotent so an in-place
+		// upgrade on a VPS that lost UFW state (manual flush, image
+		// rebuild) re-establishes them.
+		"command -v ufw",
+		"ufw allow 80/tcp",
+		"ufw allow 443/tcp",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("RebootScript missing %q:\n%s", want, s)


### PR DESCRIPTION
## Summary

Reproduced during the PR #162 row 7 smoke (right after #164 unblocked the container). UFW on stock Ubuntu cloud images ships `policy DROP` with only SSH allowed, so traffic to `:80`/`:443` — including the LE HTTP-01 challenge from the ACME servers — gets silently dropped despite the proxy listening on those ports inside the VPS.

## Change

Open both ports in `BootScript` and `RebootScript`, guarded by `command -v ufw` so images without UFW see a no-op. `ufw allow` is idempotent, so reboot just re-asserts the rules — useful if a VPS lost UFW state via a manual flush or image rebuild.

## Test plan

- [x] `go test ./...` — green; assertions for `command -v ufw` + `ufw allow 80/tcp` + `ufw allow 443/tcp` added to both `BootScript` and `RebootScript` tests.
- [x] `golangci-lint run ./...` — 0 issues.
- [ ] Manual VPS re-smoke after merge (and after #164): a fresh `proxy boot` should let LE issue the cert on its first attempt rather than after the ACME backoff window — no more `ufw allow` on the side.

## Stacking

Independent of #172 (#164's NET_BIND_SERVICE cap). Both touch BootScript / RebootScript but the diffs don't overlap (this PR adds lines before `docker run`; #172 adds a flag inside `docker run`). Either order merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)