### PR TITLE
feat(proxy): boot/reboot wait for container healthy (closes #175)

### DIFF
--- a/cmd/proxy/boot.go
+++ b/cmd/proxy/boot.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -40,6 +42,23 @@ var bootCmd = &cobra.Command{
 		if code != 0 {
 			return fmt.Errorf("boot script exited with %d", code)
 		}
+
+		// #175: confirm the container actually came up healthy. `docker run -d`
+		// returns 0 the instant containerd creates the container, well before
+		// the entrypoint has bound any ports — a crash loop is indistinguishable
+		// from a healthy container at this stage. Polling here means same-class
+		// regressions (file caps, sysctl drift, image entrypoint changes) fail
+		// loudly on first run rather than only during a manual log read.
+		waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
+		if waitTimeout > 0 {
+			fmt.Fprintf(os.Stderr, "==> Waiting for proxy to become healthy (up to %s)\n", waitTimeout)
+			// Discard remote stderr noise from the polling curls; healthcheck
+			// errors are already aggregated and surfaced by WaitForHealthy.
+			exec := &proxypkg.SSHExecutor{Client: ctx.Client, Stderr: io.Discard}
+			if hcErr := proxypkg.WaitForHealthy(exec, container, dataDir, waitTimeout, nil, proxypkg.HealthcheckOptions{}); hcErr != nil {
+				return hcErr
+			}
+		}
 		fmt.Fprintln(os.Stderr, "Boot complete.")
 		return nil
 	},
@@ -51,5 +70,6 @@ func init() {
 	bootCmd.Flags().String("image", DefaultImage, "conoha-proxy docker image")
 	bootCmd.Flags().String("data-dir", DefaultDataDir, "host data directory")
 	bootCmd.Flags().String("container", DefaultContainer, "docker container name")
+	bootCmd.Flags().Duration("wait-timeout", 30*time.Second, "max wait for container to report healthy (0 disables the check)")
 	Cmd.AddCommand(bootCmd)
 }

--- a/cmd/proxy/lifecycle.go
+++ b/cmd/proxy/lifecycle.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -57,6 +59,16 @@ var rebootCmd = &cobra.Command{
 		}
 		if code != 0 {
 			return fmt.Errorf("reboot script exited with %d", code)
+		}
+		// Same healthy-gate as boot (#175): a reboot's docker run inherits
+		// every gotcha that boot does, so the same check applies.
+		waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
+		if waitTimeout > 0 {
+			fmt.Fprintf(os.Stderr, "==> Waiting for proxy to become healthy (up to %s)\n", waitTimeout)
+			exec := &proxypkg.SSHExecutor{Client: ctx.Client, Stderr: io.Discard}
+			if hcErr := proxypkg.WaitForHealthy(exec, container, dataDir, waitTimeout, nil, proxypkg.HealthcheckOptions{}); hcErr != nil {
+				return hcErr
+			}
 		}
 		return nil
 	},
@@ -120,6 +132,7 @@ func init() {
 	rebootCmd.Flags().String("image", DefaultImage, "conoha-proxy docker image")
 	rebootCmd.Flags().String("data-dir", DefaultDataDir, "host data directory")
 	rebootCmd.Flags().String("container", DefaultContainer, "docker container name")
+	rebootCmd.Flags().Duration("wait-timeout", 30*time.Second, "max wait for container to report healthy (0 disables the check)")
 
 	for _, c := range []*cobra.Command{startCmd, stopCmd, restartCmd} {
 		addSSHFlags(c)

--- a/cmd/proxy/lifecycle.go
+++ b/cmd/proxy/lifecycle.go
@@ -61,7 +61,10 @@ var rebootCmd = &cobra.Command{
 			return fmt.Errorf("reboot script exited with %d", code)
 		}
 		// Same healthy-gate as boot (#175): a reboot's docker run inherits
-		// every gotcha that boot does, so the same check applies.
+		// every gotcha that boot does, so the same check applies. If
+		// anything, the gate matters MORE on reboot — the previous version
+		// was working, and a silent unhealthy upgrade would mask a real
+		// regression. --wait-timeout=0 is honored but discouraged here.
 		waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
 		if waitTimeout > 0 {
 			fmt.Fprintf(os.Stderr, "==> Waiting for proxy to become healthy (up to %s)\n", waitTimeout)
@@ -70,6 +73,7 @@ var rebootCmd = &cobra.Command{
 				return hcErr
 			}
 		}
+		fmt.Fprintln(os.Stderr, "Reboot complete.")
 		return nil
 	},
 }
@@ -132,7 +136,7 @@ func init() {
 	rebootCmd.Flags().String("image", DefaultImage, "conoha-proxy docker image")
 	rebootCmd.Flags().String("data-dir", DefaultDataDir, "host data directory")
 	rebootCmd.Flags().String("container", DefaultContainer, "docker container name")
-	rebootCmd.Flags().Duration("wait-timeout", 30*time.Second, "max wait for container to report healthy (0 disables the check)")
+	rebootCmd.Flags().Duration("wait-timeout", 30*time.Second, "max wait for container to report healthy (0 disables — discouraged: previous version was working)")
 
 	for _, c := range []*cobra.Command{startCmd, stopCmd, restartCmd} {
 		addSSHFlags(c)

--- a/internal/proxy/healthcheck.go
+++ b/internal/proxy/healthcheck.go
@@ -1,0 +1,140 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// Sleeper is `time.Sleep` in production. Tests inject a no-op or fast-forward
+// implementation so polling-loop assertions don't depend on wall-clock.
+type Sleeper func(time.Duration)
+
+// HealthcheckOptions tunes WaitForHealthy. PollInterval defaults to 1s,
+// StableSamples (consecutive "running" samples required before checking
+// /healthz) defaults to 3.
+type HealthcheckOptions struct {
+	PollInterval  time.Duration
+	StableSamples int
+}
+
+// WaitForHealthy polls the proxy container until both conditions hold:
+//
+//  1. `docker inspect --format '{{.State.Status}}' <container>` returns
+//     `running` for at least StableSamples consecutive samples (defaults
+//     to 3). Anything else — `restarting`, `exited`, missing — resets the
+//     counter, so a crash loop doesn't false-positive on its brief running
+//     windows.
+//  2. `curl --unix-socket <dataDir>/admin.sock http://admin/healthz` returns
+//     `{"status":"ok"}`. Polled only after the stability gate trips, since
+//     the proxy can't serve healthz until it's bound.
+//
+// On timeout the error includes the last 20 lines of `docker logs` so the
+// operator doesn't need a manual SSH round-trip to diagnose. This is the
+// gap that let the bad #172 fix slip through CI: `docker run -d` returned
+// 0 even though the container was crash-looping with "permission denied"
+// on bind. Folding the check into proxy boot itself means same-class
+// regressions (file caps, sysctl drift, image entrypoint changes) fail
+// loudly on first run rather than only during a manual log read.
+func WaitForHealthy(exec Executor, container, dataDir string, timeout time.Duration, sleep Sleeper, opt HealthcheckOptions) error {
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	if opt.PollInterval <= 0 {
+		opt.PollInterval = 1 * time.Second
+	}
+	if opt.StableSamples <= 0 {
+		opt.StableSamples = 3
+	}
+	deadline := time.Now().Add(timeout)
+	healthy := 0
+	lastStatus := "unknown"
+	for {
+		status := dockerInspectStatus(exec, container)
+		lastStatus = status
+		if status == "running" {
+			healthy++
+			if healthy >= opt.StableSamples && healthzOK(exec, dataDir) {
+				return nil
+			}
+		} else {
+			healthy = 0
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		sleep(opt.PollInterval)
+	}
+	logs := dockerLogsTail(exec, container, 20)
+	return fmt.Errorf("conoha-proxy did not become healthy within %s (last container status: %q). "+
+		"Last %d lines of `docker logs %s`:\n%s",
+		timeout, lastStatus, 20, container, indentLines(logs, "  "))
+}
+
+// dockerInspectStatus returns the container's State.Status, or "missing" when
+// the container does not exist. We intentionally don't propagate the inspect
+// error: from the caller's perspective "container exited" and "container was
+// never created" both mean "not running" and the polling loop reacts
+// identically.
+func dockerInspectStatus(exec Executor, container string) string {
+	var out bytes.Buffer
+	cmd := fmt.Sprintf("docker inspect --format '{{.State.Status}}' %s 2>/dev/null", shellQuote(container))
+	if err := exec.Run(cmd, nil, &out); err != nil {
+		return "missing"
+	}
+	return strings.TrimSpace(out.String())
+}
+
+// healthzOK returns true iff the admin socket responds with the expected
+// {"status":"ok"} JSON. A connection error, non-200, or any other body is
+// treated as "not yet healthy" so the caller can keep polling.
+func healthzOK(exec Executor, dataDir string) bool {
+	var out bytes.Buffer
+	cmd := fmt.Sprintf("curl -sf --unix-socket %s/admin.sock http://admin/healthz", dataDir+"")
+	if err := exec.Run(cmd, nil, &out); err != nil {
+		return false
+	}
+	return strings.Contains(out.String(), `"status":"ok"`)
+}
+
+func dockerLogsTail(exec Executor, container string, lines int) string {
+	var out bytes.Buffer
+	cmd := fmt.Sprintf("docker logs --tail %d %s 2>&1", lines, shellQuote(container))
+	_ = exec.Run(cmd, nil, &out)
+	return out.String()
+}
+
+func indentLines(s, prefix string) string {
+	if s == "" {
+		return ""
+	}
+	var out strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(s, "\n"), "\n") {
+		out.WriteString(prefix)
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+	return out.String()
+}
+
+// shellQuote escapes a string for safe single-quoted use on the remote shell.
+// Container names and data-dir paths are already validated at the flag layer,
+// but quoting keeps us safe if those constraints ever relax.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// Compile-time guard: WaitForHealthy must accept an io.Writer-friendly Executor.
+// Keeps refactors of the proxy.Executor signature from silently breaking us.
+var _ = func() Executor {
+	type _exec interface {
+		Run(string, io.Reader, io.Writer) error
+	}
+	var e _exec
+	if e == nil {
+		return nil
+	}
+	return e.(Executor)
+}()

--- a/internal/proxy/healthcheck.go
+++ b/internal/proxy/healthcheck.go
@@ -3,13 +3,22 @@ package proxy
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 )
 
+// logsTailLines is the number of trailing `docker logs` lines included in
+// the timeout error from WaitForHealthy. Defined as a const so the call
+// site and the format string can never desync.
+const logsTailLines = 20
+
 // Sleeper is `time.Sleep` in production. Tests inject a no-op or fast-forward
 // implementation so polling-loop assertions don't depend on wall-clock.
+//
+// Note: not context-aware. A user Ctrl-C still terminates `proxy boot`
+// because Go's default SIGINT handler aborts the process, but graceful
+// shutdown isn't supported. If we ever want context cancellation here,
+// the signature should grow a `context.Context`.
 type Sleeper func(time.Duration)
 
 // HealthcheckOptions tunes WaitForHealthy. PollInterval defaults to 1s,
@@ -67,10 +76,10 @@ func WaitForHealthy(exec Executor, container, dataDir string, timeout time.Durat
 		}
 		sleep(opt.PollInterval)
 	}
-	logs := dockerLogsTail(exec, container, 20)
+	logs := dockerLogsTail(exec, container, logsTailLines)
 	return fmt.Errorf("conoha-proxy did not become healthy within %s (last container status: %q). "+
 		"Last %d lines of `docker logs %s`:\n%s",
-		timeout, lastStatus, 20, container, indentLines(logs, "  "))
+		timeout, lastStatus, logsTailLines, container, indentLines(logs, "  "))
 }
 
 // dockerInspectStatus returns the container's State.Status, or "missing" when
@@ -92,7 +101,11 @@ func dockerInspectStatus(exec Executor, container string) string {
 // treated as "not yet healthy" so the caller can keep polling.
 func healthzOK(exec Executor, dataDir string) bool {
 	var out bytes.Buffer
-	cmd := fmt.Sprintf("curl -sf --unix-socket %s/admin.sock http://admin/healthz", dataDir+"")
+	// shellQuote dataDir as defense-in-depth: --data-dir is user-supplied
+	// at the CLI flag level, and although the existing scripts trust it
+	// untreated, this command runs at a fresh shell layer so quoting here
+	// keeps any future "weird path" surprises from reaching the SSH session.
+	cmd := fmt.Sprintf("curl -sf --unix-socket %s/admin.sock http://admin/healthz", shellQuote(dataDir))
 	if err := exec.Run(cmd, nil, &out); err != nil {
 		return false
 	}
@@ -126,15 +139,10 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// Compile-time guard: WaitForHealthy must accept an io.Writer-friendly Executor.
-// Keeps refactors of the proxy.Executor signature from silently breaking us.
-var _ = func() Executor {
-	type _exec interface {
-		Run(string, io.Reader, io.Writer) error
-	}
-	var e _exec
-	if e == nil {
-		return nil
-	}
-	return e.(Executor)
-}()
+// (No compile-time guard here on purpose: every callsite of Executor — Client
+// in admin.go, SSHExecutor in sshexec.go, the polling helpers above — already
+// fails to compile if proxy.Executor's signature changes, so an extra guard
+// would be redundant. An earlier version added a function-literal "guard"
+// that turned out to be a runtime no-op due to a nil-interface short-circuit;
+// removing it instead of "fixing" it because the protection it nominally
+// offered is already provided by ordinary type checking.)

--- a/internal/proxy/healthcheck_test.go
+++ b/internal/proxy/healthcheck_test.go
@@ -20,7 +20,7 @@ type tick struct {
 
 type fakeExec struct {
 	ticks      []tick
-	idx        int  // advances on inspect calls (each call is "one tick")
+	idx        int // advances on inspect calls (each call is "one tick")
 	logs       string
 	sleepCount int
 }

--- a/internal/proxy/healthcheck_test.go
+++ b/internal/proxy/healthcheck_test.go
@@ -1,0 +1,194 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeExec is a programmable Executor whose responses depend on which class
+// of command is being run (inspect / healthz / logs). The polling structure
+// of WaitForHealthy is "inspect, then maybe healthz" per tick, so the tests
+// shape a slice of `tick`s and consume one per iteration of the loop.
+type tick struct {
+	status   string // "" => simulate inspect failure (container missing)
+	healthOK bool   // healthz returns ok on this tick
+}
+
+type fakeExec struct {
+	ticks      []tick
+	idx        int  // advances on inspect calls (each call is "one tick")
+	logs       string
+	sleepCount int
+}
+
+func (f *fakeExec) sleep(time.Duration) { f.sleepCount++ }
+
+// currentTick is what inspect/healthz observe right now. After the slice is
+// exhausted we keep returning the LAST entry — represents "the world settled
+// into this state and stays there", which makes timeout tests deterministic
+// regardless of how many polling iterations the no-op sleeper allows in.
+func (f *fakeExec) currentTick() tick {
+	if len(f.ticks) == 0 {
+		return tick{} // empty — inspect will return missing
+	}
+	if f.idx < len(f.ticks) {
+		return f.ticks[f.idx]
+	}
+	return f.ticks[len(f.ticks)-1]
+}
+
+func (f *fakeExec) Run(cmd string, _ io.Reader, stdout io.Writer) error {
+	switch {
+	case strings.Contains(cmd, "docker inspect"):
+		t := f.currentTick()
+		f.idx++
+		if t.status == "" {
+			return errors.New("inspect: container missing")
+		}
+		_, _ = fmt.Fprintln(stdout, t.status)
+		return nil
+	case strings.Contains(cmd, "/admin.sock"):
+		// healthz reads the latest tick's healthOK without advancing the
+		// cursor. WaitForHealthy only reaches this branch after the
+		// stability counter trips, i.e. immediately after a successful
+		// "running" inspect — so the previous tick is the relevant one.
+		idx := f.idx - 1
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(f.ticks) {
+			idx = len(f.ticks) - 1
+		}
+		if idx < 0 || !f.ticks[idx].healthOK {
+			return errors.New("healthz failed")
+		}
+		_, _ = io.WriteString(stdout, `{"status":"ok"}`)
+		return nil
+	case strings.Contains(cmd, "docker logs"):
+		_, _ = io.WriteString(stdout, f.logs)
+		return nil
+	default:
+		return fmt.Errorf("fakeExec: unexpected cmd %q", cmd)
+	}
+}
+
+func TestWaitForHealthy_HappyPath(t *testing.T) {
+	// 3 stable running samples + healthz ok on the third.
+	f := &fakeExec{ticks: []tick{
+		{status: "running", healthOK: true},
+		{status: "running", healthOK: true},
+		{status: "running", healthOK: true},
+	}}
+	err := WaitForHealthy(f, "conoha-proxy", "/var/lib/conoha-proxy", 30*time.Second, f.sleep,
+		HealthcheckOptions{PollInterval: time.Millisecond, StableSamples: 3})
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	// Two sleeps between three samples (sleep happens after deadline check
+	// at end of iteration). The third inspect triggers healthz and returns
+	// before the next sleep.
+	if f.sleepCount != 2 {
+		t.Errorf("sleeps: got %d, want 2", f.sleepCount)
+	}
+}
+
+func TestWaitForHealthy_RecoversAfterRestart(t *testing.T) {
+	// Restart loop for two ticks, then stabilizes. Counter must reset on
+	// restart — if it didn't, healthcheck would false-positive on the brief
+	// "running" windows during a crashloop.
+	f := &fakeExec{ticks: []tick{
+		{status: "running"},
+		{status: "restarting"}, // resets counter
+		{status: "running"},
+		{status: "running"},
+		{status: "running", healthOK: true},
+	}}
+	err := WaitForHealthy(f, "conoha-proxy", "/var/lib/conoha-proxy", 30*time.Second, f.sleep,
+		HealthcheckOptions{PollInterval: time.Millisecond, StableSamples: 3})
+	if err != nil {
+		t.Fatalf("want nil after recovery, got %v", err)
+	}
+}
+
+func TestWaitForHealthy_TimesOutOnRestartLoop(t *testing.T) {
+	// Container bounces forever. With a tiny timeout we get a timeout error
+	// containing the last status and the docker logs tail.
+	ticks := make([]tick, 100)
+	for i := range ticks {
+		if i%2 == 0 {
+			ticks[i] = tick{status: "running"}
+		} else {
+			ticks[i] = tick{status: "restarting"}
+		}
+	}
+	f := &fakeExec{
+		ticks: ticks,
+		logs:  "Error: listen tcp :80: bind: permission denied\n",
+	}
+	err := WaitForHealthy(f, "conoha-proxy", "/var/lib/conoha-proxy", 5*time.Millisecond, f.sleep,
+		HealthcheckOptions{PollInterval: time.Millisecond, StableSamples: 3})
+	if err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+	for _, want := range []string{
+		"did not become healthy",
+		"5ms",
+		"Last", // "Last 20 lines of `docker logs ..."
+		"bind: permission denied",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestWaitForHealthy_TimesOutOnHealthzFailure(t *testing.T) {
+	// Container is running but admin socket isn't responding (proxy's HTTP
+	// listener died). Stability gate trips, healthz fails, counter holds —
+	// but healthz keeps failing → timeout.
+	ticks := make([]tick, 100)
+	for i := range ticks {
+		// Explicitly populate — zero-value tick has status="" which the fake
+		// maps to "missing" via the inspect-error branch, defeating this
+		// test's premise.
+		ticks[i].status = "running"
+		ticks[i].healthOK = false
+	}
+	f := &fakeExec{ticks: ticks, logs: "panic in HTTP handler\n"}
+	err := WaitForHealthy(f, "conoha-proxy", "/var/lib/conoha-proxy", 3*time.Millisecond, f.sleep,
+		HealthcheckOptions{PollInterval: time.Millisecond, StableSamples: 3})
+	if err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), `"running"`) {
+		t.Errorf("want last status=running in error; got: %v", err)
+	}
+}
+
+func TestWaitForHealthy_MissingContainer(t *testing.T) {
+	// `docker inspect` errors out (container never started). Status maps to
+	// "missing", counter never trips, eventual timeout.
+	ticks := make([]tick, 100)
+	// All inspect calls fail (status "" => returns error).
+	f := &fakeExec{ticks: ticks, logs: ""}
+	err := WaitForHealthy(f, "conoha-proxy", "/var/lib/conoha-proxy", 2*time.Millisecond, f.sleep,
+		HealthcheckOptions{PollInterval: time.Millisecond, StableSamples: 3})
+	if err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), `"missing"`) {
+		t.Errorf("want last status=missing; got: %v", err)
+	}
+}
+
+func TestShellQuote_HandlesEmbeddedQuote(t *testing.T) {
+	got := shellQuote("a'b")
+	want := `'a'\''b'`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/proxy/healthcheck_test.go
+++ b/internal/proxy/healthcheck_test.go
@@ -114,9 +114,17 @@ func TestWaitForHealthy_RecoversAfterRestart(t *testing.T) {
 	}
 }
 
-func TestWaitForHealthy_TimesOutOnRestartLoop(t *testing.T) {
-	// Container bounces forever. With a tiny timeout we get a timeout error
-	// containing the last status and the docker logs tail.
+func TestWaitForHealthy_TimesOutWhenNeverStable(t *testing.T) {
+	// Container alternates `running`/`restarting` and never holds running
+	// for the StableSamples threshold. With a tiny timeout we get a timeout
+	// error containing the last status and the docker logs tail.
+	//
+	// Naming note: this test does NOT prove the counter resets — that's
+	// what TestWaitForHealthy_RecoversAfterRestart covers. This test only
+	// proves "no consecutive run of length >= StableSamples => timeout".
+	// The earlier name "TimesOutOnRestartLoop" overpromised because the
+	// fake's last-tick cycling means once the slice exhausts, every
+	// subsequent inspect returns the terminal entry forever.
 	ticks := make([]tick, 100)
 	for i := range ticks {
 		if i%2 == 0 {


### PR DESCRIPTION
## Summary

Closes #175. First-line defense against the bug class that let #172 ship broken: `docker run -d` returns 0 before the container's entrypoint has bound any ports, so `proxy boot` reports "Boot complete." even when the container is crash-looping with `bind: permission denied`. Folding a healthy-gate into the CLI itself means same-class regressions (file caps, sysctl drift, image entrypoint changes, kernel default changes) fail loudly on first run.

## Change

New `internal/proxy/healthcheck.go::WaitForHealthy(exec, container, dataDir, timeout, sleeper, opts)`:

- Polls `docker inspect --format '{{.State.Status}}'`. Counts consecutive `running` samples — anything else (`restarting`, `exited`, `missing`) resets, so a crashloop's brief running window doesn't false-positive.
- After 3 consecutive `running`, calls `curl --unix-socket <dataDir>/admin.sock http://admin/healthz` — only `{"status":"ok"}` exits success.
- On timeout returns an error including the last status and the last 20 lines of `docker logs <container>` so the operator doesn't need a manual SSH round-trip to diagnose.

Wired from `cmd/proxy/boot.go` and `cmd/proxy/lifecycle.go::rebootCmd` with `--wait-timeout` (default 30s; 0 disables — handy for e2e or for users who deliberately want fire-and-forget).

## Test plan

- [x] `go test ./...` — green; new tests cover happy path, recovery-after-restart (counter resets correctly so crashloops don't false-positive), restart-loop timeout, healthz-only failure (container running but admin socket dead), and missing container.
- [x] `golangci-lint run ./...` — 0 issues.
- [ ] Manual VPS verification: re-running smoke against this branch with `--wait-timeout` should surface the historical #164/#165 failure modes as `proxy boot` errors directly (with logs included), instead of "Boot complete." → broken curl.

## Why this matters operationally

Without this gate, the only way to know `proxy boot` actually worked was a manual `docker logs` after the fact — exactly what the bad #172 review missed. With this gate, CI's e2e (DinD `--privileged`, where the bug is masked) still passes, but a real-VPS smoke surfaces the issue on the first command. That makes the release-checklist §1 step 3 ("confirm stdout reports `proxy ready`") an automated, mechanical check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)