### PR TITLE
feat(server/create): pre-flight validate --security-group (closes #186)

### DIFF
--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -69,6 +69,16 @@ var createCmd = &cobra.Command{
 		adminPass, _ := cmd.Flags().GetString("admin-pass")
 		sgNames, _ := cmd.Flags().GetStringArray("security-group")
 
+		// Pre-flight: validate explicit --security-group names exist in tenant (#186).
+		// Skipped when sgNames is empty: the preset path validates inside resolvePreset,
+		// and the interactive path picks from the API list (already valid).
+		if len(sgNames) > 0 {
+			networkAPI := api.NewNetworkAPI(client)
+			if err := validateSecurityGroupNames(networkAPI, sgNames); err != nil {
+				return err
+			}
+		}
+
 		forName, _ := cmd.Flags().GetString("for")
 		if forName != "" {
 			imageAPI := api.NewImageAPI(client)

--- a/cmd/server/preset.go
+++ b/cmd/server/preset.go
@@ -102,7 +102,7 @@ func resolvePreset(
 		}
 	}
 	if len(sgs) == 0 {
-		if vErr := validatePresetSecurityGroups(networkAPI, spec.SecurityGroups); vErr != nil {
+		if vErr := validateSecurityGroupNames(networkAPI, spec.SecurityGroups); vErr != nil {
 			err = vErr
 			return
 		}
@@ -111,11 +111,14 @@ func resolvePreset(
 	return
 }
 
-// validatePresetSecurityGroups returns nil if every name in want exists in
+// validateSecurityGroupNames returns nil if every name in want exists in
 // the tenant's security-group list. On a missing entry it returns an error
 // listing the missing names plus the actual SG list, so the operator can
 // self-diagnose without rerunning `conoha server list-sg`.
-func validatePresetSecurityGroups(networkAPI *api.NetworkAPI, want []string) error {
+//
+// Used by both the preset path (preset.SecurityGroups) and the explicit
+// --security-group flag path on `server create` (#186).
+func validateSecurityGroupNames(networkAPI *api.NetworkAPI, want []string) error {
 	sgs, err := networkAPI.ListSecurityGroups()
 	if err != nil {
 		return fmt.Errorf("listing security groups: %w", err)
@@ -139,6 +142,6 @@ func validatePresetSecurityGroups(networkAPI *api.NetworkAPI, want []string) err
 		return nil
 	}
 	sort.Strings(names)
-	return fmt.Errorf("preset security groups not found: %s (available: %s)",
+	return fmt.Errorf("security groups not found: %s (available: %s)",
 		strings.Join(missing, ", "), strings.Join(names, ", "))
 }

--- a/cmd/server/preset_test.go
+++ b/cmd/server/preset_test.go
@@ -62,7 +62,7 @@ func TestPresetRegistry_HasProxy(t *testing.T) {
 	}
 }
 
-func TestValidatePresetSecurityGroups_AllPresent(t *testing.T) {
+func TestValidateSecurityGroupNames_AllPresent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/v2.0/security-groups") {
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -85,12 +85,12 @@ func TestValidatePresetSecurityGroups_AllPresent(t *testing.T) {
 	networkAPI := api.NewNetworkAPI(client)
 
 	want := []string{"default", "IPv4v6-SSH", "IPv4v6-Web", "IPv4v6-ICMP"}
-	if err := validatePresetSecurityGroups(networkAPI, want); err != nil {
+	if err := validateSecurityGroupNames(networkAPI, want); err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
 }
 
-func TestValidatePresetSecurityGroups_Missing(t *testing.T) {
+func TestValidateSecurityGroupNames_Missing(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -107,7 +107,7 @@ func TestValidatePresetSecurityGroups_Missing(t *testing.T) {
 	networkAPI := api.NewNetworkAPI(client)
 
 	want := []string{"default", "IPv4v6-SSH", "IPv4v6-Web", "IPv4v6-ICMP"}
-	err := validatePresetSecurityGroups(networkAPI, want)
+	err := validateSecurityGroupNames(networkAPI, want)
 	if err == nil {
 		t.Fatal("expected error for missing SGs, got nil")
 	}
@@ -124,7 +124,7 @@ func TestValidatePresetSecurityGroups_Missing(t *testing.T) {
 	}
 }
 
-func TestValidatePresetSecurityGroups_APIError(t *testing.T) {
+func TestValidateSecurityGroupNames_APIError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 		_, _ = w.Write([]byte(`{"error":"boom"}`))
@@ -135,7 +135,7 @@ func TestValidatePresetSecurityGroups_APIError(t *testing.T) {
 	client := &api.Client{HTTP: ts.Client(), Token: "fake-token", TenantID: "tenant-1"}
 	networkAPI := api.NewNetworkAPI(client)
 
-	err := validatePresetSecurityGroups(networkAPI, []string{"default"})
+	err := validateSecurityGroupNames(networkAPI, []string{"default"})
 	if err == nil {
 		t.Fatal("expected error from 500 response, got nil")
 	}


### PR DESCRIPTION
## Summary

- `conoha server create --security-group X` 가 존재하지 않는 SG 이름이면 ConoHa CreateServer API 호출 시점에 일반적인 API 에러로 실패했음. PR #184 가 도입한 \`validatePresetSecurityGroups\` 는 preset 경로(\`--for proxy\`)에서만 사전 검증함.
- 동일 함수를 explicit \`--security-group\` 플래그 경로에서도 재사용해 사전 검증을 추가. 미존재 SG 시 flavor/image/volume 선택 이전에 명확한 에러(\"available: ...\" 목록 포함)로 종료.
- 일반화에 맞춰 \`validatePresetSecurityGroups\` → \`validateSecurityGroupNames\` 리네임, 에러 메시지의 \"preset\" 접두 제거.

## Behavior

| 시나리오 | ListSecurityGroups 호출 |
|---|---|
| \`--security-group X\` (단독) | 1회 (신규) |
| \`--for proxy\` (단독) | 1회 (preset 검증 — 기존) |
| \`--for proxy --security-group X\` | 1회 (explicit 검증; preset SG 미사용이므로 preset 검증 skip) |
| 인터랙티브 (플래그 없음) | 1회 (selectSecurityGroups — 기존) |

새 검증은 \`sgNames\` 가 비어있을 때만 skip 되므로 preset 단독/인터랙티브 경로에서 중복 호출 없음.

## Test plan

- [x] \`go test ./cmd/server/...\` — 기존 \`TestValidate{Preset→}SecurityGroupNames_*\` 3건 모두 통과
- [x] \`go test ./...\` — 회귀 없음
- [x] \`go build ./...\`
- [ ] (수동) \`conoha server create --name x --security-group bogus\` 가 CreateServer 이전에 \"security groups not found: bogus (available: ...)\" 로 실패하는지 VPS에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)