### PR TITLE
build: install as 'conoha' instead of 'conoha-cli'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ build:
 	go build $(LDFLAGS) -o $(BINARY) .
 
 install:
-	go install $(LDFLAGS) .
+	@GOBIN_DIR="$$(go env GOBIN)"; \
+	if [ -z "$$GOBIN_DIR" ]; then GOBIN_DIR="$$(go env GOPATH)/bin"; fi; \
+	mkdir -p "$$GOBIN_DIR"; \
+	go build $(LDFLAGS) -o "$$GOBIN_DIR/$(BINARY)" . && \
+	echo "installed: $$GOBIN_DIR/$(BINARY)"
 
 test:
 	go test ./... -v


### PR DESCRIPTION
## Summary
- `make install` was producing `conoha-cli` in `$GOBIN` instead of `conoha`, because `go install` uses the module directory name and ignores `BINARY := conoha`.
- Switch the `install` target to `go build -o "$GOBIN_DIR/$(BINARY)" .` so the installed binary name matches what `make build` produces and what users expect on `PATH`.
- Falls back to `$(go env GOPATH)/bin` when `GOBIN` is unset; creates the directory if missing; preserves existing `LDFLAGS` (version stamping).

## Test plan
- [x] `make install` produces `conoha` (not `conoha-cli`) in `GOBIN`
- [x] Installed binary reports the expected version (`v0.7.1-…`)
- [x] `make build` and `make test` unchanged
- [x] `go test ./...` and `golangci-lint run ./...` pass (pre-push hook)