### PR TITLE
fix(dns): accept 'uuid' alongside 'id' on domain/record decode (closes #170)

### DIFF
--- a/internal/model/dns.go
+++ b/internal/model/dns.go
@@ -1,5 +1,14 @@
 package model
 
+import "encoding/json"
+
+// Domain represents a DNS zone. The real ConoHa API returns the identifier
+// as `uuid` on /v1/domains, while the field has historically been `id` in
+// internal data flow and on the (mocked) /v1/domains/<id> response.
+//
+// We expose a single `ID` field and accept both shapes on the wire via a
+// custom UnmarshalJSON so callers don't have to know which endpoint
+// surfaces which name (#170).
 type Domain struct {
 	ID          string `json:"id" yaml:"id"`
 	Name        string `json:"name" yaml:"name"`
@@ -10,10 +19,48 @@ type Domain struct {
 	Description string `json:"description" yaml:"description"`
 }
 
+// UnmarshalJSON accepts either `id` or `uuid` for the identifier. The real
+// /v1/domains list response uses `uuid`; the legacy field name `id` is
+// preserved on output so existing JSON consumers / table renderers don't
+// break.
+func (d *Domain) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		ID          string `json:"id"`
+		UUID        string `json:"uuid"`
+		Name        string `json:"name"`
+		Email       string `json:"email"`
+		TTL         int    `json:"ttl"`
+		Serial      int    `json:"serial"`
+		Status      string `json:"status"`
+		Description string `json:"description"`
+	}
+	var w wire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	d.ID = w.ID
+	if d.ID == "" {
+		// Real API returns `uuid` on the list endpoint. Fall through here
+		// when the id slot is empty, but never overwrite a populated id —
+		// some mock fixtures (and possibly future API versions) include
+		// both fields and we treat `id` as canonical.
+		d.ID = w.UUID
+	}
+	d.Name = w.Name
+	d.Email = w.Email
+	d.TTL = w.TTL
+	d.Serial = w.Serial
+	d.Status = w.Status
+	d.Description = w.Description
+	return nil
+}
+
 type DomainsResponse struct {
 	Domains []Domain `json:"domains"`
 }
 
+// Record represents a DNS record. Same `id` vs `uuid` accommodation as
+// Domain (#170): the list endpoint surfaces `uuid` in production.
 type Record struct {
 	ID       string `json:"id" yaml:"id"`
 	Name     string `json:"name" yaml:"name"`
@@ -21,6 +68,33 @@ type Record struct {
 	Data     string `json:"data" yaml:"data"`
 	TTL      int    `json:"ttl" yaml:"ttl"`
 	Priority *int   `json:"priority" yaml:"priority"`
+}
+
+// UnmarshalJSON accepts either `id` or `uuid` for the identifier; see Domain.
+func (r *Record) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		ID       string `json:"id"`
+		UUID     string `json:"uuid"`
+		Name     string `json:"name"`
+		Type     string `json:"type"`
+		Data     string `json:"data"`
+		TTL      int    `json:"ttl"`
+		Priority *int   `json:"priority"`
+	}
+	var w wire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	r.ID = w.ID
+	if r.ID == "" {
+		r.ID = w.UUID
+	}
+	r.Name = w.Name
+	r.Type = w.Type
+	r.Data = w.Data
+	r.TTL = w.TTL
+	r.Priority = w.Priority
+	return nil
 }
 
 type RecordsResponse struct {

--- a/internal/model/dns_test.go
+++ b/internal/model/dns_test.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Real ConoHa /v1/domains list endpoint returns identifiers as `uuid`.
+// Before #170 the struct only declared `json:"id"`, so the entire ID slot
+// came back empty and the documented `dns record add --domain-id <id>`
+// flow was unusable. Lock in the wire-shape contract here.
+func TestDomain_UnmarshalAcceptsUUID(t *testing.T) {
+	in := []byte(`{
+		"uuid": "6bb9771f-dd23-451b-ad9a-1b67298b85b2",
+		"name": "example.com.",
+		"email": "admin@example.com",
+		"ttl": 3600,
+		"serial": 1234567890,
+		"status": "ACTIVE"
+	}`)
+	var d Domain
+	if err := json.Unmarshal(in, &d); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if d.ID != "6bb9771f-dd23-451b-ad9a-1b67298b85b2" {
+		t.Errorf("ID = %q, want UUID populated from `uuid` field", d.ID)
+	}
+	if d.Name != "example.com." {
+		t.Errorf("Name = %q", d.Name)
+	}
+}
+
+// The legacy field name `id` must keep working — both because mock API
+// servers in unit tests use it and because some endpoints (e.g. the
+// /v1/domains/<id> GET) may still return it. `id` takes precedence over
+// `uuid` when both are present so a mixed-mode response decodes
+// deterministically.
+func TestDomain_UnmarshalPrefersIDOverUUID(t *testing.T) {
+	in := []byte(`{"id": "explicit-id", "uuid": "fallback-uuid", "name": "example.com."}`)
+	var d Domain
+	if err := json.Unmarshal(in, &d); err != nil {
+		t.Fatal(err)
+	}
+	if d.ID != "explicit-id" {
+		t.Errorf("ID = %q, want explicit-id (id beats uuid when both present)", d.ID)
+	}
+}
+
+// Marshalling preserves the legacy `id` field name so existing JSON
+// consumers and table renderers don't see a shape change.
+func TestDomain_MarshalKeepsIDFieldName(t *testing.T) {
+	d := Domain{ID: "domain-1", Name: "example.com.", TTL: 3600}
+	out, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{`"id":"domain-1"`, `"name":"example.com."`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("marshal missing %q in %s", want, got)
+		}
+	}
+	if strings.Contains(got, `"uuid":`) {
+		t.Errorf("marshal must not emit `uuid` (legacy `id` is the public field): %s", got)
+	}
+}
+
+func TestRecord_UnmarshalAcceptsUUID(t *testing.T) {
+	in := []byte(`{
+		"uuid": "d876cf43-4635-429a-8a35-2e9f5ec4c2a8",
+		"name": "rc.example.com.",
+		"type": "A",
+		"data": "203.0.113.10",
+		"ttl": 60
+	}`)
+	var r Record
+	if err := json.Unmarshal(in, &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != "d876cf43-4635-429a-8a35-2e9f5ec4c2a8" {
+		t.Errorf("ID = %q, want UUID populated", r.ID)
+	}
+	if r.Type != "A" || r.TTL != 60 {
+		t.Errorf("decoded fields wrong: %+v", r)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #170. The real ConoHa DNS API returns identifiers as `uuid`, but the struct only declared `json:"id"` — the entire ID slot came back empty:

```
$ conoha dns domain list --format json
[{ "id": "", "name": "example.com.", "ttl": 3600 }, ...]
```

That broke the documented `proxy boot` → `dns record add --domain-id …` flow in `docs/release-checklist.md §1 step 2`. Users had to hit the raw DNS API as a side-channel just to pull the UUID. Surfaced during the PR #162 row 7 manual smoke.

## Change

Custom `UnmarshalJSON` on `Domain` and `Record`. Reads either field on the wire; `id` wins when both are present, which keeps the existing mock fixtures in `dns_test.go` (and the singular `/v1/domains/<id>` shape they reflect) decoding correctly, and pins `id` as the canonical name.

Marshalling is unchanged: outgoing JSON still uses `id` so JSON consumers and table renderers don't see a shape change.

## Test plan

- [x] `go test ./...` — green; existing `id`-shaped fixtures in `internal/api/dns_test.go` still pass, new `internal/model/dns_test.go` covers `uuid` input, `id`-beats-`uuid` precedence, and outgoing-JSON shape stability.
- [x] `golangci-lint run ./...` — 0 issues.
- [ ] Manual: `conoha dns domain list --format json` against the live API now shows populated `id` values (matching what raw `curl` returns under `uuid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)