### PR TITLE
feat(image): --image accepts name & substring, not just UUID (closes #190)

### DIFF
--- a/cmd/server/create.go
+++ b/cmd/server/create.go
@@ -122,12 +122,16 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		// Fetch image details (used for pre-flight validation and summary display)
+		// Fetch image details (used for pre-flight validation and summary display).
+		// FindImage accepts UUID, exact name, or unambiguous substring (#190),
+		// so e.g. --image ubuntu-24.04 can resolve to the catalog's full
+		// vmi-docker-...-ubuntu-24.04-amd64 entry.
 		imageAPI := api.NewImageAPI(client)
-		img, err := imageAPI.GetImage(imageID)
+		img, err := imageAPI.FindImage(imageID)
 		if err != nil {
-			return fmt.Errorf("fetching image details: %w", err)
+			return fmt.Errorf("resolving image: %w", err)
 		}
+		imageID = img.ID
 
 		// Pre-flight: validate image memory requirements (#32)
 		if img.MinRAM > 0 && flavor.RAM < img.MinRAM {

--- a/internal/api/image.go
+++ b/internal/api/image.go
@@ -44,9 +44,14 @@ func (a *ImageAPI) GetImage(id string) (*model.Image, error) {
 // say `--image ubuntu-24.04` and have the CLI pick e.g.
 // `vmi-docker-29.2-ubuntu-24.04-amd64` when that's the only candidate.
 //
+// Resolution is restricted to status=active so the CLI never returns a
+// half-baked image (queued/saving/killed) that the boot path would
+// then reject. Callers needing every image regardless of status should
+// use ListImages directly.
+//
 // Resolution order:
 //  1. UUID-shaped input → GetImage
-//  2. Exact name match → that image
+//  2. Exact name match against an active image → that image
 //  3. Single substring match (case-insensitive) → that image
 //  4. Multiple substring matches → error listing candidates
 //  5. No match → error with hint
@@ -54,19 +59,23 @@ func (a *ImageAPI) FindImage(nameOrID string) (*model.Image, error) {
 	if looksLikeUUID(nameOrID) {
 		return a.GetImage(nameOrID)
 	}
+	if nameOrID == "" {
+		return nil, fmt.Errorf("image name cannot be empty (try `conoha image list` to see available images)")
+	}
 	images, err := a.ListImages()
 	if err != nil {
 		return nil, err
 	}
-	// Exact name match wins outright (active or otherwise) — even if a
-	// fuzzy substring would also hit, an exact equality is unambiguous.
+	// Exact name match wins outright over substring — even if a fuzzy
+	// substring would also hit, an exact equality is unambiguous.
 	for i := range images {
+		if images[i].Status != "active" {
+			continue
+		}
 		if images[i].Name == nameOrID {
 			return &images[i], nil
 		}
 	}
-	// Substring fallback restricted to active images so we don't surface
-	// half-baked uploads.
 	needle := strings.ToLower(nameOrID)
 	var matches []*model.Image
 	for i := range images {

--- a/internal/api/image.go
+++ b/internal/api/image.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/crowdy/conoha-cli/internal/model"
 )
@@ -36,6 +37,59 @@ func (a *ImageAPI) GetImage(id string) (*model.Image, error) {
 		return nil, err
 	}
 	return &img, nil
+}
+
+// FindImage resolves an image by UUID, exact name, or unambiguous substring
+// match against active image names (#190). Substring matching lets users
+// say `--image ubuntu-24.04` and have the CLI pick e.g.
+// `vmi-docker-29.2-ubuntu-24.04-amd64` when that's the only candidate.
+//
+// Resolution order:
+//  1. UUID-shaped input → GetImage
+//  2. Exact name match → that image
+//  3. Single substring match (case-insensitive) → that image
+//  4. Multiple substring matches → error listing candidates
+//  5. No match → error with hint
+func (a *ImageAPI) FindImage(nameOrID string) (*model.Image, error) {
+	if looksLikeUUID(nameOrID) {
+		return a.GetImage(nameOrID)
+	}
+	images, err := a.ListImages()
+	if err != nil {
+		return nil, err
+	}
+	// Exact name match wins outright (active or otherwise) — even if a
+	// fuzzy substring would also hit, an exact equality is unambiguous.
+	for i := range images {
+		if images[i].Name == nameOrID {
+			return &images[i], nil
+		}
+	}
+	// Substring fallback restricted to active images so we don't surface
+	// half-baked uploads.
+	needle := strings.ToLower(nameOrID)
+	var matches []*model.Image
+	for i := range images {
+		if images[i].Status != "active" {
+			continue
+		}
+		if strings.Contains(strings.ToLower(images[i].Name), needle) {
+			matches = append(matches, &images[i])
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("image %q not found (try `conoha image list` to see available images)", nameOrID)
+	case 1:
+		return matches[0], nil
+	default:
+		names := make([]string, len(matches))
+		for i, m := range matches {
+			names[i] = m.Name
+		}
+		return nil, fmt.Errorf("image %q is ambiguous, matches %d images: %s.\nUse the full name or UUID instead",
+			nameOrID, len(matches), strings.Join(names, ", "))
+	}
 }
 
 func (a *ImageAPI) DeleteImage(id string) error {

--- a/internal/api/image_edgecase_test.go
+++ b/internal/api/image_edgecase_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Edge cases for FindImage that complement TestImageFindImage:
+//   - case-insensitive substring matching
+//   - exact-match precedence over substring match (both active)
+//   - empty-string input is rejected up front (not silently matched)
+//   - exact name match against a non-active image is NOT returned
+//     (boot path would otherwise fail later with an opaque API error)
+func TestImageFindImage_EdgeCases(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"images": []map[string]any{
+				{"id": "id-1", "name": "Ubuntu-24.04-LTS", "status": "active"},
+				{"id": "id-2", "name": "centos-stream-9", "status": "active"},
+				// exact-vs-substring precedence
+				{"id": "id-3", "name": "ubuntu", "status": "active"},
+				{"id": "id-4", "name": "ubuntu-server-edge", "status": "active"},
+				// killed image with a clean exact-match name
+				{"id": "id-5", "name": "old-debian-11", "status": "killed"},
+			},
+		})
+	}))
+	defer ts.Close()
+	t.Setenv("CONOHA_ENDPOINT", ts.URL)
+	api := NewImageAPI(newTestClient(ts))
+
+	t.Run("case-insensitive substring matches", func(t *testing.T) {
+		// UBUNTU != "ubuntu" exactly (exact match is case-sensitive) so
+		// falls to substring (case-insensitive) → matches 3 images →
+		// ambiguous error. Confirms the case-insensitive substring path.
+		_, err := api.FindImage("UBUNTU")
+		if err == nil {
+			t.Fatal("expected ambiguous error for UBUNTU vs 3 ubuntu-* names")
+		}
+		if !strings.Contains(err.Error(), "ambiguous") {
+			t.Errorf("expected ambiguous error, got: %v", err)
+		}
+		for _, want := range []string{"Ubuntu-24.04-LTS", "ubuntu", "ubuntu-server-edge"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("expected candidate %q in error, got: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("exact match wins over substring", func(t *testing.T) {
+		// "ubuntu" matches id-3 exactly. Substring would also match id-1, id-4.
+		img, err := api.FindImage("ubuntu")
+		if err != nil {
+			t.Fatalf("expected exact-match resolution, got error: %v", err)
+		}
+		if img.ID != "id-3" {
+			t.Errorf("expected id-3 (exact match), got %s name=%q", img.ID, img.Name)
+		}
+	})
+
+	t.Run("empty input rejected", func(t *testing.T) {
+		// Without an explicit guard, "" would substring-match every active
+		// image — single-image tenants would silently get that image,
+		// multi-image tenants would see an "ambiguous" error. Both are
+		// confusing; reject up front.
+		_, err := api.FindImage("")
+		if err == nil {
+			t.Fatal("expected error for empty input")
+		}
+		if !strings.Contains(err.Error(), "empty") {
+			t.Errorf("expected 'empty' in error, got: %v", err)
+		}
+	})
+
+	t.Run("exact name match on non-active image not returned", func(t *testing.T) {
+		// "old-debian-11" exists but is killed. Returning it would let
+		// the boot path attempt a doomed create against a half-baked
+		// image. Reject as not-found instead.
+		_, err := api.FindImage("old-debian-11")
+		if err == nil {
+			t.Fatal("expected not-found for exact name on killed image")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' error, got: %v", err)
+		}
+	})
+}

--- a/internal/api/image_test.go
+++ b/internal/api/image_test.go
@@ -46,6 +46,93 @@ func TestImageList(t *testing.T) {
 	}
 }
 
+// #190: --image should accept UUID, exact name, or unambiguous substring.
+func TestImageFindImage(t *testing.T) {
+	const uuid = "12345678-1234-1234-1234-123456789abc"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/v2/images/"+uuid):
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": uuid, "name": "fetched-by-uuid", "status": "active",
+			})
+		default:
+			json.NewEncoder(w).Encode(map[string]any{
+				"images": []map[string]any{
+					{"id": "id-1", "name": "vmi-docker-29.2-ubuntu-24.04-amd64", "status": "active"},
+					{"id": "id-2", "name": "vmi-rails-7.1-ubuntu-24.04-amd64", "status": "active"},
+					{"id": "id-3", "name": "centos-stream-9", "status": "active"},
+					{"id": "id-4", "name": "stale-ubuntu-22.04", "status": "killed"},
+				},
+			})
+		}
+	}))
+	defer ts.Close()
+	t.Setenv("CONOHA_ENDPOINT", ts.URL)
+	api := NewImageAPI(newTestClient(ts))
+
+	t.Run("by UUID", func(t *testing.T) {
+		img, err := api.FindImage(uuid)
+		if err != nil {
+			t.Fatalf("FindImage(uuid) error: %v", err)
+		}
+		if img.ID != uuid {
+			t.Errorf("expected ID %q, got %q", uuid, img.ID)
+		}
+	})
+
+	t.Run("by exact name", func(t *testing.T) {
+		img, err := api.FindImage("centos-stream-9")
+		if err != nil {
+			t.Fatalf("FindImage(exact) error: %v", err)
+		}
+		if img.ID != "id-3" {
+			t.Errorf("expected ID 'id-3', got %q", img.ID)
+		}
+	})
+
+	t.Run("ambiguous substring lists candidates", func(t *testing.T) {
+		_, err := api.FindImage("ubuntu-24.04")
+		if err == nil {
+			t.Fatal("expected ambiguous-match error")
+		}
+		if !strings.Contains(err.Error(), "ambiguous") {
+			t.Errorf("expected 'ambiguous' in error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "vmi-docker-29.2-ubuntu-24.04-amd64") {
+			t.Errorf("expected candidates listed, got: %v", err)
+		}
+	})
+
+	t.Run("unique substring resolves", func(t *testing.T) {
+		img, err := api.FindImage("centos")
+		if err != nil {
+			t.Fatalf("FindImage(unique substring) error: %v", err)
+		}
+		if img.ID != "id-3" {
+			t.Errorf("expected ID 'id-3', got %q", img.ID)
+		}
+	})
+
+	t.Run("substring ignores non-active images", func(t *testing.T) {
+		// 'stale-ubuntu-22.04' is killed; should not be matched.
+		_, err := api.FindImage("22.04")
+		if err == nil {
+			t.Fatal("expected not-found for killed image")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' error, got: %v", err)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := api.FindImage("nonexistent-os")
+		if err == nil {
+			t.Fatal("expected not-found error")
+		}
+	})
+}
+
 func TestImageGet(t *testing.T) {
 	const imageID = "img-abc-123"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- README/sample suggestions like \`--image ubuntu-24.04\` previously failed because the CLI only accepted UUIDs and the ConoHa3 catalog ships VMI variants (\`vmi-docker-29.2-ubuntu-24.04-amd64\` etc.) instead of a plain \`ubuntu-24.04\` entry.
- New \`ImageAPI.FindImage(nameOrID)\` resolves UUID → exact-name → unambiguous-substring (case-insensitive) and surfaces a candidate list when the substring is ambiguous.
- \`server create --image\` now calls \`FindImage\` instead of \`GetImage\`, so the README example finally Just Works when exactly one VMI matches.

## Resolution behaviour

| Input | Result |
| --- | --- |
| \`12345678-...\` (UUID-shaped) | direct \`GetImage\` |
| \`vmi-docker-29.2-ubuntu-24.04-amd64\` (exact match) | that image |
| \`ubuntu-24.04\` matching 2+ VMIs | error listing candidates |
| \`centos\` matching exactly 1 active image | that image |
| \`22.04\` matching only \`status=killed\` | not-found |
| \`nonexistent-os\` | not-found, hint: \`conoha image list\` |

## Test plan

- [x] \`go test ./internal/api/... -run Image\` — six \`TestImageFindImage\` subtests cover all five branches plus killed-status filtering
- [x] \`go test ./...\` — full suite green
- [ ] Live verify: \`conoha server create --image ubuntu-24.04 ...\` resolves to the catalog's matching VMI when there's exactly one
- [ ] Live verify: ambiguous case prints the candidate list

## Out of scope

This PR does not surface a plain \`ubuntu-24.04\` base entry in \`image list\` — that catalog content is owned by ConoHa, not the CLI. The samples README pattern of \`--image ubuntu-24.04\` will still need an actual matching catalog entry to succeed; this change just makes name-based resolution feasible when one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)