### PR TITLE
fix(output): dereference pointer fields in table/csv (closes #193)

### DIFF
--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -62,7 +62,7 @@ func (f *CSVFormatter) Format(w io.Writer, data any) error {
 		}
 		record := make([]string, row.NumField())
 		for j := 0; j < row.NumField(); j++ {
-			record[j] = fmt.Sprintf("%v", row.Field(j).Interface())
+			record[j] = formatFieldValue(row.Field(j))
 		}
 		if err := writer.Write(record); err != nil {
 			return err

--- a/internal/output/fieldfmt.go
+++ b/internal/output/fieldfmt.go
@@ -1,0 +1,20 @@
+package output
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// formatFieldValue renders a struct field value for tabular formatters
+// (table/csv). It dereferences pointer values so that *int / *string fields
+// display the underlying value rather than the pointer address (#193).
+// nil pointers render as the empty string.
+func formatFieldValue(v reflect.Value) string {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+	return fmt.Sprintf("%v", v.Interface())
+}

--- a/internal/output/fieldfmt.go
+++ b/internal/output/fieldfmt.go
@@ -10,7 +10,7 @@ import (
 // display the underlying value rather than the pointer address (#193).
 // nil pointers render as the empty string.
 func formatFieldValue(v reflect.Value) string {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return ""
 		}

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -211,6 +211,63 @@ func TestTableFormatterSingleStructPointer(t *testing.T) {
 	}
 }
 
+// #193: *int and *string fields must render as their dereferenced value,
+// not as a pointer address, in table and csv output. nil pointers render
+// as empty strings.
+func TestTableFormatterPointerFields(t *testing.T) {
+	type rowWithPtrs struct {
+		Name string  `json:"name"`
+		Min  *int    `json:"min"`
+		Max  *int    `json:"max"`
+		Note *string `json:"note"`
+	}
+	min, max := 53, 5353
+	note := "dns"
+	data := []rowWithPtrs{
+		{Name: "a", Min: &min, Max: &max, Note: &note},
+		{Name: "b", Min: nil, Max: nil, Note: nil},
+	}
+
+	var buf bytes.Buffer
+	if err := (&TableFormatter{}).Format(&buf, data); err != nil {
+		t.Fatalf("Format() error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "53") || !strings.Contains(out, "5353") || !strings.Contains(out, "dns") {
+		t.Errorf("expected dereferenced values 53/5353/dns, got: %s", out)
+	}
+	if strings.Contains(out, "0x") {
+		t.Errorf("output contains pointer-like substring (0x...), got: %s", out)
+	}
+}
+
+func TestCSVFormatterPointerFields(t *testing.T) {
+	type rowWithPtrs struct {
+		Name string `json:"name"`
+		Min  *int   `json:"min"`
+	}
+	min := 7
+	data := []rowWithPtrs{
+		{Name: "a", Min: &min},
+		{Name: "b", Min: nil},
+	}
+
+	var buf bytes.Buffer
+	if err := (&CSVFormatter{}).Format(&buf, data); err != nil {
+		t.Fatalf("Format() error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "a,7") {
+		t.Errorf("expected 'a,7' in csv, got: %s", out)
+	}
+	if !strings.Contains(out, "b,\n") && !strings.HasSuffix(strings.TrimRight(out, "\n"), "b,") {
+		t.Errorf("expected nil pointer to render as empty field, got: %q", out)
+	}
+	if strings.Contains(out, "0x") {
+		t.Errorf("csv output contains pointer-like substring, got: %s", out)
+	}
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		format string

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -64,7 +64,7 @@ func (f *TableFormatter) Format(w io.Writer, data any) error {
 		}
 		fields := make([]string, row.NumField())
 		for j := 0; j < row.NumField(); j++ {
-			fields[j] = fmt.Sprintf("%v", row.Field(j).Interface())
+			fields[j] = formatFieldValue(row.Field(j))
 		}
 		if _, err := fmt.Fprintln(tw, strings.Join(fields, "\t")); err != nil {
 			return err


### PR DESCRIPTION
## Summary

- `conoha network sgr list/show` printed `port_range_min`/`port_range_max` as Go pointer addresses (e.g. `0x3f95...`) instead of the underlying int value, because the table/csv formatters used `fmt.Sprintf(\"%v\", ...)` directly on a `reflect.Value.Interface()` for `*int` fields.
- Add `formatFieldValue` helper that dereferences pointer fields (and renders nil as empty string), used by both the table and csv formatters.

JSON output was already correct (the standard `encoding/json` dereferences pointers), so this only affects table/csv.

## Test plan

- [x] `go test ./internal/output/...` — new tests `TestTableFormatterPointerFields` / `TestCSVFormatterPointerFields` pass; existing tests remain green
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — clean
- [ ] Live verify: `conoha network sgr create --port-min 53 --port-max 53 ...` then `conoha network sgr list` shows `53` instead of `0x...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)