### PR TITLE
fix(debug): pretty-print API bodies so CONOHA_DEBUG=api output is readable

### DIFF
--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -47,11 +47,17 @@ var sensitiveHeaders = map[string]bool{
 	"Authorization":   true,
 }
 
-var passwordRe = regexp.MustCompile(`"password"\s*:\s*"[^"]*"`)
+// secretRe matches a JSON member whose key is a known secret (exact key, so
+// "password_hash" is left alone) and whose value is a JSON string. The value
+// sub-pattern (?:[^"\\]|\\.)* consumes escaped quotes, so a value like
+// "a\"b" is masked whole instead of leaving a trailing fragment.
+var secretRe = regexp.MustCompile(`"(password|private_key|adminPass|secret)"\s*:\s*"(?:[^"\\]|\\.)*"`)
 
-// maskSensitive masks passwords and tokens in a string.
+// maskSensitive replaces the values of known secret-bearing JSON keys with
+// "****" so they never reach debug output (e.g. auth passwords, a Nova-issued
+// keypair private_key, a server adminPass, an application-credential secret).
 func maskSensitive(s string) string {
-	return passwordRe.ReplaceAllString(s, `"password":"****"`)
+	return secretRe.ReplaceAllString(s, `"${1}":"****"`)
 }
 
 // formatBody renders an HTTP body for debug output. JSON is pretty-printed and

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -66,7 +66,9 @@ func formatBody(dir string, body []byte) string {
 		masked = pretty.String()
 	}
 	var b strings.Builder
-	for _, line := range strings.Split(masked, "\n") {
+	// Trim a single trailing newline so a body that already ends in "\n"
+	// (common for non-JSON payloads) does not yield a bare prefix-only line.
+	for _, line := range strings.Split(strings.TrimSuffix(masked, "\n"), "\n") {
 		b.WriteString(dir)
 		b.WriteString(line)
 		b.WriteByte('\n')

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -52,6 +54,26 @@ func maskSensitive(s string) string {
 	return passwordRe.ReplaceAllString(s, `"password":"****"`)
 }
 
+// formatBody renders an HTTP body for debug output. JSON is pretty-printed and
+// every line is prefixed with dir ("> " for requests, "< " for responses) so a
+// multi-kilobyte payload prints as many short, readable lines rather than one
+// giant line whose start scrolls off-screen. Non-JSON bodies are emitted
+// verbatim on a single prefixed line. Passwords are always masked.
+func formatBody(dir string, body []byte) string {
+	masked := maskSensitive(string(body))
+	var pretty bytes.Buffer
+	if json.Indent(&pretty, []byte(masked), "", "  ") == nil {
+		masked = pretty.String()
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(masked, "\n") {
+		b.WriteString(dir)
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
 func debugLogRequest(req *http.Request, body []byte) {
 	if debugLevel < DebugVerbose {
 		return
@@ -66,7 +88,7 @@ func debugLogRequest(req *http.Request, body []byte) {
 			fmt.Fprintf(os.Stderr, "> %s: %s\n", name, val)
 		}
 		if len(body) > 0 {
-			fmt.Fprintf(os.Stderr, "> %s\n", maskSensitive(string(body)))
+			fmt.Fprint(os.Stderr, formatBody("> ", body))
 		}
 	}
 }
@@ -85,7 +107,7 @@ func debugLogResponse(resp *http.Response, duration time.Duration, body []byte) 
 			fmt.Fprintf(os.Stderr, "< %s: %s\n", name, val)
 		}
 		if len(body) > 0 {
-			fmt.Fprintf(os.Stderr, "< %s\n", maskSensitive(string(body)))
+			fmt.Fprint(os.Stderr, formatBody("< ", body))
 		}
 	}
 	fmt.Fprintln(os.Stderr)

--- a/internal/api/debug_test.go
+++ b/internal/api/debug_test.go
@@ -1,6 +1,9 @@
 package api
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestMaskSensitive(t *testing.T) {
 	tests := []struct {
@@ -22,6 +25,31 @@ func TestMaskSensitive(t *testing.T) {
 			name:     "password with spaces",
 			input:    `{"password" : "my pass"}`,
 			expected: `{"password":"****"}`,
+		},
+		{
+			name:     "keypair private_key",
+			input:    `{"keypair":{"name":"k","private_key":"-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END-----\n"}}`,
+			expected: `{"keypair":{"name":"k","private_key":"****"}}`,
+		},
+		{
+			name:     "server adminPass",
+			input:    `{"server":{"id":"x","adminPass":"hunter2"}}`,
+			expected: `{"server":{"id":"x","adminPass":"****"}}`,
+		},
+		{
+			name:     "application credential secret",
+			input:    `{"application_credential":{"secret":"s3cr3t"}}`,
+			expected: `{"application_credential":{"secret":"****"}}`,
+		},
+		{
+			name:     "password value containing an escaped quote",
+			input:    `{"password":"a\"b","name":"keep"}`,
+			expected: `{"password":"****","name":"keep"}`,
+		},
+		{
+			name:     "similarly named key is not masked",
+			input:    `{"password_hash":"keep","secret_ref":"keep"}`,
+			expected: `{"password_hash":"keep","secret_ref":"keep"}`,
 		},
 	}
 
@@ -76,6 +104,19 @@ func TestFormatBodyNonJSONFallsBack(t *testing.T) {
 	want := "> not json at all\n"
 	if got != want {
 		t.Errorf("formatBody() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatBodyMasksPrivateKeyInPrettyPrint(t *testing.T) {
+	// A Nova-generated keypair response carries the private key in the body;
+	// formatBody must mask it even while pretty-printing.
+	body := []byte(`{"keypair":{"name":"k","private_key":"-----BEGIN KEY-----\nsecret\n-----END-----\n"}}`)
+	got := formatBody("< ", body)
+	if strings.Contains(got, "BEGIN KEY") || strings.Contains(got, "secret") {
+		t.Errorf("private key leaked in debug output:\n%s", got)
+	}
+	if !strings.Contains(got, `"private_key": "****"`) {
+		t.Errorf("expected masked private_key in output:\n%s", got)
 	}
 }
 

--- a/internal/api/debug_test.go
+++ b/internal/api/debug_test.go
@@ -79,6 +79,35 @@ func TestFormatBodyNonJSONFallsBack(t *testing.T) {
 	}
 }
 
+func TestFormatBodyIndentsJSONArrayRoot(t *testing.T) {
+	// A top-level JSON array (as returned by several list endpoints) is
+	// indented, not left on one line.
+	got := formatBody("< ", []byte(`[{"id":"x"}]`))
+	want := "< [\n<   {\n<     \"id\": \"x\"\n<   }\n< ]\n"
+	if got != want {
+		t.Errorf("formatBody() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestFormatBodyTrailingNewlineNoStrayLine(t *testing.T) {
+	// A non-JSON body ending in a newline must not produce a trailing
+	// prefix-only line (e.g. a bare "< ").
+	got := formatBody("< ", []byte("<html>error</html>\n"))
+	want := "< <html>error</html>\n"
+	if got != want {
+		t.Errorf("formatBody() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatBodyMultiLineNonJSON(t *testing.T) {
+	// Every line of a multi-line non-JSON body is prefixed.
+	got := formatBody("> ", []byte("line1\nline2"))
+	want := "> line1\n> line2\n"
+	if got != want {
+		t.Errorf("formatBody() = %q, want %q", got, want)
+	}
+}
+
 func TestSensitiveHeaders(t *testing.T) {
 	if !sensitiveHeaders["X-Auth-Token"] {
 		t.Error("X-Auth-Token should be sensitive")

--- a/internal/api/debug_test.go
+++ b/internal/api/debug_test.go
@@ -58,6 +58,27 @@ func TestDebugLevelFromEnv(t *testing.T) {
 	}
 }
 
+func TestFormatBodyPrettyPrintsJSON(t *testing.T) {
+	// A JSON body must be indented and every line prefixed, so a large payload
+	// renders as many short, wrapping-friendly lines instead of one giant line
+	// whose start scrolls off-screen.
+	got := formatBody("< ", []byte(`{"a":1,"password":"secret"}`))
+	want := "< {\n<   \"a\": 1,\n<   \"password\": \"****\"\n< }\n"
+	if got != want {
+		t.Errorf("formatBody() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestFormatBodyNonJSONFallsBack(t *testing.T) {
+	// Non-JSON bodies (e.g. an HTML error page) are printed verbatim, one
+	// prefixed line, never dropped.
+	got := formatBody("> ", []byte("not json at all"))
+	want := "> not json at all\n"
+	if got != want {
+		t.Errorf("formatBody() = %q, want %q", got, want)
+	}
+}
+
 func TestSensitiveHeaders(t *testing.T) {
 	if !sensitiveHeaders["X-Auth-Token"] {
 		t.Error("X-Auth-Token should be sensitive")


### PR DESCRIPTION
## Problem

With `CONOHA_DEBUG=api`, each HTTP request/response body is logged to stderr as a **single unformatted line**. Real ConoHa payloads are large (`servers/detail` ≈ 37 KB, `flavors/detail` ≈ 15 KB), so that one line wraps across hundreds of terminal rows and scrolls — the leading `< {"servers": …` disappears and the output appears to start in the middle of the JSON, unreadable.

`-v` / `--verbose` (DebugVerbose) is unaffected: it only prints `> METHOD URL` / `< status` lines. The problem is specific to body-level debug (`CONOHA_DEBUG=api`).

Closes #204. Closes #206.

## Fix

`internal/api/debug.go`:

**Readable output (#204)** — add `formatBody()`:
- Pretty-print JSON bodies via `json.Indent`.
- Prefix **every** line with the direction marker (`> ` / `< `), curl-style.
- Fall back to the verbatim string for non-JSON bodies (e.g. HTML error pages); trim a single trailing newline so such bodies don't emit a bare prefix-only line.

**Broader redaction (#206)** — body masking previously covered only `"password"`, so a Nova-issued keypair `private_key`, a server `adminPass`, and an application-credential `secret` were logged verbatim. `maskSensitive` now:
- masks an allow-list of secret keys (`password`, `private_key`, `adminPass`, `secret`), matched on the **exact** key so `password_hash` stays visible;
- uses a proper JSON-string value matcher `(?:[^"\\]|\\.)*` so an escaped quote in the value no longer leaves a leaking fragment.

Masking runs on the compact body before `json.Indent`, so secrets are gone before pretty-printing.

## Verification

Ran `CONOHA_DEBUG=api conoha server list` against the live API before/after:

| | before | after |
|---|---|---|
| longest stderr line | 37,316 chars | 105 chars |
| stderr lines | 35 | 2,519 (indented JSON) |
| stdout (table) | clean | clean (unchanged) |
| only `****` in output | `X-Auth-Token` | `X-Auth-Token` (list data not over-masked) |

`make test` and `golangci-lint run ./internal/api/` pass. Unit tests cover: JSON pretty-print, non-JSON fallback, multi-line + trailing-newline bodies, JSON array root, per-field masking (`private_key`/`adminPass`/`secret`), escaped-quote-in-value, a negative similar-name case, and a `formatBody` assertion that a private key never appears in pretty-printed output.
