### PR TITLE
feat(server/create): refuse g2d-* flavors with a clear error (closes #196)

### DIFF
--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -104,6 +104,18 @@ var createCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("flavor %q not found: %w", flavorID, err)
 			}
+			// Refuse built-in-disk (g2d-*) flavors up front (#196). They require
+			// a server-side block_device_mapping payload the CLI does not
+			// currently build; the upstream API would otherwise return a
+			// confusing HTTP 400 ("block_device_mapping required") well after
+			// the create-summary prompt.
+			if isUnsupportedFlavor(flavor.Name) {
+				return fmt.Errorf(
+					"flavor %q is not supported by this CLI (built-in-disk family).\n"+
+						"Use a volume-backed flavor instead: g2l-* (Linux) or g2w-* (Windows).\n"+
+						"List available flavors with: conoha flavor list",
+					flavor.Name)
+			}
 			if !isUsableFlavor(flavor.Name) {
 				fmt.Fprintf(os.Stderr, "Warning: flavor %q may not be supported via public API\n", flavor.Name)
 			}
@@ -327,6 +339,14 @@ func resolveUserData(cmd *cobra.Command) (string, error) {
 // Only Linux (g2l) hourly (-t-) flavors are supported.
 func isUsableFlavor(name string) bool {
 	return strings.HasPrefix(name, "g2l-t-")
+}
+
+// isUnsupportedFlavor reports flavors that the CLI knows it cannot create
+// successfully today. g2d-* are built-in-disk flavors that require a
+// server-side block_device_mapping payload this CLI does not currently
+// build (see #196); refusing them early avoids a misleading HTTP 400.
+func isUnsupportedFlavor(name string) bool {
+	return strings.HasPrefix(name, "g2d-")
 }
 
 func selectFlavor(compute *api.ComputeAPI) (*model.Flavor, error) {

--- a/cmd/server/create_test.go
+++ b/cmd/server/create_test.go
@@ -177,6 +177,28 @@ func TestIsUsableFlavor(t *testing.T) {
 	}
 }
 
+// #196: g2d-* (built-in-disk family) must be rejected early.
+func TestIsUnsupportedFlavor(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"g2d-t-c2m4d60", true},
+		{"g2d-t-c4m8d100", true},
+		{"g2l-t-c2m4", false},
+		{"g2w-t-c2m4", false},
+		{"g2lp-t-c2m4", false}, // not a 'g2d-' prefix even if 'd' appears later
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUnsupportedFlavor(tt.name); got != tt.want {
+				t.Errorf("isUnsupportedFlavor(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveUserData_MutualExclusion(t *testing.T) {
 	cmd := newTestCmd(map[string]string{
 		"user-data-raw": "echo hi",


### PR DESCRIPTION
## Summary

- \`server create --flavor <g2d-*-uuid>\` previously ran all the way through the create-summary prompt and only then surfaced an upstream \`HTTP 400: block_device_mapping required\` — confusing because the CLI had emitted a vague \"may not be supported\" warning at the same time.
- Refuse g2d-* (built-in-disk family) up front with an actionable error pointing to volume-backed alternatives (g2l-* / g2w-*).
- Keeps the existing \`isUsableFlavor\` warning path for other unfamiliar names so we don't over-restrict.

The interactive flavor picker already filters to g2l-t-* via \`isUsableFlavor\`, so this only affects users who explicitly pass \`--flavor <g2d-*>\` (UUID or name).

## Test plan

- [x] \`go test ./cmd/server/... -run Flavor\` — new \`TestIsUnsupportedFlavor\` covers g2d-* matching
- [x] \`go test ./...\` — full suite green
- [ ] Live verify: \`conoha server create --flavor <g2d-uuid> ...\` exits with the new error before any prompts/network

## Future work

When/if ConoHa3 publishes the BDM shape required for g2d-* over the public API, swap the early refusal for an automatic BDM build so users can actually create dedicated-disk servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)