### PR TITLE
fix(deploy): pass --env-file to compose so .env.server feeds interpolation (closes #166)

### DIFF
--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -309,7 +309,7 @@ func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 		code, _, _ := ops.Run(check, nil)
 		if code != 0 {
 			fmt.Fprintf(os.Stderr, "==> Starting accessories: %v\n", effectiveAccessories)
-			if err := runRemoteOps(ops, buildAccessoryUp(slotWork, accessoryProjectName(pf.Name), p.ComposeFile, accOverridePath, effectiveAccessories), nil); err != nil {
+			if err := runRemoteOps(ops, buildAccessoryUp(slotWork, accessoryProjectName(pf.Name), p.ComposeFile, accOverridePath, pf.Name, effectiveAccessories), nil); err != nil {
 				return fmt.Errorf("accessory up: %w", err)
 			}
 		}
@@ -345,7 +345,7 @@ func runProxyDeployState(p proxyDeployParams, ops DeployOps) error {
 		services = append(services, b.Service)
 	}
 	fmt.Fprintf(os.Stderr, "==> Building and starting %v in new slot\n", services)
-	if err := runRemoteOps(ops, buildSlotComposeUp(slotWork, slotProjectName(pf.Name, slot), p.ComposeFile, overridePath, services), nil); err != nil {
+	if err := runRemoteOps(ops, buildSlotComposeUp(slotWork, slotProjectName(pf.Name, slot), p.ComposeFile, overridePath, pf.Name, services), nil); err != nil {
 		return fmt.Errorf("compose up (slot): %w", err)
 	}
 

--- a/cmd/app/deploy_ops_test.go
+++ b/cmd/app/deploy_ops_test.go
@@ -226,7 +226,7 @@ func TestRunProxyDeployState_HappyPath_FirstDeploy(t *testing.T) {
 	mustOrdered(t, ops.Commands,
 		"tar xzf",
 		"conoha-override.yml",
-		"docker compose -p myapp-abc1234",
+		"docker compose --env-file '/opt/conoha/myapp/.env.server' -p myapp-abc1234",
 		"docker port",
 		"CURRENT_SLOT",
 		"printf %s 'abc1234'",

--- a/cmd/app/remotecmds.go
+++ b/cmd/app/remotecmds.go
@@ -26,11 +26,19 @@ func buildSlotUploadCmd(workDir, _ string) string {
 // blue_green:false expose services into the slot project, where they
 // would start without the override env_file and crash. Slot services
 // reach accessories via the shared `accessories` network instead.
-func buildSlotComposeUp(workDir, project, composeFile, overrideFile string, services []string) string {
+//
+// `--env-file` points at /opt/conoha/<app>/.env.server so compose's
+// interpolation context (`${KEY:-default}` in the user's compose.yml)
+// sees user-set values from `app env set`. Without this, env_file in the
+// override would lose to compose's `environment:` block at parse time —
+// see #166. `touch` ensures the file exists before compose validates the
+// flag (compose errors on missing --env-file targets).
+func buildSlotComposeUp(workDir, project, composeFile, overrideFile, app string, services []string) string {
 	args := strings.Join(services, " ")
+	envFile := envFilePath(app)
 	return fmt.Sprintf(
-		"cd '%s' && docker compose -p %s -f %s -f %s up -d --build --no-deps %s",
-		workDir, project, composeFile, overrideFile, args)
+		"cd '%s' && touch '%s' && docker compose --env-file '%s' -p %s -f %s -f %s up -d --build --no-deps %s",
+		workDir, envFile, envFile, project, composeFile, overrideFile, args)
 }
 
 // buildDockerPortCmd produces a command that prints the host:port mapping
@@ -105,15 +113,19 @@ func buildScheduleDrainCmd(workDir, project, app, slot string, drainMs int) stri
 // overrideFile is optional (empty string means none); when set it's a path
 // relative to workDir that publishes host ports for blue_green:false expose
 // blocks so the proxy can reach them.
-func buildAccessoryUp(workDir, project, composeFile, overrideFile string, accessories []string) string {
+//
+// `--env-file` mirrors buildSlotComposeUp so accessories' compose.yml gets
+// the same .env.server-aware interpolation context. See #166.
+func buildAccessoryUp(workDir, project, composeFile, overrideFile, app string, accessories []string) string {
 	args := strings.Join(accessories, " ")
 	overrideArg := ""
 	if overrideFile != "" {
 		overrideArg = fmt.Sprintf("-f %s ", overrideFile)
 	}
+	envFile := envFilePath(app)
 	return fmt.Sprintf(
-		"cd '%s' && docker compose -p %s -f %s %sup -d %s",
-		workDir, project, composeFile, overrideArg, args)
+		"cd '%s' && touch '%s' && docker compose --env-file '%s' -p %s -f %s %sup -d %s",
+		workDir, envFile, envFile, project, composeFile, overrideArg, args)
 }
 
 // buildAccessoryExists reports (via shell exit 0/1) whether the accessory project

--- a/cmd/app/remotecmds_test.go
+++ b/cmd/app/remotecmds_test.go
@@ -19,10 +19,11 @@ func TestBuildSlotUploadCmd(t *testing.T) {
 }
 
 func TestBuildComposeUp_Slot(t *testing.T) {
-	got := buildSlotComposeUp("/opt/conoha/myapp/abc1234", "myapp-abc1234", "compose.yml", "override.yml", []string{"web"})
+	got := buildSlotComposeUp("/opt/conoha/myapp/abc1234", "myapp-abc1234", "compose.yml", "override.yml", "myapp", []string{"web"})
 	for _, want := range []string{
 		"cd '/opt/conoha/myapp/abc1234'",
-		"docker compose -p myapp-abc1234 -f compose.yml -f override.yml",
+		"touch '/opt/conoha/myapp/.env.server'",
+		"docker compose --env-file '/opt/conoha/myapp/.env.server' -p myapp-abc1234 -f compose.yml -f override.yml",
 		"up -d --build --no-deps web",
 	} {
 		if !strings.Contains(got, want) {
@@ -82,9 +83,10 @@ func TestBuildScheduleDrainCmd(t *testing.T) {
 }
 
 func TestBuildAccessoryUp(t *testing.T) {
-	got := buildAccessoryUp("/opt/conoha/myapp/abc1234", "myapp-accessories", "compose.yml", "", []string{"db", "redis"})
+	got := buildAccessoryUp("/opt/conoha/myapp/abc1234", "myapp-accessories", "compose.yml", "", "myapp", []string{"db", "redis"})
 	for _, want := range []string{
-		"docker compose -p myapp-accessories",
+		"touch '/opt/conoha/myapp/.env.server'",
+		"docker compose --env-file '/opt/conoha/myapp/.env.server' -p myapp-accessories",
 		"-f compose.yml",
 		"up -d db redis",
 	} {
@@ -98,8 +100,9 @@ func TestBuildAccessoryUp(t *testing.T) {
 }
 
 func TestBuildAccessoryUp_WithOverride(t *testing.T) {
-	got := buildAccessoryUp("/opt/conoha/myapp/abc1234", "myapp-accessories", "compose.yml", "conoha-accessories-override.yml", []string{"db", "dex"})
+	got := buildAccessoryUp("/opt/conoha/myapp/abc1234", "myapp-accessories", "compose.yml", "conoha-accessories-override.yml", "myapp", []string{"db", "dex"})
 	for _, want := range []string{
+		"--env-file '/opt/conoha/myapp/.env.server'",
 		"-f compose.yml",
 		"-f conoha-accessories-override.yml",
 		"up -d db dex",


### PR DESCRIPTION
## Summary

- Closes #166. `compose.yml`'s `environment:` block interpolates `${KEY:-default}` at parse time. Without `--env-file`, compose's interpolation context misses `app env set` values, so `:-default` wins and silently overrides the env_file injection from the slot/accessory override.
- Pass `--env-file /opt/conoha/<app>/.env.server` to docker compose in `buildSlotComposeUp` and `buildAccessoryUp` so interpolation and `env_file:` agree on the same source.
- `touch` guards against a fresh deploy where `.env.server` does not exist yet (compose errors on missing `--env-file` targets).

## Why this layer

Sample-level workarounds (drop offending `KEY=${KEY:-default}` from each compose) require every sample to know about this gotcha and lose the ability to use `app env set` for those keys. CLI-level fix lets samples keep their natural `${VAR:-default}` style and `app env set` works for any key.

The no-proxy mode already does the equivalent via `cat .env.server >> .env` (`cmd/app/deploy.go:147`); this brings proxy mode into parity.

## Follow-up (separate PR)

Once merged, the 8 samples in `crowdy/conoha-cli-app-samples` that carry "do NOT add ..." NOTE blocks (workaround for #166) can be cleaned up — restoring `${VAR:-default}` lines in `environment:` and the env vars they were missing.

## Test plan

- [x] `go test ./...` green
- [ ] Smoke on fresh ConoHa VPS: deploy gitea, run `conoha app env set GITEA__database__PASSWD=<rand>`, redeploy, exec into container and confirm env reflects `<rand>` (previously stuck at compose default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)