### PR TITLE
feat(app): status degrades gracefully without conoha.yml (closes #176)

### DIFF
--- a/cmd/app/status.go
+++ b/cmd/app/status.go
@@ -109,9 +109,21 @@ var statusCmd = &cobra.Command{
 		// `<name>-<label>` service names). When it's absent we degrade to
 		// root-only and warn on stderr — useful for monitoring scripts and
 		// recovery on a workstation without the source tree.
+		//
+		// Distinguish "missing" (benign — the documented use case) from
+		// "invalid" (a real bug worth surfacing): an invalid conoha.yml
+		// in cwd is a typo or schema drift the user almost certainly
+		// wants to know about, not silently skip.
 		pf, pfErr := config.LoadProjectFile(config.ProjectFileName)
-		if pfErr != nil || pf.Validate() != nil {
-			fmt.Fprintln(os.Stderr, "warning: no valid conoha.yml in cwd; expose blocks will not be enumerated (root service only)")
+		var degraded bool
+		if pfErr != nil {
+			fmt.Fprintln(os.Stderr, "warning: no conoha.yml in cwd; enumerating root proxy service only")
+			degraded = true
+		} else if vErr := pf.Validate(); vErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: conoha.yml in cwd is invalid (%v); enumerating root proxy service only\n", vErr)
+			degraded = true
+		}
+		if degraded {
 			report, rootErr := collectRootOnlyStatus(admin, ctx.AppName)
 			if rootErr != nil {
 				if format == "json" {
@@ -166,7 +178,11 @@ func collectAppStatus(admin statusClient, pf *config.ProjectFile, warn io.Writer
 	if err != nil {
 		return nil, fmt.Errorf("proxy get %q: %w", pf.Name, err)
 	}
-	r := &appStatusReport{Root: root}
+	// Initialize Expose as a non-nil empty slice so the JSON shape stays
+	// `"expose": []` for projects with zero expose blocks. Matches what
+	// collectRootOnlyStatus emits — keeps consumers from having to special-
+	// case `null` vs `[]`.
+	r := &appStatusReport{Root: root, Expose: []exposeStatusEntry{}}
 	for i := range pf.Expose {
 		b := &pf.Expose[i]
 		name := exposeServiceName(pf.Name, b.Label)

--- a/cmd/app/status.go
+++ b/cmd/app/status.go
@@ -96,24 +96,37 @@ var statusCmd = &cobra.Command{
 			return nil
 		}
 
-		pf, pfErr := config.LoadProjectFile(config.ProjectFileName)
-		if pfErr != nil || pf.Validate() != nil {
-			// JSON consumers need a deterministic failure; table consumers
-			// have already seen compose ps and can live without proxy detail.
-			if format == "json" {
-				if pfErr == nil {
-					pfErr = pf.Validate()
-				}
-				return fmt.Errorf("load conoha.yml: %w", pfErr)
-			}
-			return nil
-		}
-
 		dataDir, _ := cmd.Flags().GetString("data-dir")
 		if dataDir == "" {
 			dataDir = proxy.DefaultDataDir
 		}
 		admin := proxypkg.NewClient(&proxypkg.SSHExecutor{Client: ctx.Client}, proxy.SocketPath(dataDir))
+
+		// #176: status used to bail in JSON mode when conoha.yml was missing
+		// or invalid in cwd, even though the proxy admin API can answer
+		// {root, expose:[]} on its own. Project file is only required to
+		// enumerate the expose-block list (we need the labels to build the
+		// `<name>-<label>` service names). When it's absent we degrade to
+		// root-only and warn on stderr — useful for monitoring scripts and
+		// recovery on a workstation without the source tree.
+		pf, pfErr := config.LoadProjectFile(config.ProjectFileName)
+		if pfErr != nil || pf.Validate() != nil {
+			fmt.Fprintln(os.Stderr, "warning: no valid conoha.yml in cwd; expose blocks will not be enumerated (root service only)")
+			report, rootErr := collectRootOnlyStatus(admin, ctx.AppName)
+			if rootErr != nil {
+				if format == "json" {
+					return rootErr
+				}
+				fmt.Fprintf(os.Stderr, "\n==> Proxy service %q: (error: %v)\n", ctx.AppName, rootErr)
+				return nil
+			}
+			if format == "json" {
+				return renderStatusJSON(os.Stdout, report)
+			}
+			_, _ = fmt.Fprintln(os.Stdout)
+			_, _ = fmt.Fprintln(os.Stdout, "==> Proxy services")
+			return renderStatusTable(os.Stdout, report)
+		}
 
 		report, err := collectAppStatus(admin, pf, os.Stderr)
 		if err != nil {
@@ -131,6 +144,17 @@ var statusCmd = &cobra.Command{
 		_, _ = fmt.Fprintln(os.Stdout, "==> Proxy services")
 		return renderStatusTable(os.Stdout, report)
 	},
+}
+
+// collectRootOnlyStatus returns a status report containing just the root
+// service. Used when conoha.yml isn't available (#176). expose is an empty
+// (non-nil) slice so JSON consumers see `"expose": []` rather than null.
+func collectRootOnlyStatus(admin statusClient, name string) (*appStatusReport, error) {
+	root, err := admin.Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("proxy get %q: %w", name, err)
+	}
+	return &appStatusReport{Root: root, Expose: []exposeStatusEntry{}}, nil
 }
 
 // collectAppStatus fetches root + per-expose proxy services. A Get failure on

--- a/cmd/app/status_test.go
+++ b/cmd/app/status_test.go
@@ -138,6 +138,21 @@ func TestCollectAppStatus_RootOnly(t *testing.T) {
 	if len(r.Expose) != 0 {
 		t.Errorf("Expose = %+v, want empty", r.Expose)
 	}
+	// JSON shape parity with collectRootOnlyStatus (#176): zero-expose
+	// projects must serialize as `"expose": []`, not `null`. Guards
+	// against a future "drop the empty-slice init" refactor that would
+	// silently make this path emit null and break consumers that started
+	// trusting `[]`.
+	if r.Expose == nil {
+		t.Error("Expose should be non-nil empty slice for JSON shape stability")
+	}
+	buf := &bytes.Buffer{}
+	if err := renderStatusJSON(buf, r); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"expose": []`) {
+		t.Errorf("expected `\"expose\": []` in JSON; got:\n%s", buf.String())
+	}
 	if got := admin.calls; len(got) != 1 || got[0] != "myapp" {
 		t.Errorf("calls = %v, want [myapp]", got)
 	}

--- a/cmd/app/status_test.go
+++ b/cmd/app/status_test.go
@@ -71,6 +71,56 @@ func (f *fakeStatusClient) Get(name string) (*proxypkg.Service, error) {
 	return nil, errors.New("fakeStatusClient: unknown service " + name)
 }
 
+// Regression for #176: when conoha.yml is absent or invalid, status must
+// degrade gracefully — query the root by name, return empty (non-nil)
+// expose slice. Before this, status bailed in JSON mode with
+// `load conoha.yml: ... no such file or directory`, which was useless for
+// monitoring scripts running outside the project dir.
+func TestCollectRootOnlyStatus_HappyPath(t *testing.T) {
+	admin := &fakeStatusClient{
+		services: map[string]*proxypkg.Service{
+			"myapp": {Name: "myapp", Phase: proxypkg.PhaseLive},
+		},
+	}
+	r, err := collectRootOnlyStatus(admin, "myapp")
+	if err != nil {
+		t.Fatalf("collectRootOnlyStatus: %v", err)
+	}
+	if r.Root == nil || r.Root.Name != "myapp" {
+		t.Fatalf("root = %+v, want service myapp", r.Root)
+	}
+	if r.Expose == nil {
+		t.Fatal("Expose should be non-nil empty slice — JSON consumers expect [] not null")
+	}
+	if len(r.Expose) != 0 {
+		t.Errorf("Expose = %+v, want empty", r.Expose)
+	}
+	// Verify the JSON shape — `expose: []` not `expose: null`. Stable
+	// contract for parsers that may have started checking this field.
+	buf := &bytes.Buffer{}
+	if err := renderStatusJSON(buf, r); err != nil {
+		t.Fatalf("renderStatusJSON: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"expose": []`) {
+		t.Errorf("JSON missing `\"expose\": []`:\n%s", buf.String())
+	}
+}
+
+func TestCollectRootOnlyStatus_RootMissing(t *testing.T) {
+	// Proxy doesn't know this app at all. Surface that so JSON consumers
+	// can treat it as "service not registered" rather than empty success.
+	admin := &fakeStatusClient{
+		errs: map[string]error{"myapp": errors.New("not found")},
+	}
+	_, err := collectRootOnlyStatus(admin, "myapp")
+	if err == nil {
+		t.Fatal("want error when root not found, got nil")
+	}
+	if !strings.Contains(err.Error(), "myapp") {
+		t.Errorf("error should name the app; got: %v", err)
+	}
+}
+
 func TestCollectAppStatus_RootOnly(t *testing.T) {
 	pf := &config.ProjectFile{Name: "myapp"}
 	admin := &fakeStatusClient{


### PR DESCRIPTION
## Summary

Closes #176. Follow-up to #169. `app status` used to bail in JSON mode with `load conoha.yml: ... no such file or directory` when run outside a project dir — even though the proxy admin API can answer `{root, expose: []}` on its own. The project file is only needed to enumerate the expose-block labels.

## Change

When `conoha.yml` is missing or invalid:

- emit a stderr warning that expose blocks won't be enumerated
- query just the root service by the resolved app name
- return `{root, expose: []}` — stable JSON shape (`expose` is non-nil empty slice so consumers see `[]`, not `null`)

In-project behavior unchanged: full report (root + every expose) when `conoha.yml` is present and valid.

## Use cases this unblocks

- Monitoring / observability cron jobs running outside the source tree.
- Recovery on a fresh workstation that doesn't have the repo checked out.
- Any `--app-name` + server invocation where the user isn't expected to also stage a `conoha.yml` just to query state.

## Test plan

- [x] `go test ./...` — green; new tests cover the root-only path (happy + root-missing) and assert the JSON shape stays `\"expose\": []` (not null).
- [x] `golangci-lint run ./...` — 0 issues.
- [ ] Manual verification: run `cd /tmp && conoha app status --no-input --insecure --app-name <name> --format json <server>` against a deployed app — should emit a single-line stderr warning and a valid JSON document on stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)