### PR TITLE
fix(network): sg show/delete accept name as well as ID (closes #194)

### DIFF
--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -308,7 +308,7 @@ func init() {
 	}
 
 	sgShowCmd := &cobra.Command{
-		Use:   "show <id>",
+		Use:   "show <id|name>",
 		Short: "Show security group details",
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -316,11 +316,17 @@ func init() {
 			if err != nil {
 				return err
 			}
-			sg, err := api.NewNetworkAPI(client).GetSecurityGroup(args[0])
+			netAPI := api.NewNetworkAPI(client)
+			sg, err := netAPI.FindSecurityGroup(args[0])
 			if err != nil {
 				return err
 			}
-			return cmdutil.FormatOutput(cmd, sg)
+			// Re-fetch by ID to include rules (list endpoint may return abbreviated form).
+			full, err := netAPI.GetSecurityGroup(sg.ID)
+			if err != nil {
+				return err
+			}
+			return cmdutil.FormatOutput(cmd, full)
 		},
 	}
 
@@ -346,11 +352,27 @@ func init() {
 	_ = sgCreateCmd.MarkFlagRequired("name")
 
 	sgDeleteCmd := &cobra.Command{
-		Use:   "delete <id>",
+		Use:   "delete <id|name>",
 		Short: "Delete a security group",
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ok, err := prompt.Confirm(fmt.Sprintf("Delete security group %s?", args[0]))
+			client, err := cmdutil.NewClient(cmd)
+			if err != nil {
+				return err
+			}
+			netAPI := api.NewNetworkAPI(client)
+			// Resolve name → ID upfront (#194). Passing a name to the delete
+			// endpoint otherwise yields a confusing HTTP 405 from the
+			// upstream OpenStack API.
+			sg, err := netAPI.FindSecurityGroup(args[0])
+			if err != nil {
+				return err
+			}
+			label := sg.Name
+			if label == "" {
+				label = sg.ID
+			}
+			ok, err := prompt.Confirm(fmt.Sprintf("Delete security group %q (%s)?", label, sg.ID))
 			if err != nil {
 				return err
 			}
@@ -358,14 +380,10 @@ func init() {
 				fmt.Fprintln(os.Stderr, "Cancelled.")
 				return nil
 			}
-			client, err := cmdutil.NewClient(cmd)
-			if err != nil {
+			if err := netAPI.DeleteSecurityGroup(sg.ID); err != nil {
 				return err
 			}
-			if err := api.NewNetworkAPI(client).DeleteSecurityGroup(args[0]); err != nil {
-				return err
-			}
-			fmt.Fprintf(os.Stderr, "Security group %s deleted\n", args[0])
+			fmt.Fprintf(os.Stderr, "Security group %s deleted\n", sg.ID)
 			return nil
 		},
 	}

--- a/internal/api/network.go
+++ b/internal/api/network.go
@@ -283,17 +283,27 @@ func (a *NetworkAPI) RemoveServerSecurityGroup(serverID, sgName string) error {
 	return nil
 }
 
-func (a *NetworkAPI) resolveSecurityGroupID(name string) (string, error) {
+// FindSecurityGroup looks up a security group by either its UUID or name.
+// Used by commands that accept "<id|name>" arguments (sg show / sg delete).
+func (a *NetworkAPI) FindSecurityGroup(nameOrID string) (*model.SecurityGroup, error) {
 	sgs, err := a.ListSecurityGroups()
+	if err != nil {
+		return nil, err
+	}
+	for i := range sgs {
+		if sgs[i].ID == nameOrID || sgs[i].Name == nameOrID {
+			return &sgs[i], nil
+		}
+	}
+	return nil, fmt.Errorf("security group not found: %s", nameOrID)
+}
+
+func (a *NetworkAPI) resolveSecurityGroupID(name string) (string, error) {
+	sg, err := a.FindSecurityGroup(name)
 	if err != nil {
 		return "", err
 	}
-	for _, sg := range sgs {
-		if sg.Name == name || sg.ID == name {
-			return sg.ID, nil
-		}
-	}
-	return "", fmt.Errorf("security group not found: %s", name)
+	return sg.ID, nil
 }
 
 // AttachPort attaches a port to a server (uses compute API).

--- a/internal/api/network_test.go
+++ b/internal/api/network_test.go
@@ -478,6 +478,50 @@ func TestSecurityGroupGetSecurityGroup(t *testing.T) {
 	}
 }
 
+// #194: sg delete needs name→ID resolution. FindSecurityGroup is the
+// shared helper used by both `sg show` and `sg delete`.
+func TestSecurityGroupFindSecurityGroup(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"security_groups": []map[string]any{
+				{"id": "sg-uuid-1", "name": "web", "description": "Web SG"},
+				{"id": "sg-uuid-2", "name": "db", "description": "DB SG"},
+			},
+		})
+	}))
+	defer ts.Close()
+	t.Setenv("CONOHA_ENDPOINT", ts.URL)
+
+	api := NewNetworkAPI(newTestClient(ts))
+
+	t.Run("by name", func(t *testing.T) {
+		sg, err := api.FindSecurityGroup("web")
+		if err != nil {
+			t.Fatalf("FindSecurityGroup(name) error: %v", err)
+		}
+		if sg.ID != "sg-uuid-1" {
+			t.Errorf("expected ID 'sg-uuid-1', got %q", sg.ID)
+		}
+	})
+
+	t.Run("by id", func(t *testing.T) {
+		sg, err := api.FindSecurityGroup("sg-uuid-2")
+		if err != nil {
+			t.Fatalf("FindSecurityGroup(id) error: %v", err)
+		}
+		if sg.Name != "db" {
+			t.Errorf("expected name 'db', got %q", sg.Name)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		if _, err := api.FindSecurityGroup("nonexistent"); err == nil {
+			t.Fatal("expected error for unknown name/ID")
+		}
+	})
+}
+
 func TestSecurityGroupCreateSecurityGroup(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {


### PR DESCRIPTION
## Summary

- \`conoha network sg delete <name>\` returned an HTTP 405 from the upstream OpenStack endpoint because the CLI passed the literal name where the API expects a UUID. Other commands (e.g., \`server delete <name|id>\`) already accept either; this aligns sg show/delete with that.
- New \`NetworkAPI.FindSecurityGroup(nameOrID)\` helper, used by both \`sg show\` and \`sg delete\`. The existing internal \`resolveSecurityGroupID\` now delegates to it.
- \`sg show\` re-fetches by ID after the lookup so the rules array is included (list endpoint can return abbreviated form).
- The \`sg delete\` confirm prompt now shows both name and ID, and accepts an exact name match (no fuzzy resolution).

## Test plan

- [x] \`go test ./internal/api/... -run Find\` — new \`TestSecurityGroupFindSecurityGroup\` covers by-name, by-id, not-found
- [x] \`go test ./...\` — full suite green
- [ ] Live verify: \`conoha network sg create --name temp-sg && conoha network sg delete temp-sg\` succeeds (no 405)
- [ ] Live verify: \`conoha network sg show temp-sg\` returns details

🤖 Generated with [Claude Code](https://claude.com/claude-code)