### PR TITLE
docs(readme): switch doc site link to conoha-cli.crowdy.dev

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -11,7 +11,7 @@
 
 A command-line interface for the ConoHa VPS3 API. Written in Go as a single binary with an agent-friendly design.
 
-**[Documentation](https://crowdy.github.io/conoha-cli-pages/)** — Guides, deployment examples, and command reference
+**[Documentation](https://conoha-cli.crowdy.dev/)** — Guides, deployment examples, and command reference
 
 > **Note**: This tool is for VPS3 only. It is not compatible with legacy VPS2 CLIs (hironobu-s/conoha-vps, miyabisun/conoha-cli).
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -11,7 +11,7 @@
 
 ConoHa VPS3 API용 커맨드라인 인터페이스입니다. Go로 작성된 싱글 바이너리로, 에이전트 친화적 설계를 채택하고 있습니다.
 
-**[문서 사이트](https://crowdy.github.io/conoha-cli-pages/)** — 가이드, 실전 배포 예제, 커맨드 레퍼런스
+**[문서 사이트](https://conoha-cli.crowdy.dev/)** — 가이드, 실전 배포 예제, 커맨드 레퍼런스
 
 > **참고**: 이 도구는 VPS3 전용입니다. 구 VPS2용 CLI(hironobu-s/conoha-vps, miyabisun/conoha-cli)와는 호환되지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ConoHa VPS3 API 用のコマンドラインインターフェースです。Go で書かれたシングルバイナリで、エージェントフレンドリーな設計を採用しています。
 
-**[ドキュメントサイト](https://crowdy.github.io/conoha-cli-pages/)** — ガイド・実践デプロイ例・コマンドリファレンス
+**[ドキュメントサイト](https://conoha-cli.crowdy.dev/)** — ガイド・実践デプロイ例・コマンドリファレンス
 
 > **注意**: 本ツールは VPS3 専用です。旧 VPS2 用の CLI（hironobu-s/conoha-vps、miyabisun/conoha-cli）とは互換性がありません。
 


### PR DESCRIPTION
## Summary
- Custom domain `conoha-cli.crowdy.dev` now fronts the GitHub Pages site (`crowdy/conoha-cli-pages`).
- Update doc site link in all three READMEs (ja/en/ko) to the canonical URL.

## Test plan
- [x] `curl -sI https://conoha-cli.crowdy.dev/` returns HTTP/2 200 (GitHub Pages served)

🤖 Generated with [Claude Code](https://claude.com/claude-code)