### PR TITLE
chore(release): mark RC tags as prerelease + skip brew/scoop on RC

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,14 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+release:
+  # `auto` detects pre-release from the tag suffix (-rc, -alpha, -beta, -pre)
+  # and marks the GitHub release as pre-release. Combined with the
+  # `skip_upload: auto` settings on brews/scoops below, this gives us the
+  # release-checklist's "RC → soak → final" workflow without polluting the
+  # public Homebrew/Scoop channels with release-candidate builds.
+  prerelease: auto
+
 brews:
   - repository:
       owner: crowdy
@@ -31,6 +39,9 @@ brews:
     homepage: "https://crowdy.github.io/conoha-cli-pages/"
     description: "CLI tool for ConoHa VPS3 API"
     license: "Apache-2.0"
+    # Skip the Homebrew tap update for pre-release tags (RC/alpha/beta).
+    # Final tags continue to publish normally.
+    skip_upload: auto
 
 scoops:
   - repository:
@@ -41,6 +52,8 @@ scoops:
     homepage: "https://crowdy.github.io/conoha-cli-pages/"
     description: "CLI tool for ConoHa VPS3 API"
     license: "Apache-2.0"
+    # Skip the Scoop bucket update for pre-release tags. Same rationale as brews.
+    skip_upload: auto
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

Prep for the project's first actually-followed RC tag (v0.7.0-rc1). The release-checklist describes a "RC → soak → final" workflow but the goreleaser config has no prerelease handling — pushing an RC tag today would publish it to the public Homebrew tap and Scoop bucket as if it were a stable release.

## Change

- `release.prerelease: auto` — goreleaser detects pre-release from the tag suffix (`-rc`, `-alpha`, `-beta`, `-pre`) and marks the GitHub release accordingly.
- `skip_upload: auto` on `brews:` and `scoops:` — skip those publishing steps when the release is a pre-release.

Final tags (no suffix) keep publishing to all three sinks unchanged.

## Test plan

- [x] `golangci-lint run ./...` — N/A (config only).
- [x] `go test ./...` — green (config only, no code change).
- [ ] Verified by the next RC push: `v0.7.0-rc1` should produce a GitHub pre-release with no Homebrew/Scoop side-effects, and the subsequent `v0.7.0` should publish normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)